### PR TITLE
build(deps): declare @dnd-kit/utilities as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
         "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
         "@popperjs/core": "2.11.8",
         "json-stable-stringify": "1.3.0",
         "monkey-around": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/modifiers": "9.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@popperjs/core": "2.11.8",
     "json-stable-stringify": "1.3.0",
     "monkey-around": "3.0.0",


### PR DESCRIPTION
Closes #86. `@dnd-kit/utilities` (3.2.2) is imported by 3 components but was only present transitively (flagged by `import/no-extraneous-dependencies`). Declares it directly. No code changes.