### PR TITLE
fix(security): replace innerHTML with DOM API and safe text substitution

### DIFF
--- a/src/actions/dynamicSelector/DynamicSelectorSettings.tsx
+++ b/src/actions/dynamicSelector/DynamicSelectorSettings.tsx
@@ -195,7 +195,7 @@ export function dynamicSelectorDetails(
     // Clear any previous content in the output container
     const existingOutput = container.querySelector(`.${c("output-container")}`);
     if (existingOutput) {
-      existingOutput.innerHTML = "";
+      existingOutput.empty();
     }
 
     // Create the output container if it doesn't exist
@@ -230,7 +230,7 @@ export function dynamicSelectorDetails(
   const clearScriptOutput = (container: HTMLElement) => {
     const outputDiv = container.querySelector(`.${c("output-container")}`);
     if (outputDiv) {
-      outputDiv.innerHTML = "";
+      outputDiv.empty();
     }
   };
 }

--- a/src/actions/script/ScriptSettings.tsx
+++ b/src/actions/script/ScriptSettings.tsx
@@ -102,7 +102,7 @@ export const scriptSettings: ActionSetting = (
     const outputDiv = container.querySelector(".output-container");
     if (!outputDiv) return;
 
-    outputDiv.innerHTML = "";
+    outputDiv.empty();
 
     if (result.error) {
       outputDiv.createEl("div", {
@@ -120,6 +120,6 @@ export const scriptSettings: ActionSetting = (
   // Función para limpiar resultados
   const clearScriptOutput = (container: HTMLElement) => {
     const outputDiv = container.querySelector(".output-container");
-    if (outputDiv) outputDiv.innerHTML = "";
+    if (outputDiv) outputDiv.empty();
   };
 };

--- a/src/actions/script/extensions/autoconfiguration/ScriptStepAutocomplete.ts
+++ b/src/actions/script/extensions/autoconfiguration/ScriptStepAutocomplete.ts
@@ -188,7 +188,7 @@ function createZettelFlowRenderer(completion: Completion): (element: HTMLElement
         container.appendChild(type);
 
         // Clear and append to the element
-        element.innerHTML = '';
+        element.empty();
         element.appendChild(container);
     };
 }

--- a/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion.ts
+++ b/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion.ts
@@ -193,7 +193,7 @@ function createZettelFlowRenderer(completion: Completion): (element: HTMLElement
         container.appendChild(type);
 
         // Clear and append to the element
-        element.innerHTML = '';
+        element.empty();
         element.appendChild(container);
     };
 }

--- a/src/config/modals/handlers/hooks/extensions/autoconfiguration/HookAutocomplete.ts
+++ b/src/config/modals/handlers/hooks/extensions/autoconfiguration/HookAutocomplete.ts
@@ -140,7 +140,7 @@ function createHookRenderer(completion: Completion): (element: HTMLElement) => v
         container.appendChild(type);
 
         // Clear and append to the element
-        element.innerHTML = '';
+        element.empty();
         element.appendChild(container);
     };
 }

--- a/src/starters/services/VariableTextProcessors.ts
+++ b/src/starters/services/VariableTextProcessors.ts
@@ -9,9 +9,10 @@ import {
 } from "@codemirror/view";
 import { RangeSetBuilder } from "@codemirror/state";
 import { App, Editor, EditorPosition, EditorSuggest, EditorSuggestContext, EditorSuggestTriggerInfo, TFile } from "obsidian";
+import { substitutePlaceholders } from "starters/services/placeholders";
 
 /**
- * Loads text processors to replace placeholders of the form {{key}} 
+ * Loads text processors to replace placeholders of the form {{key}}
  * with corresponding frontmatter metadata. This includes both 
  * the markdown post-processor and the live preview extension.
  * 
@@ -32,11 +33,23 @@ export function loadVariableTextProcessors(plugin: ZettelFlow): void {
         const metadata = plugin.app.metadataCache.getFileCache(file)?.frontmatter;
         if (!metadata) return;
 
+        // Walk text nodes only and replace placeholders as text (never as HTML) so that
+        // frontmatter values cannot inject markup into the rendered note.
         element.querySelectorAll("p").forEach((paragraph) => {
-            paragraph.innerHTML = paragraph.innerHTML.replace(
-                placeholderRegex,
-                (_match, key) => metadata[key.trim()] ?? `{{${key}}}`
-            );
+            const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT);
+            const textNodes: Text[] = [];
+            let current = walker.nextNode();
+            while (current) {
+                textNodes.push(current as Text);
+                current = walker.nextNode();
+            }
+            textNodes.forEach((node) => {
+                const original = node.textContent ?? "";
+                const replaced = substitutePlaceholders(original, metadata);
+                if (replaced !== original) {
+                    node.textContent = replaced;
+                }
+            });
         });
     });
 

--- a/src/starters/services/placeholders.ts
+++ b/src/starters/services/placeholders.ts
@@ -1,0 +1,19 @@
+/**
+ * Replaces every {{key}} placeholder in a plain-text string with the matching frontmatter
+ * value (inserted as text, never as HTML). Unknown keys are left untouched.
+ *
+ * Pure and dependency-free so it can be unit-tested in isolation and reused by the
+ * markdown post-processor without pulling in Obsidian/CodeMirror.
+ *
+ * @param text The plain-text content of a single text node.
+ * @param metadata The active file's frontmatter.
+ */
+export function substitutePlaceholders(
+    text: string,
+    metadata: Record<string, unknown>
+): string {
+    return text.replace(/{{(.*?)}}/g, (_match, key: string) => {
+        const value = metadata[key.trim()];
+        return value == null ? `{{${key}}}` : String(value);
+    });
+}

--- a/test/starters/services/VariableTextProcessors.test.ts
+++ b/test/starters/services/VariableTextProcessors.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "@jest/globals";
+import { substitutePlaceholders } from "starters/services/placeholders";
+
+describe("substitutePlaceholders", () => {
+  const meta = { title: "My Note", count: 3, done: false, empty: "" };
+
+  it("replaces a known placeholder with its frontmatter value", () => {
+    expect(substitutePlaceholders("Title: {{title}}", meta)).toBe("Title: My Note");
+  });
+
+  it("trims whitespace inside the braces when looking up the key", () => {
+    expect(substitutePlaceholders("{{ title }}", meta)).toBe("My Note");
+  });
+
+  it("stringifies non-string values", () => {
+    expect(substitutePlaceholders("{{count}}/{{done}}", meta)).toBe("3/false");
+  });
+
+  it("keeps an empty-string value (only null/undefined fall back)", () => {
+    expect(substitutePlaceholders("[{{empty}}]", meta)).toBe("[]");
+  });
+
+  it("leaves unknown placeholders untouched, preserving the original key text", () => {
+    expect(substitutePlaceholders("{{missing}} and {{ nope }}", meta)).toBe(
+      "{{missing}} and {{ nope }}"
+    );
+  });
+
+  it("replaces multiple placeholders in one string", () => {
+    expect(substitutePlaceholders("{{title}} x{{count}}", meta)).toBe("My Note x3");
+  });
+
+  it("returns text without placeholders unchanged", () => {
+    expect(substitutePlaceholders("plain text", meta)).toBe("plain text");
+  });
+});


### PR DESCRIPTION
Closes #84.

## What
Removes **all `innerHTML` usage** from `src` (the `no-forbidden-elements` security guideline).

- **7 mechanical swaps:** `el.innerHTML = ""` -> `el.empty()` (autocomplete renderers in HookAutocomplete / ScriptStepAutocomplete / Autocompletion, and the output clears in ScriptSettings / DynamicSelectorSettings). Behavior-identical.
- **`{{frontmatter}}` post-processor (`VariableTextProcessors.ts`):** rewritten to walk **text nodes only** and substitute placeholders as **text**, via a new pure, dependency-free `substitutePlaceholders` helper (`placeholders.ts`) that is **unit-tested** (7 cases).

## ⚠️ Behavior change to review
Previously the post-processor did `paragraph.innerHTML = paragraph.innerHTML.replace(...)`, so a frontmatter value containing markup would be rendered as **HTML**. Now values are inserted as **text** (safer, and the expected behavior for a property value). Plain-string frontmatter — the normal case — is unaffected.

## Verification
- `npm run typecheck` ✅  ·  `npm run lint` (oxlint) ✅  ·  `npm test` ✅ (25 tests, +7)
- 0 `innerHTML` remaining in `src`.

Left open for your review because it changes rendering behavior. Part of the M1 Obsidian-score work (#82).