### PR TITLE
fix(logger): always emit errors regardless of the debug toggle

### DIFF
--- a/src/architecture/monitoring/Logger.ts
+++ b/src/architecture/monitoring/Logger.ts
@@ -90,13 +90,9 @@ class Log implements LogInterface {
             }
         }
 
-        if (this.levelInfo >= LevelInfoRecord.error && this.isDebugModeEnabled) {
-            this.error = console.error.bind(console, `[ERROR]`);
-        } else {
-            this.error = () => {
-                // Disable error mode
-            }
-        }
+        // Errors always surface, regardless of the debug toggle, so users can report issues
+        // (this also matches Obsidian's guideline of logging errors by default).
+        this.error = console.error.bind(console, `[ERROR]`);
     }
 
     public static getInstance(): LogInterface {

--- a/test/architecture/monitoring/Logger.test.ts
+++ b/test/architecture/monitoring/Logger.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import { log } from "architecture/monitoring/Logger";
+
+describe("Logger", () => {
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let debugSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    debugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it("emits error even when debug mode is off", () => {
+    log.setDebugMode(false);
+    log.error("boom");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("still emits error when debug mode is on", () => {
+    log.setDebugMode(true);
+    log.error("boom");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does NOT emit debug when debug mode is off", () => {
+    log.setDebugMode(false);
+    log.setLevelInfo("trace");
+    log.debug("noise");
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits debug when debug mode is on and the level is high enough", () => {
+    log.setDebugMode(true);
+    log.setLevelInfo("debug");
+    log.debug("hello");
+    expect(debugSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #89. Errors were gated on the debug-mode toggle, so `log.error` was silenced when logging was off. Errors now always surface (matching Obsidian's "log errors by default" guideline); warn/info/debug/trace are unchanged. Unit-tested (4 cases). typecheck + oxlint + jest green.