### PR TITLE
fix(lifecycle): unload plugin components on plugin unload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SETTINGS, ZettelFlowSettings } from 'config';
-import { loadVariableTextProcessors, loadPluginComponents, loadServicesThatRequireSettings } from 'starters';
+import { loadVariableTextProcessors, loadPluginComponents, loadServicesThatRequireSettings, unloadPluginComponents } from 'starters';
 import { Notice, Plugin } from 'obsidian';
 import { actionsStore } from 'architecture/api/store/ActionsStore';
 import {
@@ -32,6 +32,7 @@ export default class ZettelFlow extends Plugin {
 	}
 
 	onunload() {
+		unloadPluginComponents();
 		actionsStore.unregisterAll();
 	}
 

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -19,6 +19,14 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.loadComponents();
 }
 
+/**
+ * Unload all registered plugin components, running their onUnload() and clearing the
+ * registry so a re-enable starts from a clean slate.
+ */
+export function unloadPluginComponents(): void {
+    ZComponentsManager.unloadComponents();
+}
+
 export function loadServicesThatRequireSettings(setttings: ZettelFlowSettings): void {
     log.setDebugMode(setttings.loggerEnabled);
     log.setLevelInfo(setttings.logLevel);

--- a/test/starters/services/ZComponentsManager.test.ts
+++ b/test/starters/services/ZComponentsManager.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { ZComponentsManager } from "starters/services/ZComponentsManager";
+
+// PluginComponent is used only as a type in the manager, so importing it here stays light.
+type FakeComponent = { onLoad: () => void; onUnload: () => void };
+
+describe("ZComponentsManager", () => {
+  beforeEach(() => {
+    // Ensure a clean registry (the manager is a module-level singleton).
+    ZComponentsManager.unloadComponents();
+  });
+
+  it("runs onUnload on every registered component and clears the registry", () => {
+    const a: FakeComponent = { onLoad: jest.fn(), onUnload: jest.fn() };
+    const b: FakeComponent = { onLoad: jest.fn(), onUnload: jest.fn() };
+
+    ZComponentsManager.registerComponent(a as unknown as never);
+    ZComponentsManager.registerComponent(b as unknown as never);
+
+    ZComponentsManager.unloadComponents();
+
+    expect(a.onUnload).toHaveBeenCalledTimes(1);
+    expect(b.onUnload).toHaveBeenCalledTimes(1);
+
+    (a.onUnload as ReturnType<typeof jest.fn>).mockClear();
+    ZComponentsManager.unloadComponents();
+    expect(a.onUnload).not.toHaveBeenCalled();
+  });
+
+  it("runs onLoad on every registered component", () => {
+    const a: FakeComponent = { onLoad: jest.fn(), onUnload: jest.fn() };
+    ZComponentsManager.registerComponent(a as unknown as never);
+    ZComponentsManager.loadComponents();
+    expect(a.onLoad).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #90. `onunload` only cleared the action store; `ZComponentsManager.unloadComponents()` was never called, so component `onUnload()` never ran and the registry leaked across re-enables. Adds `unloadPluginComponents()` and calls it from `onunload`. Unit-tested (2 cases). typecheck + oxlint + jest green.