### PR TITLE
test(notes): add ContentDTO and NoteDTO unit tests + test infra

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,13 +14,15 @@ module.exports = {
   testEnvironment: "node",
   roots: ["<rootDir>/test"],
   testMatch: ["**/*.test.ts"],
+  setupFiles: ["<rootDir>/test/setup.ts"],
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: "tsconfig.jest.json" }],
   },
   moduleFileExtensions: ["ts", "tsx", "js", "json"],
   moduleNameMapper: {
     "^obsidian$": "<rootDir>/test/__mocks__/obsidian.ts",
-    "^architecture$": "<rootDir>/src/architecture",
+    "^architecture$": "<rootDir>/test/__mocks__/architecture.ts",
+    "^architecture/plugin$": "<rootDir>/test/__mocks__/architecture-plugin.ts",
     "^architecture/(.*)$": "<rootDir>/src/architecture/$1",
     "^config$": "<rootDir>/src/config",
     "^config/(.*)$": "<rootDir>/src/config/$1",

--- a/test/__mocks__/architecture-plugin.ts
+++ b/test/__mocks__/architecture-plugin.ts
@@ -1,0 +1,5 @@
+// Lightweight stub of the `architecture/plugin` barrel for unit tests.
+export const FileService = {
+  PATH_SEPARATOR: "/",
+  MARKDOWN_EXTENSION: ".md",
+};

--- a/test/__mocks__/architecture.ts
+++ b/test/__mocks__/architecture.ts
@@ -1,0 +1,14 @@
+// Lightweight stub of the `architecture` barrel for unit tests (avoids loading the whole
+// framework, which pulls in Obsidian-coupled modules).
+export const log = {
+  trace: () => undefined,
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  setDebugMode: () => undefined,
+  setLevelInfo: () => undefined,
+};
+
+export const c = (...classes: string[]): string =>
+  classes.map((cls) => `zettelkasten-flow__${cls}`).join(" ");

--- a/test/application/notes/model/ContentDTO.test.ts
+++ b/test/application/notes/model/ContentDTO.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "@jest/globals";
+import { ContentDTO } from "application/notes/model/ContentDTO";
+
+describe("ContentDTO", () => {
+  it("appends body content with add()/get()", () => {
+    const c = new ContentDTO();
+    c.add("Hello ").add("world");
+    expect(c.get()).toBe("Hello world");
+  });
+
+  it("substitutes every {{key}} occurrence via modify()", () => {
+    const c = new ContentDTO();
+    c.add("{{a}} and {{a}} and {{b}}");
+    c.modify("a", "X");
+    expect(c.get()).toBe("X and X and {{b}}");
+  });
+
+  it("merges frontmatter and hoists a 'tags' field into the tag list", () => {
+    const c = new ContentDTO();
+    c.addFrontMatter({ title: "t", tags: ["one", "two"] });
+    expect(c.getFrontmatter()).toEqual({ title: "t" });
+    expect(c.getFrontmatter().tags).toBeUndefined();
+    expect(c.getTags()).toEqual(["one", "two"]);
+  });
+
+  it("de-duplicates tags across addTag/addTags", () => {
+    const c = new ContentDTO();
+    c.addTag("x").addTag("x").addTags(["x", "y"]).addTags("z");
+    expect(c.getTags()).toEqual(["x", "y", "z"]);
+    expect(c.hasTags()).toBe(true);
+  });
+
+  it("ignores empty or invalid tag inputs", () => {
+    const c = new ContentDTO();
+    c.addTags("").addTags(null as unknown as string);
+    expect(c.getTags()).toEqual([]);
+    expect(c.hasTags()).toBe(false);
+  });
+
+  it("resets content, frontmatter and tags", () => {
+    const c = new ContentDTO();
+    c.add("body");
+    c.addFrontMatter({ a: 1 });
+    c.addTag("t");
+    c.reset();
+    expect(c.get()).toBe("");
+    expect(c.getFrontmatter()).toEqual({});
+    expect(c.getTags()).toEqual([]);
+  });
+});

--- a/test/application/notes/model/NoteDTO.test.ts
+++ b/test/application/notes/model/NoteDTO.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "@jest/globals";
+import { NoteDTO } from "application/notes/model/NoteDTO";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+describe("NoteDTO", () => {
+  it("builds the final path from target folder + title + .md", () => {
+    const n = new NoteDTO();
+    n.setTargetFolder("Notes/Inbox").setTitle("My Note");
+    expect(n.getFinalPath()).toBe("Notes/Inbox/My Note.md");
+  });
+
+  it("strips a trailing slash from the target folder", () => {
+    const n = new NoteDTO();
+    n.setTargetFolder("Notes/").setTitle("t");
+    expect(n.getTargetFolder()).toBe("Notes");
+    expect(n.getFinalPath()).toBe("Notes/t.md");
+  });
+
+  it("records paths and actions by position", () => {
+    const n = new NoteDTO();
+    n.addPath("a.md", 0).addPath("b.md", 1);
+    n.addAction({ type: "prompt", id: "1", label: "L" } as any, "val", 0);
+    n.addBackgroundAction({ type: "script", id: "2" } as any, 1);
+    expect(n.getPath(0)).toBe("a.md");
+    expect(n.getElement(0)).toMatchObject({ type: "prompt", result: "val" });
+    expect(n.getElement(1)).toMatchObject({ type: "script", result: null });
+  });
+
+  it("ignores invalid path inputs", () => {
+    const n = new NoteDTO();
+    n.addPath(undefined, 0).addPath("x.md", -1);
+    expect(n.getPaths().size).toBe(0);
+  });
+
+  it("deletePos removes every path and action at or after the position", () => {
+    const n = new NoteDTO();
+    n.addPath("a", 0).addPath("b", 1).addPath("c", 2);
+    n.addAction({ type: "t", id: "i" } as any, "r", 2);
+    n.deletePos(1);
+    expect([...n.getPaths().keys()]).toEqual([0]);
+    expect(n.getElements().size).toBe(0);
+  });
+
+  it("tracks the unique-prefix pattern", () => {
+    const n = new NoteDTO();
+    expect(n.hasPattern()).toBe(false);
+    n.setPattern("YYYY");
+    expect(n.hasPattern()).toBe(true);
+    expect(n.getPattern()).toBe("YYYY");
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,8 @@
+// Polyfills for Obsidian's non-standard prototype augmentations used by code under test.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+if (typeof (Array.prototype as any).contains !== "function") {
+  (Array.prototype as any).contains = function <T>(this: T[], value: T): boolean {
+    return this.indexOf(value) !== -1;
+  };
+}
+export {};


### PR DESCRIPTION
Part of #87. Adds reusable test infra (a `.contains` polyfill + lightweight `architecture`/`architecture/plugin` mocks) and 12 unit tests for the note-assembly core: `ContentDTO` (zones, `{{key}}` substitution, tag hoisting/dedup, reset) and `NoteDTO` (final path, path/action tracking, `deletePos`, prefix pattern). Tests-only; typecheck + oxlint + jest green (36 tests). Remaining for #87: `FlowImpl` graph traversal and the wizard callbacks.