### PR TITLE
style(settings): replace inline display styles with an is-hidden CSS class

### DIFF
--- a/src/actions/calendar/CalendarSettings.ts
+++ b/src/actions/calendar/CalendarSettings.ts
@@ -117,9 +117,9 @@ export function calendarDetails(contentEl: HTMLElement, action: Action, readonly
                     const parent: HTMLElement | null = staticInput.closest('.setting-item');
                     if (parent) {
                         if (isStatic) {
-                            parent.style.display = 'flex';
+                            parent.removeClass("zettelkasten-flow__is-hidden");
                         } else {
-                            parent.style.display = 'none';
+                            parent.addClass("zettelkasten-flow__is-hidden");
                             staticInput.value = '';
                             delete action.staticValue;
                         }
@@ -142,8 +142,8 @@ export function calendarDetails(contentEl: HTMLElement, action: Action, readonly
             text.inputEl.id = dynamicId;
         });
     if (staticBehaviour) {
-        staticValueContainer.settingEl.style.display = 'flex';
+        staticValueContainer.settingEl.removeClass("zettelkasten-flow__is-hidden");
     } else {
-        staticValueContainer.settingEl.style.display = 'none';
+        staticValueContainer.settingEl.addClass("zettelkasten-flow__is-hidden");
     }
 }

--- a/src/actions/checkbox/CheckboxSettings.ts
+++ b/src/actions/checkbox/CheckboxSettings.ts
@@ -82,9 +82,9 @@ export const checkboxDetails = (contentEl: HTMLElement, action: Action, readonly
                     const parent: HTMLElement | null = staticInput.closest('.setting-item');
                     if (parent) {
                         if (isStatic) {
-                            parent.style.display = 'flex';
+                            parent.removeClass("zettelkasten-flow__is-hidden");
                         } else {
-                            parent.style.display = 'none';
+                            parent.addClass("zettelkasten-flow__is-hidden");
                             staticInput.value = '';
                             delete action.staticValue;
                         }
@@ -107,8 +107,8 @@ export const checkboxDetails = (contentEl: HTMLElement, action: Action, readonly
         });
 
     if (staticBehaviour) {
-        staticValueContainer.settingEl.style.display = 'flex';
+        staticValueContainer.settingEl.removeClass("zettelkasten-flow__is-hidden");
     } else {
-        staticValueContainer.settingEl.style.display = 'none';
+        staticValueContainer.settingEl.addClass("zettelkasten-flow__is-hidden");
     }
 };

--- a/src/actions/cssClasses/CssClassesSettings.tsx
+++ b/src/actions/cssClasses/CssClassesSettings.tsx
@@ -45,9 +45,9 @@ export function cssClassesDetails(
             staticInput.closest(".setting-item");
           if (parent) {
             if (isStatic) {
-              parent.style.display = "flex";
+              parent.removeClass("zettelkasten-flow__is-hidden");
             } else {
-              parent.style.display = "none";
+              parent.addClass("zettelkasten-flow__is-hidden");
               staticInput.value = "";
               delete action.staticValue;
             }
@@ -80,8 +80,8 @@ export function cssClassesDetails(
   );
 
   if (staticBehaviour) {
-    staticValueContainer.settingEl.style.display = "flex";
+    staticValueContainer.settingEl.removeClass("zettelkasten-flow__is-hidden");
   } else {
-    staticValueContainer.settingEl.style.display = "none";
+    staticValueContainer.settingEl.addClass("zettelkasten-flow__is-hidden");
   }
 }

--- a/src/actions/number/NumberSettings.ts
+++ b/src/actions/number/NumberSettings.ts
@@ -95,9 +95,9 @@ export function numberDetails(contentEl: HTMLElement, action: Action, readonly: 
                     const parent: HTMLElement | null = staticInput.closest('.setting-item');
                     if (parent) {
                         if (isStatic) {
-                            parent.style.display = 'flex';
+                            parent.removeClass("zettelkasten-flow__is-hidden");
                         } else {
-                            parent.style.display = 'none';
+                            parent.addClass("zettelkasten-flow__is-hidden");
                             staticInput.value = '';
                             delete action.staticValue;
                         }
@@ -127,8 +127,8 @@ export function numberDetails(contentEl: HTMLElement, action: Action, readonly: 
     });
 
     if (staticBehaviour) {
-        staticValueContainer.settingEl.style.display = 'flex';
+        staticValueContainer.settingEl.removeClass("zettelkasten-flow__is-hidden");
     } else {
-        staticValueContainer.settingEl.style.display = 'none';
+        staticValueContainer.settingEl.addClass("zettelkasten-flow__is-hidden");
     }
 }

--- a/src/actions/prompt/PromptSettings.ts
+++ b/src/actions/prompt/PromptSettings.ts
@@ -95,9 +95,9 @@ export function promptDetails(contentEl: HTMLElement, action: Action, readMode: 
                     const parent: HTMLElement | null = staticInput.closest('.setting-item');
                     if (parent) {
                         if (isStatic) {
-                            parent.style.display = 'flex';
+                            parent.removeClass("zettelkasten-flow__is-hidden");
                         } else {
-                            parent.style.display = 'none';
+                            parent.addClass("zettelkasten-flow__is-hidden");
                             staticInput.value = '';
                             delete action.staticValue;
                         }
@@ -119,8 +119,8 @@ export function promptDetails(contentEl: HTMLElement, action: Action, readMode: 
         });
 
     if (staticBehaviour) {
-        staticValueContainer.settingEl.style.display = 'flex';
+        staticValueContainer.settingEl.removeClass("zettelkasten-flow__is-hidden");
     } else {
-        staticValueContainer.settingEl.style.display = 'none';
+        staticValueContainer.settingEl.addClass("zettelkasten-flow__is-hidden");
     }
 }

--- a/src/actions/tags/TagsSettings.tsx
+++ b/src/actions/tags/TagsSettings.tsx
@@ -46,9 +46,9 @@ export function tagsDetails(
             staticInput.closest(".setting-item");
           if (parent) {
             if (isStatic) {
-              parent.style.display = "flex";
+              parent.removeClass("zettelkasten-flow__is-hidden");
             } else {
-              parent.style.display = "none";
+              parent.addClass("zettelkasten-flow__is-hidden");
               staticInput.value = "";
               delete action.staticValue;
             }
@@ -78,8 +78,8 @@ export function tagsDetails(
   );
 
   if (staticBehaviour) {
-    staticValueContainer.settingEl.style.display = "flex";
+    staticValueContainer.settingEl.removeClass("zettelkasten-flow__is-hidden");
   } else {
-    staticValueContainer.settingEl.style.display = "none";
+    staticValueContainer.settingEl.addClass("zettelkasten-flow__is-hidden");
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -32,6 +32,11 @@
 @use 'components/hooksConfig.scss';
 @use 'components/codeEditor.scss';
 
+/* Utility: hide an element without inline styles (see no-static-styles-assignment). */
+.zettelkasten-flow__is-hidden {
+    display: none !important;
+}
+
 /* This section warning the user with red tones */
 .zettelkasten-flow__settings-developer-section {
     background-color: var(--background-modifier-error);


### PR DESCRIPTION
Part of #88. Migrates the 24 static `el.style.display` toggles across the 6 action settings panels (prompt, number, checkbox, calendar, tags, cssClasses) to a `.zettelkasten-flow__is-hidden` utility class via `add`/`removeClass`. **Safe-by-construction:** the toggled element is always an Obsidian `.setting-item` (which is `display:flex` by default), so the class toggle is equivalent to the previous inline `flex`/`none`. `eslint-plugin-obsidianmd`: **475 -> 443** problems. typecheck + oxlint + jest green. Remaining for #88: CommunityFlowModal accordions (some dynamic), Select, the editor modals (min-width), TaskManagement, and the VariableTextProcessors widget span.