### PR TITLE
fix(timers): use window.setTimeout/clearTimeout for popout-window compatibility

### DIFF
--- a/src/application/community/CommunityFlowModal.tsx
+++ b/src/application/community/CommunityFlowModal.tsx
@@ -82,7 +82,7 @@ export class CommunityFlowModal extends Modal {
       actionBtn.setText(t("template_copied"));
       actionBtn.setAttribute("aria-disabled", "true");
       actionBtn.setAttribute("disabled", "true");
-      setTimeout(() => {
+      window.setTimeout(() => {
         actionBtn.setText(btnText);
         actionBtn.removeAttribute("aria-disabled");
         actionBtn.removeAttribute("disabled");

--- a/src/application/community/components/CommunityTemplatesGallery.tsx
+++ b/src/application/community/components/CommunityTemplatesGallery.tsx
@@ -78,7 +78,7 @@ export function CommunityTemplatesGallery(props: PluginComponentProps) {
   const [isLoading, setIsLoading] = useState(false);
 
   // Reference for debouncing search input
-  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const searchTimeoutRef = useRef<number | null>(null);
 
   // Infinite scroll sentinel reference
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -145,7 +145,7 @@ export function CommunityTemplatesGallery(props: PluginComponentProps) {
   useEffect(() => {
     return () => {
       if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current);
+        window.clearTimeout(searchTimeoutRef.current);
       }
     };
   }, []);
@@ -157,10 +157,10 @@ export function CommunityTemplatesGallery(props: PluginComponentProps) {
     setSearchTerm(e.target.value);
 
     if (searchTimeoutRef.current) {
-      clearTimeout(searchTimeoutRef.current);
+      window.clearTimeout(searchTimeoutRef.current);
     }
 
-    searchTimeoutRef.current = setTimeout(() => {
+    searchTimeoutRef.current = window.setTimeout(() => {
       setTargetSearchTerm(e.target.value);
     }, 400);
   };

--- a/src/application/community/components/StaticTemplatesGallery.tsx
+++ b/src/application/community/components/StaticTemplatesGallery.tsx
@@ -29,7 +29,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
   const [isLoading, setIsLoading] = useState(false);
 
   // Ref para debouncing en búsqueda
-  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const searchTimeoutRef = useRef<number | null>(null);
 
   // Reinicia las plantillas al cambiar el término o el filtro
   useEffect(() => {
@@ -69,15 +69,15 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
   // Limpieza del timeout al desmontar
   useEffect(() => {
     return () => {
-      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+      if (searchTimeoutRef.current) window.clearTimeout(searchTimeoutRef.current);
     };
   }, []);
 
   // Handlers
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
-    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-    searchTimeoutRef.current = setTimeout(() => {
+    if (searchTimeoutRef.current) window.clearTimeout(searchTimeoutRef.current);
+    searchTimeoutRef.current = window.setTimeout(() => {
       setTargetSearchTerm(e.target.value);
     }, 400);
   };

--- a/src/application/notes/NoteBuilder.ts
+++ b/src/application/notes/NoteBuilder.ts
@@ -137,7 +137,7 @@ export class NoteBuilder {
         .postProcess({ element, content: this.content, note: this.note, context: this.context }, file);
     }
 
-    setTimeout(() => {
+    window.setTimeout(() => {
       ObsidianApi.executeCommandById('templater-obsidian:replace-in-file-templater');
     }, 1000);
   }

--- a/src/architecture/components/core/codeView/CodeView.ts
+++ b/src/architecture/components/core/codeView/CodeView.ts
@@ -13,7 +13,7 @@ export class CodeView extends TextFileView implements HoverParent {
     parentDiv: HTMLDivElement;
 
     editor: EditService;
-    editorJit: NodeJS.Timeout | null;
+    editorJit: number | null;
 
     data: string;
 
@@ -61,8 +61,8 @@ export class CodeView extends TextFileView implements HoverParent {
             this.parentDiv,
             this.data,
             (update) => {
-                if (this.editorJit) clearTimeout(this.editorJit);
-                this.editorJit = setTimeout(() => {
+                if (this.editorJit) window.clearTimeout(this.editorJit);
+                this.editorJit = window.setTimeout(() => {
                     this.data = update.state.doc.toString();
                     this.editor
                         .setContent(this.data)

--- a/src/config/modals/handlers/hooks/components/PropertyHookAccordion.tsx
+++ b/src/config/modals/handlers/hooks/components/PropertyHookAccordion.tsx
@@ -29,11 +29,11 @@ export const PropertyHookAccordion: React.FC<PropertyHookAccordionProps> = ({
   useEffect(() => {
     setLocalScript(script);
 
-    const timer = setTimeout(() => {
+    const timer = window.setTimeout(() => {
       setAnimationClass("");
     }, 300);
 
-    return () => clearTimeout(timer);
+    return () => window.clearTimeout(timer);
   }, [script]);
 
   // Integrate with dndkit for drag-and-drop
@@ -49,7 +49,7 @@ export const PropertyHookAccordion: React.FC<PropertyHookAccordionProps> = ({
   // Handle the removal with animation
   const handleDelete = () => {
     setAnimationClass("exit");
-    setTimeout(() => {
+    window.setTimeout(() => {
       onDelete();
     }, 300);
   };

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAccordion.tsx
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAccordion.tsx
@@ -27,10 +27,10 @@ export function ActionAccordion(props: ActionAccordionProps) {
     if (!action.id) {
       action.id = uuid7();
     }
-    const timer = setTimeout(() => {
+    const timer = window.setTimeout(() => {
       setAnimationClass("");
     }, 300); // Adjust to your animation duration
-    return () => clearTimeout(timer);
+    return () => window.clearTimeout(timer);
   }, [action]);
 
   // Integrate with dndkit using useSortable
@@ -48,7 +48,7 @@ export function ActionAccordion(props: ActionAccordionProps) {
    */
   const handleRemove = () => {
     setAnimationClass("exit");
-    setTimeout(() => {
+    window.setTimeout(() => {
       onRemove();
     }, 300); // Adjust to your animation duration
   };


### PR DESCRIPTION
Part of #85 (Obsidian-lint burn-down). Prefixes all 16 bare timers with `window.*` (`obsidianmd/prefer-window-timers`) and types the stored handles as `number` instead of `NodeJS.Timeout` (also removes Node types, better for mobile). `eslint-plugin-obsidianmd`: **443 -> 424** (rule now at 0). typecheck + oxlint + jest green.