### PR TITLE
chore(lint): disable no-undef for TypeScript in eslint-obsidianmd config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,5 +34,11 @@ export default [
         ecmaFeatures: { jsx: true },
       },
     },
+    rules: {
+      // `no-undef` is redundant under TypeScript (tsc already enforces it) and false-positives
+      // on type-only names (CanvasData, EventRef, Menu, React...). typescript-eslint recommends
+      // turning it off for .ts/.tsx. See https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule
+      "no-undef": "off",
+    },
   },
 ];


### PR DESCRIPTION
Part of #85. `no-undef` is redundant under TypeScript (tsc enforces it) and false-positived on type-only names (`CanvasData`×10, `EventRef`×3, `Menu`, `React`). typescript-eslint officially recommends turning it off for .ts/.tsx. Config-only. `eslint-plugin-obsidianmd`: **424 -> 409**.