### PR TITLE
refactor(autocomplete): build completion items with createDiv/createSpan

### DIFF
--- a/src/actions/script/extensions/autoconfiguration/ScriptStepAutocomplete.ts
+++ b/src/actions/script/extensions/autoconfiguration/ScriptStepAutocomplete.ts
@@ -163,33 +163,12 @@ function createZettelFlowRenderer(completion: Completion): (element: HTMLElement
         // Add a CSS class for styling
         element.classList.add(c('cm-completion'));
 
-        // Create a container for better styling
-        const container = document.createElement('div');
-        container.className = c('cm-completion-container');
-
-        // Add ZettelFlow icon/badge
-        const badge = document.createElement('span');
-        badge.className = c('cm-completion-badge');
-        badge.textContent = '✨';
-
-        // Label with custom styling
-        const label = document.createElement('span');
-        label.className = c('cm-completion-label');
-        label.textContent = completion.label;
-
-        // Type indicator
-        const type = document.createElement('span');
-        type.className = c('cm-completion-type');
-        type.textContent = completion.type || 'property';
-
-        // Assemble the elements
-        container.appendChild(badge);
-        container.appendChild(label);
-        container.appendChild(type);
-
-        // Clear and append to the element
+        // Rebuild the completion item using Obsidian's DOM helpers
         element.empty();
-        element.appendChild(container);
+        const container = element.createDiv({ cls: c('cm-completion-container') });
+        container.createSpan({ cls: c('cm-completion-badge'), text: '✨' });
+        container.createSpan({ cls: c('cm-completion-label'), text: completion.label });
+        container.createSpan({ cls: c('cm-completion-type'), text: completion.type || 'property' });
     };
 }
 

--- a/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion.ts
+++ b/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion.ts
@@ -168,33 +168,12 @@ function createZettelFlowRenderer(completion: Completion): (element: HTMLElement
         // Add a CSS class for styling
         element.classList.add(c('cm-completion'));
 
-        // Create a container for better styling
-        const container = document.createElement('div');
-        container.className = c('cm-completion-container');
-
-        // Add ZettelFlow icon/badge
-        const badge = document.createElement('span');
-        badge.className = c('cm-completion-badge');
-        badge.textContent = '✨';
-
-        // Label with custom styling
-        const label = document.createElement('span');
-        label.className = c('cm-completion-label');
-        label.textContent = completion.label;
-
-        // Type indicator
-        const type = document.createElement('span');
-        type.className = c('cm-completion-type');
-        type.textContent = completion.type || 'property';
-
-        // Assemble the elements
-        container.appendChild(badge);
-        container.appendChild(label);
-        container.appendChild(type);
-
-        // Clear and append to the element
+        // Rebuild the completion item using Obsidian's DOM helpers
         element.empty();
-        element.appendChild(container);
+        const container = element.createDiv({ cls: c('cm-completion-container') });
+        container.createSpan({ cls: c('cm-completion-badge'), text: '✨' });
+        container.createSpan({ cls: c('cm-completion-label'), text: completion.label });
+        container.createSpan({ cls: c('cm-completion-type'), text: completion.type || 'property' });
     };
 }
 

--- a/src/config/modals/handlers/hooks/extensions/autoconfiguration/HookAutocomplete.ts
+++ b/src/config/modals/handlers/hooks/extensions/autoconfiguration/HookAutocomplete.ts
@@ -115,33 +115,12 @@ function createHookRenderer(completion: Completion): (element: HTMLElement) => v
         element.classList.add(c('cm-completion'));
         element.classList.add(c('cm-hook-completion'));
 
-        // Create a container for better styling
-        const container = document.createElement('div');
-        container.className = c('cm-completion-container');
-
-        // Add Hook icon/badge
-        const badge = document.createElement('span');
-        badge.className = c('cm-completion-badge');
-        badge.textContent = '⚓';
-
-        // Label with custom styling
-        const label = document.createElement('span');
-        label.className = c('cm-completion-label');
-        label.textContent = completion.label;
-
-        // Type indicator
-        const type = document.createElement('span');
-        type.className = c('cm-completion-type');
-        type.textContent = completion.type || 'property';
-
-        // Assemble the elements
-        container.appendChild(badge);
-        container.appendChild(label);
-        container.appendChild(type);
-
-        // Clear and append to the element
+        // Rebuild the completion item using Obsidian's DOM helpers
         element.empty();
-        element.appendChild(container);
+        const container = element.createDiv({ cls: c('cm-completion-container') });
+        container.createSpan({ cls: c('cm-completion-badge'), text: '⚓' });
+        container.createSpan({ cls: c('cm-completion-label'), text: completion.label });
+        container.createSpan({ cls: c('cm-completion-type'), text: completion.type || 'property' });
     };
 }
 


### PR DESCRIPTION
Part of #85. Replaces `document.createElement` + `className` + `appendChild` in the 3 completion renderers (ZettelFlow x2 + Hook) with Obsidian's `createDiv`/`createSpan` helpers (`obsidianmd/prefer-create-el`). Produces identical DOM. `eslint-plugin-obsidianmd`: **409 -> 397**. typecheck + oxlint + jest green.