### PR TITLE
refactor(canvas): use createDiv/createEl/createSpan over document.createElement

### DIFF
--- a/src/architecture/plugin/canvas/extensions/EditCanvasExtension.ts
+++ b/src/architecture/plugin/canvas/extensions/EditCanvasExtension.ts
@@ -158,7 +158,7 @@ export default class EditStepCanvasExtension extends CanvasExtension {
      * @returns The newly created HTML button element.
      */
     private createPopupMenuOption(menuOption: MenuOption): HTMLElement {
-        const menuOptionElement = document.createElement("button");
+        const menuOptionElement = createEl("button");
 
         // Use the provided ID if present
         if (menuOption.id) {

--- a/src/architecture/plugin/canvas/extensions/utils/CanvasHelper.ts
+++ b/src/architecture/plugin/canvas/extensions/utils/CanvasHelper.ts
@@ -14,7 +14,7 @@ export default class CanvasHelper {
     static readonly GRID_SIZE = 20
 
     static createControlMenuButton(menuOption: MenuOption): HTMLElement {
-        const quickSetting = document.createElement('div')
+        const quickSetting = createDiv()
         if (menuOption.id) quickSetting.id = menuOption.id
         quickSetting.classList.add('canvas-control-item')
         setIcon(quickSetting, menuOption.icon)
@@ -30,7 +30,7 @@ export default class CanvasHelper {
     }
 
     static createCardMenuOption(canvas: Canvas, menuOption: MenuOption, previewNodeSize: () => Size, onPlaced: (canvas: Canvas, pos: Position) => void): HTMLElement {
-        const menuOptionElement = document.createElement('div')
+        const menuOptionElement = createDiv()
         if (menuOption.id) menuOptionElement.id = menuOption.id
         menuOptionElement.classList.add('canvas-card-menu-button')
         menuOptionElement.classList.add('mod-draggable')
@@ -57,7 +57,7 @@ export default class CanvasHelper {
     }
 
     static createPopupMenuOption(menuOption: MenuOption): HTMLElement {
-        const menuOptionElement = document.createElement('button')
+        const menuOptionElement = createEl('button')
         if (menuOption.id) menuOptionElement.id = menuOption.id
         menuOptionElement.classList.add('clickable-icon')
         setIcon(menuOptionElement, menuOption.icon)
@@ -82,7 +82,7 @@ export default class CanvasHelper {
                 menuOptionElement.classList.add('is-active')
 
                 // Add popup menu
-                const submenu = document.createElement('div')
+                const submenu = createDiv()
                 submenu.id = submenuId
                 submenu.classList.add('canvas-submenu')
 
@@ -128,18 +128,18 @@ export default class CanvasHelper {
 
 
     static createDropdownOptionElement(menuOption: MenuOption): HTMLElement {
-        const menuDropdownOptionElement = document.createElement('div')
+        const menuDropdownOptionElement = createDiv()
         menuDropdownOptionElement.classList.add('menu-item')
         menuDropdownOptionElement.classList.add('tappable')
 
         // Add icon
-        const iconElement = document.createElement('div')
+        const iconElement = createDiv()
         iconElement.classList.add('menu-item-icon')
         setIcon(iconElement, menuOption.icon)
         menuDropdownOptionElement.appendChild(iconElement)
 
         // Add label
-        const labelElement = document.createElement('div')
+        const labelElement = createDiv()
         labelElement.classList.add('menu-item-title')
         labelElement.textContent = menuOption.label
         menuDropdownOptionElement.appendChild(labelElement)
@@ -162,7 +162,7 @@ export default class CanvasHelper {
     }
 
     static createDropdownSeparatorElement(): HTMLElement {
-        const separatorElement = document.createElement('div')
+        const separatorElement = createDiv()
         separatorElement.classList.add('menu-separator')
 
         return separatorElement

--- a/src/starters/services/VariableTextProcessors.ts
+++ b/src/starters/services/VariableTextProcessors.ts
@@ -164,11 +164,10 @@ class SelectableTextWidget extends WidgetType {
      * @returns A span element with styling.
      */
     public toDOM(): HTMLElement {
-        const span = document.createElement("span");
-        span.textContent = this.value;
-        span.style.color = "var(--text-accent-color)";
-        span.style.textDecoration = "underline";
-        return span;
+        return createSpan({
+            cls: "zettelkasten-flow__placeholder-widget",
+            text: this.value,
+        });
     }
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -37,6 +37,12 @@
     display: none !important;
 }
 
+/* {{frontmatter}} live-preview placeholder widget (VariableTextProcessors). */
+.zettelkasten-flow__placeholder-widget {
+    color: var(--text-accent-color);
+    text-decoration: underline;
+}
+
 /* This section warning the user with red tones */
 .zettelkasten-flow__settings-developer-section {
     background-color: var(--background-modifier-error);


### PR DESCRIPTION
Part of #85 and #88. Migrates `CanvasHelper` (8 sites), `EditCanvasExtension` (1) and the `{{frontmatter}}` live-preview widget span to Obsidian's global `createDiv`/`createEl`/`createSpan` helpers — these create detached elements, so the DOM is identical. Also moves the widget's inline `color`/`text-decoration` to a `.zettelkasten-flow__placeholder-widget` CSS class. `eslint-plugin-obsidianmd`: **397 -> 385**. typecheck + oxlint + jest green.