### PR TITLE
style(ui): use sentence case for button labels and section headings

### DIFF
--- a/src/actions/dynamicSelector/DynamicSelectorSettings.tsx
+++ b/src/actions/dynamicSelector/DynamicSelectorSettings.tsx
@@ -105,7 +105,7 @@ export function dynamicSelectorDetails(
     .addButton((button) => {
       button
         .setDisabled(readonly)
-        .setButtonText("Clear Output")
+        .setButtonText("Clear output")
         .onClick(() => {
           clearScriptOutput(debugContainer);
         });

--- a/src/actions/script/ScriptSettings.tsx
+++ b/src/actions/script/ScriptSettings.tsx
@@ -49,7 +49,7 @@ export const scriptSettings: ActionSetting = (
       });
     })
     .addButton((button) => {
-      button.setButtonText("Clear Output");
+      button.setButtonText("Clear output");
       button.onClick(() => {
         clearScriptOutput(debugContainer);
       });

--- a/src/application/community/CommunityFlowModal.tsx
+++ b/src/application/community/CommunityFlowModal.tsx
@@ -155,7 +155,7 @@ ${this.flow.description}`;
       const imgSection = this.contentEl.createDiv({
         cls: c("modal-reader-flow-image-section"),
       });
-      imgSection.createEl("h3", { text: "Flow Preview" });
+      imgSection.createEl("h3", { text: "Flow preview" });
 
       const container = imgSection.createDiv({
         cls: c("flow-image-container"),
@@ -188,7 +188,7 @@ ${this.flow.description}`;
     const section = this.contentEl.createDiv({
       cls: c("modal-reader-flow-nodes-section"),
     });
-    section.createEl("h3", { text: "Flow Nodes" });
+    section.createEl("h3", { text: "Flow nodes" });
 
     const container = section.createDiv({ cls: c("flow-nodes-container") });
     const grouped: Record<string, CommunityFlowNode[]> = {};
@@ -372,7 +372,7 @@ ${this.flow.description}`;
     const section = this.contentEl.createDiv({
       cls: c("modal-reader-flow-edges-section"),
     });
-    section.createEl("h3", { text: "Flow Connections" });
+    section.createEl("h3", { text: "Flow connections" });
     const list = section
       .createDiv({ cls: c("flow-edges-container") })
       .createEl("ul", { cls: c("flow-edges-list") });


### PR DESCRIPTION
Part of #85 (`obsidianmd/ui/sentence-case`). Lowercases 5 Title Case UI strings: 'Clear output' (x2) and 'Flow preview/nodes/connections'. Two warnings remain **intentionally** — proper nouns (ZettelFlow / CodeView) and a URL placeholder (`https://...`) — which the rule false-positives and forbids inline-disabling (`no-restricted-disable`). `eslint-plugin-obsidianmd`: **385 -> 380**. typecheck + oxlint + jest green.