### PR TITLE
fix: protect user canvas on re-onboarding + fix empty managed-step modal

### DIFF
--- a/docs/architecture/plugin-core.md
+++ b/docs/architecture/plugin-core.md
@@ -138,8 +138,8 @@ Both extend `CanvasExtension` (constructor stores `plugin`, calls `abstract init
 - **`EditStepCanvasExtension`** — listens to `canvas:popup-menu`; on a ZettelFlow canvas adds
   "Edit ZettelFlow Step" (single selection → `StepBuilderModal`) or "Copy Flow to Clipboard".
 - **`AddManagedStepExtension`** — listens to `zettelflow-node-connection-drop-menu`; adds
-  "Create Managed Step" (pick an installed step → creates a node with
-  `unknownData.zettelflowConfig`) and "Import Flow Data from Clipboard".
+  "Create Managed Step" (if templates are installed: pick one first; otherwise: blank step config)
+  → creates a node with `unknownData.zettelflowConfig`) and "Import Flow Data from Clipboard".
 
 All extensions gate on `CanvasHelper.isCanvasFlow(plugin)` — i.e. the active file is
 `ribbonCanvas` / `editorCanvas` or lives under `foldersFlowsPath` / `hooks.folderFlowPath`.

--- a/src/application/notes/onboardingService.ts
+++ b/src/application/notes/onboardingService.ts
@@ -76,6 +76,10 @@ async function writeFile(
  *
  * Returns true if the file was rewritten, false if no repair was needed.
  */
+// The old onboarding (before aaac1c5) created Introduction.md with just this line.
+// We only auto-repair that exact default; any other content is user-customised.
+const OLD_BROKEN_TEMPLATE = "# {{title}}";
+
 export async function repairBrokenExampleFlow(plugin: ZettelFlow): Promise<boolean> {
     if (plugin.settings.ribbonCanvas !== EXAMPLE_CANVAS_PATH) return false;
     const { vault } = plugin.app;
@@ -83,6 +87,7 @@ export async function repairBrokenExampleFlow(plugin: ZettelFlow): Promise<boole
     if (!stepFile) return false;
     const content = await vault.cachedRead(stepFile);
     if (content.includes("zettelFlowSettings:")) return false;
+    if (content.trim() !== OLD_BROKEN_TEMPLATE) return false;
     await vault.modify(stepFile, STEP_TEMPLATE);
     return true;
 }
@@ -94,8 +99,14 @@ export async function createExampleFlow(plugin: ZettelFlow): Promise<string | nu
         await ensureFolder(vault, EXAMPLE_STEPS_FOLDER);
         await ensureFolder(vault, EXAMPLE_NOTES_FOLDER);
 
+        // Step file: always write the latest template so the frontmatter is correct.
         await writeFile(vault, EXAMPLE_STEP_PATH, STEP_TEMPLATE);
-        await writeFile(vault, EXAMPLE_CANVAS_PATH, EXAMPLE_CANVAS_CONTENT);
+
+        // Canvas: only create when it does not yet exist.
+        // An existing canvas may contain user-added nodes — never overwrite it.
+        if (!vault.getFileByPath(EXAMPLE_CANVAS_PATH)) {
+            await vault.create(EXAMPLE_CANVAS_PATH, EXAMPLE_CANVAS_CONTENT);
+        }
 
         plugin.settings.ribbonCanvas = EXAMPLE_CANVAS_PATH;
         await plugin.saveSettings();

--- a/src/architecture/plugin/canvas/extensions/AddManagedStepExtension.ts
+++ b/src/architecture/plugin/canvas/extensions/AddManagedStepExtension.ts
@@ -123,14 +123,25 @@ export default class AddManagedStepExtension extends CanvasExtension {
      * Handles the managed step creation process by first prompting the user to select a step,
      * then presenting node creation options based on the chosen step.
      *
+     * When no step templates are installed, skip the template picker and go directly to
+     * the node-type selection with a blank step configuration so the canvas is never left
+     * with an unusable empty modal.
+     *
      * @param {Canvas} canvas - The canvas where the node will be created.
      * @param {Position} pos - The position at which to create the node.
      */
     private handleManagedStepCreation(canvas: Canvas, pos: Position): void {
-        new UsedInstalledStepsModal(this.plugin, (step) => {
+        const installedSteps = this.plugin.settings.installedTemplates.steps;
+        const openNodeTypeModal = (step: StepSettings) => {
             const options: Option[] = this.getCreationOptions(canvas, pos, step);
             new OptionsModal(this.plugin.app, "Type of Canvas component", options).open();
-        }).open();
+        };
+
+        if (Object.keys(installedSteps).length > 0) {
+            new UsedInstalledStepsModal(this.plugin, openNodeTypeModal).open();
+        } else {
+            openNodeTypeModal({ root: false, actions: [], label: "" });
+        }
     }
 
     /**

--- a/test/application/notes/onboardingService.test.ts
+++ b/test/application/notes/onboardingService.test.ts
@@ -156,6 +156,19 @@ describe("repairBrokenExampleFlow", () => {
         );
     });
 
+    it("does NOT overwrite a file with custom content that lacks frontmatter", async () => {
+        const { plugin, vault } = makeRepairPlugin({
+            stepExists: true,
+            stepContent: "# My custom introduction\n\nUser notes here.\n",
+            ribbonCanvas: EXAMPLE_CANVAS_PATH,
+        });
+
+        const repaired = await repairBrokenExampleFlow(plugin);
+
+        expect(repaired).toBe(false);
+        expect(vault.modify).not.toHaveBeenCalled();
+    });
+
     it("does NOT overwrite a file that already has correct frontmatter", async () => {
         const { plugin, vault } = makeRepairPlugin({
             stepExists: true,
@@ -197,16 +210,25 @@ describe("repairBrokenExampleFlow", () => {
     });
 });
 
-describe("createExampleFlow — files already exist (overwrite)", () => {
-    it("calls vault.modify instead of vault.create when files exist", async () => {
+describe("createExampleFlow — files already exist", () => {
+    it("overwrites the step file but preserves the canvas when both exist", async () => {
         const { plugin, vault } = makeMockPlugin(true, true);
         await createExampleFlow(plugin);
+        // Step file: overwritten to apply latest template
         expect(vault.modify).toHaveBeenCalledWith(mockTFile, expect.stringContaining("zettelFlowSettings"));
-        expect(vault.modify).toHaveBeenCalledWith(mockTCanvas, expect.any(String));
-        expect(vault.create).not.toHaveBeenCalled();
+        // Canvas: NOT overwritten — user data is preserved
+        const canvasModify = (vault.modify.mock.calls as [object, string][]).find(
+            ([f]) => (f as { path: string }).path === EXAMPLE_CANVAS_PATH
+        );
+        expect(canvasModify).toBeUndefined();
+        // Canvas: NOT re-created (already exists)
+        const canvasCreate = (vault.create.mock.calls as [string, string][]).find(
+            ([p]) => p === EXAMPLE_CANVAS_PATH
+        );
+        expect(canvasCreate).toBeUndefined();
     });
 
-    it("still sets ribbonCanvas and saves settings after modify", async () => {
+    it("still sets ribbonCanvas and saves settings", async () => {
         const { plugin } = makeMockPlugin(true, true);
         await createExampleFlow(plugin);
         expect(plugin.settings.ribbonCanvas).toBe(EXAMPLE_CANVAS_PATH);


### PR DESCRIPTION
## Problem

Two user-reported defects:

1. **Canvas data loss.** Re-running the example onboarding called `vault.modify()` on an
   existing `My first flow.canvas`, silently overwriting a user's real canvas. Also,
   `repairBrokenExampleFlow` rewrote **any** intro step lacking `zettelFlowSettings:`, so a
   customised `Introduction.md` was destroyed.
2. **"Create managed step" always empty.** From the canvas, the option opened
   `UsedInstalledStepsModal`, which lists only *installed community step templates*. With none
   installed the modal was permanently empty and there was no way to proceed.

## Fix

```mermaid
flowchart TD
    A["createExampleFlow()"] --> B{canvas file exists?}
    B -->|yes| C["skip — never overwrite user canvas"]
    B -->|no| D["vault.create(canvas)"]
    E["repairBrokenExampleFlow()"] --> F{intro body == old broken default?}
    F -->|no| G["skip — preserve custom content"]
    F -->|yes| H["rewrite with correct frontmatter"]
    I["Create managed step"] --> J{installed step templates?}
    J -->|yes| K["UsedInstalledStepsModal"]
    J -->|no| L["node-type picker with blank step config"]
```

- `createExampleFlow` only creates the example canvas when it is **absent** — existing canvases
  are never touched.
- `repairBrokenExampleFlow` rewrites the intro step **only** when its body is exactly the old
  broken default (`# {{title}}`); customised content is preserved.
- `AddManagedStepExtension` opens the node-type picker directly (blank step config) when no
  community step templates are installed.

## Tests

- `test/application/notes/onboardingService.test.ts`: adds regression cases — canvas is not
  overwritten when it already exists; a custom intro without frontmatter is not rewritten.
- `npm run verify` green (typecheck + oxlint + jest + lint:obsidian).

## Docs

- `docs/architecture/plugin-core.md` updated to describe the managed-step fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)