### PR TITLE
docs(readme): showcase the Zettelkasten toolkit + README exit criterion

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -45,7 +45,7 @@ has the checklist; the plan comment has the files, guardrails, and risks.
 
 ## Exit → stage 5
 
-When all tasks are checked off, do **three things before declaring done**:
+When all tasks are checked off, do **four things before declaring done**:
 
 ### 1. Docs audit (mandatory)
 
@@ -63,12 +63,28 @@ changed UI text — ask: *does the existing docs page cover this?*
 This audit is a **blocking exit criterion** — do not commit the implementation without it.
 Docs and code travel in the same commit (or a `docs:` follow-up commit immediately after).
 
-### 2. Quality check
+### 2. README showcase audit (mandatory for user-facing features)
+
+Adoption is a first-class goal: the main `README.md` is how new users decide to install. For every
+change that ships something a *user* would care about — a new command, sidebar view, action, or
+workflow — ask: *would a prospective user find this in the README?*
+
+- **New user-facing feature** → add a row to the **Features** table. For a **headline** capability
+  (a whole new tool/view/workflow, not a minor option) also add a bullet to the
+  **Zettelkasten toolkit** section near the top, phrased as user value (what it does for them).
+- **New action** → also bump the "N built-in actions" row count and list.
+- **No user-facing surface** (pure refactor, internal fix) → state explicitly that no README change
+  is needed.
+
+Like the docs audit, this is a **blocking exit criterion** — a shipped-but-unadvertised feature is
+a missed download. README and code travel in the same change.
+
+### 3. Quality check
 
 Run the **`obsidian-plugin-quality`** skill and the **`obsidian-plugin-reviewer`** agent on the
 diff, and verify every acceptance criterion in the issue spec (body).
 
-### 3. Close the issue via PR
+### 4. Close the issue via PR
 
 **Closing the issue (constitution §X).** Commits only *reference* the issue (`(#N)`) — they never
 close it. The issue is closed by the **pull request** that merges the branch to `main`: put

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,5 +163,11 @@ This harness is committed (only `.claude/settings.local.json` is git-ignored). I
   `implement` skill exit step encodes the full checklist.
 - When you change behavior or a public surface, update the matching page under `docs/` (and the
   `mkdocs.yml` nav) in the same change.
+- **Surface important features in the README (adoption is a first-class goal).** If a change ships
+  a feature a *user* would care about (a new command, view, action, or workflow — not an internal
+  refactor), it must appear in the main `README.md` in the same change: add a row to the **Features**
+  table, and for a headline capability also a bullet in the **Zettelkasten toolkit** section. The
+  README is how new users decide to install — a shipped-but-unadvertised feature is a missed
+  download. This is a blocking exit criterion (see the `implement` skill).
 - Don't introduce `innerHTML`, inline styles, or Title-case UI strings — they cost score.
 - Keep the two locale files (`en.ts`/`es.ts`) in sync.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@
 
 ---
 
+## Zettelkasten toolkit
+
+ZettelFlow is more than a note templater — it is a full **Zettelkasten workflow**. Beyond the
+canvas wizard, it ships a set of tools that grow and maintain your slip-box:
+
+- **📝 Note-builder companion pane** — a live preview of the note as you build it, plus
+  suggested connections to existing notes so you can link before you file.
+- **🔑 Zettel ID action** — stamp every note with a stable unique identifier (sortable
+  timestamp or Luhmann-style **Folgezettel** branching like `21 → 21a → 21a1`).
+- **🩺 Slip-box health dashboard** — a sidebar that surfaces **orphan** and **dead-end** notes
+  so link-debt never piles up unseen.
+- **🚀 Starter flows** — one-click, ready-made flows for the four classic note types
+  (fleeting, literature, permanent, structure/MOC).
+- **🗺️ Map-of-content builder** — gather notes by tag/folder into a MOC and refresh it safely;
+  re-runs never touch your own prose.
+- **✨ Connection resurfacing** — "talk to your slip-box": for the note you're reading, see
+  older, related notes worth revisiting, plus a daily spark of forgotten ideas.
+- **✂️ Atomicity split assist** — turn a multi-topic note into linked atomic notes in one
+  command, leaving the source as a hub.
+
+> New here? Run **Install Zettelkasten starter flows** from the command palette, or open
+> **Settings → ZettelFlow** to launch these tools.
+
+---
+
 ## How it works
 
 ```
@@ -54,10 +79,17 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | Feature | Description |
 |---|---|
 | **Canvas-based flows** | Use Obsidian's native canvas as the workflow engine — no custom DSL to learn. |
-| **11 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script. |
+| **12 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID. |
 | **Conditional edges** | Label a canvas arrow `if: frontmatter.type === "meeting"` to branch the workflow at runtime. |
 | **Dynamic templates** | Use `{{title}}`, `{{date}}`, `{{frontmatter.key}}`, `{{canvas.name}}` in step body templates. |
 | **Live body preview** | See the rendered note body while editing a step's template (desktop). |
+| **Companion pane** | Live note preview + connection suggestions while the wizard runs — link before you file. |
+| **Zettel ID action** | Stable unique IDs per note: sortable timestamp or Folgezettel branching (`21 → 21a → 21a1`). |
+| **Slip-box health** | Sidebar dashboard surfacing orphan (no outgoing links) and dead-end (no backlinks) notes. |
+| **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes. |
+| **Map-of-content builder** | Gather notes by tag/folder into a MOC; re-runs update a managed region and keep your prose. |
+| **Connection resurfacing** | Ranked older/related notes for the active note, with a daily-spark serendipity surface. |
+| **Atomicity split** | Split a multi-topic note into linked atomic notes, leaving the source as an index/hub. |
 | **Vault hooks** | Trigger flows automatically on folder creation events or frontmatter property changes. |
 | **Community templates** | Browse, install, and share flows, steps, and actions from the community browser. |
 | **.zftemplate export/import** | Bundle a canvas and its step files into a single portable file to share with others. |


### PR DESCRIPTION
## Summary

- **README**: adds a **"Zettelkasten toolkit"** highlight section near the top and extends the **Features** table with the seven new capabilities shipped in this release line (companion pane, Zettel ID/Folgezettel, slip-box health, starter flows, MOC builder, connection resurfacing, atomicity split). Bumps the built-in action count to **12**. Goal: new users discover the value and install.
- **Harness**: adds a working agreement in `CLAUDE.md` and a mandatory **"README showcase audit"** step in the `implement` skill — user-facing features must be surfaced in the README in the same change, as a **blocking exit criterion**.

Docs/harness only — no source changes.

## Test plan

- [ ] README renders on GitHub with the new section + table rows
- [ ] `npm run verify` still green (no code touched)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)