### PR TITLE
perf(canvas): preserve canvas keys, cache types.json, fewer reads

### DIFF
--- a/docs/architecture/plugin-core.md
+++ b/docs/architecture/plugin-core.md
@@ -124,6 +124,15 @@ On construction it waits for `workspace.onLayoutReady`, resolves a fully-loaded 
 - `CanvasView.setViewData` → on invalid JSON, repair with `tiny-jsonc` (tolerates trailing
   commas), then fire **`zettelflow-node-connection-drop-menu`**.
 
+### Programmatic canvas writes
+
+Programmatic saves (e.g. persisting a step's `zettelflowConfig`) do **not** go through the
+monkey-patched `getViewData`; they use `FlowImpl.save()` → `vault.modify` with the separate
+`canvasJsonFormatter`. That formatter pretty-prints `nodes`/`edges` one entry per line **and
+preserves every other top-level canvas key** so no canvas data is lost on save. The in-memory flow
+node map is built from a node's `TFile` extension at use-time — it never stamps a synthetic
+`extension` field onto the persisted node.
+
 ### `PatchHelper`
 
 A typed wrapper over `monkey-around`'s `around`. Every uninstaller is registered with

--- a/src/application/notes/NoteBuilder.ts
+++ b/src/application/notes/NoteBuilder.ts
@@ -169,9 +169,13 @@ export class NoteBuilder {
         .postProcess({ element, content: this.content, note: this.note, context: this.context }, file);
     }
 
-    window.setTimeout(() => {
-      ObsidianApi.executeCommandById('templater-obsidian:replace-in-file-templater');
-    }, 1000);
+    // Only trigger Templater's replace-in-file if the plugin is actually installed — otherwise
+    // this schedules a no-op command lookup on every note build.
+    if (ObsidianApi.globalApp().plugins.getPlugin('templater-obsidian')) {
+      window.setTimeout(() => {
+        ObsidianApi.executeCommandById('templater-obsidian:replace-in-file-templater');
+      }, 1000);
+    }
   }
 
   private async errorManagement() {

--- a/src/architecture/plugin/canvas/Flows.ts
+++ b/src/architecture/plugin/canvas/Flows.ts
@@ -75,9 +75,9 @@ export class FlowImpl implements Flow {
         this.nodes = data.nodes
             .filter(node => node.type !== "link")
             .reduce((map, obj) => {
-                if (obj.type === "file" && obj.file.endsWith(".js")) {
-                    obj.extension = "js";
-                }
+                // Note: we intentionally do NOT stamp a synthetic `extension` field on the node.
+                // `.js` file nodes are detected from the TFile extension at use-time; mutating the
+                // persisted node object here would serialize a non-schema key back into the canvas.
                 map.set(obj.id, obj);
                 return map;
             }, new Map<string, AllCanvasNodeData>());

--- a/src/architecture/plugin/canvas/formatter.ts
+++ b/src/architecture/plugin/canvas/formatter.ts
@@ -1,8 +1,26 @@
 import { CanvasData } from "obsidian/canvas";
 
-export function canvasJsonFormatter(data: CanvasData) {
+/**
+ * Serializes canvas data back to the on-disk `.canvas` JSON shape, pretty-printing `nodes` and
+ * `edges` one entry per line (matching Obsidian's own format for a clean diff).
+ *
+ * Any OTHER top-level key present on `data` (e.g. a future `metadata` field) is preserved
+ * verbatim — dropping unknown keys would silently lose canvas data on every programmatic save.
+ */
+export function canvasJsonFormatter(data: CanvasData): string {
     const nodesFormatted = data.nodes.map((node) => JSON.stringify(node));
     const edgesFormatted = data.edges.map((edge) => JSON.stringify(edge));
 
-    return `{\n\t"nodes":[\n\t\t${nodesFormatted.join(",\n\t\t")}\n\t],\n\t"edges":[\n\t\t${edgesFormatted.join(",\n\t\t")}\n\t]\n}`;
+    const parts = [
+        `\t"nodes":[\n\t\t${nodesFormatted.join(",\n\t\t")}\n\t]`,
+        `\t"edges":[\n\t\t${edgesFormatted.join(",\n\t\t")}\n\t]`,
+    ];
+
+    // Preserve every other top-level key exactly as-is (no reordering of nodes/edges).
+    for (const [key, value] of Object.entries(data)) {
+        if (key === "nodes" || key === "edges") continue;
+        parts.push(`\t${JSON.stringify(key)}:${JSON.stringify(value)}`);
+    }
+
+    return `{\n${parts.join(",\n")}\n}`;
 }

--- a/src/architecture/plugin/services/FrontmatterService.ts
+++ b/src/architecture/plugin/services/FrontmatterService.ts
@@ -155,7 +155,9 @@ export class FrontmatterService {
      * @returns {Promise<string>}
      */
     public async getContent(): Promise<string> {
-        const rawContent = await ObsidianApi.vault().read(this.file);
+        // cachedRead avoids a full uncached disk read per template during a note build; the
+        // content is only used to assemble the new note, so the cache view is authoritative.
+        const rawContent = await ObsidianApi.vault().cachedRead(this.file);
         const endLine = this.metadata.frontmatterPosition?.end?.line;
         return rawContent.split("\n").slice(endLine ? endLine + 1 : 0).join("\n").concat("\n");
     }

--- a/src/architecture/plugin/services/ObsidianNativeTypesManager.ts
+++ b/src/architecture/plugin/services/ObsidianNativeTypesManager.ts
@@ -49,18 +49,41 @@ export class ObsidianNativeTypesManager {
     }
 
     /**
+     * Short-lived cache of the parsed `types.json` so a burst of note builds (each of which needs
+     * the native types to type-cast frontmatter) doesn't read + parse the config file every time.
+     * Invalidated on any write and after a short TTL so external edits are still picked up.
+     */
+    private static typesCache: { value: Record<string, string>; expiry: number } | null = null;
+    private static readonly TYPES_CACHE_TTL_MS = 5000;
+
+    /** Drops the cached `types.json` so the next read re-fetches from disk. */
+    public static invalidateTypesCache(): void {
+        ObsidianNativeTypesManager.typesCache = null;
+    }
+
+    /**
      * Retrieves all types defined in the Obsidian configuration.
+     * Reads and parses `types.json` at most once per {@link TYPES_CACHE_TTL_MS} window; callers
+     * receive a fresh shallow copy so they can freely mutate it without corrupting the cache.
      * @returns {Promise<Record<string, string>>} A promise that resolves to an object containing type names and their values.
      */
     public static async getAllTypes(): Promise<Record<string, string>> {
+        const cache = ObsidianNativeTypesManager.typesCache;
+        if (cache && cache.expiry > Date.now()) {
+            return { ...cache.value };
+        }
+
         const typesFilePath = `${ObsidianApi.vault().configDir}/types.json`;
         // Check if file exists
         if (!await ObsidianApi.vault().adapter.exists(typesFilePath)) {
+            ObsidianNativeTypesManager.typesCache = { value: {}, expiry: Date.now() + ObsidianNativeTypesManager.TYPES_CACHE_TTL_MS };
             return {};
         }
         const raw = await ObsidianApi.vault().adapter.read(typesFilePath);
         const parsed = JSON.parse(raw) as { types: Record<string, string> };
-        return parsed.types;
+        const value = parsed.types ?? {};
+        ObsidianNativeTypesManager.typesCache = { value, expiry: Date.now() + ObsidianNativeTypesManager.TYPES_CACHE_TTL_MS };
+        return { ...value };
     }
     /**
      * Retrieves all native types defined in the Obsidian configuration.
@@ -93,6 +116,7 @@ export class ObsidianNativeTypesManager {
             `${ObsidianApi.vault().configDir}/types.json`,
             JSON.stringify({ types }, null, 2)
         );
+        ObsidianNativeTypesManager.invalidateTypesCache();
     }
 
     /**
@@ -110,6 +134,7 @@ export class ObsidianNativeTypesManager {
             `${ObsidianApi.vault().configDir}/types.json`,
             JSON.stringify({ types }, null, 2)
         );
+        ObsidianNativeTypesManager.invalidateTypesCache();
     }
 
     /**
@@ -128,5 +153,6 @@ export class ObsidianNativeTypesManager {
             `${ObsidianApi.vault().configDir}/types.json`,
             JSON.stringify({ types }, null, 2)
         );
+        ObsidianNativeTypesManager.invalidateTypesCache();
     }
 }

--- a/test/architecture/plugin/canvas/formatter.test.ts
+++ b/test/architecture/plugin/canvas/formatter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "@jest/globals";
+import { canvasJsonFormatter } from "architecture/plugin/canvas/formatter";
+import type { CanvasData } from "obsidian/canvas";
+
+describe("canvasJsonFormatter", () => {
+    it("produces valid JSON with nodes and edges", () => {
+        const data = {
+            nodes: [{ id: "a", type: "text", text: "hello", x: 0, y: 0, width: 10, height: 10 }],
+            edges: [{ id: "e1", fromNode: "a", toNode: "b" }],
+        } as unknown as CanvasData;
+
+        const parsed = JSON.parse(canvasJsonFormatter(data));
+        expect(parsed.nodes).toHaveLength(1);
+        expect(parsed.nodes[0].id).toBe("a");
+        expect(parsed.edges).toHaveLength(1);
+        expect(parsed.edges[0].id).toBe("e1");
+    });
+
+    it("preserves unknown top-level keys (no data loss on save)", () => {
+        const data = {
+            nodes: [],
+            edges: [],
+            metadata: { foo: 1, nested: { bar: "baz" } },
+            futureField: "keep me",
+        } as unknown as CanvasData;
+
+        const parsed = JSON.parse(canvasJsonFormatter(data));
+        expect(parsed.metadata).toEqual({ foo: 1, nested: { bar: "baz" } });
+        expect(parsed.futureField).toBe("keep me");
+    });
+
+    it("still pretty-prints nodes and edges one per line", () => {
+        const data = {
+            nodes: [
+                { id: "a", type: "text", text: "1", x: 0, y: 0, width: 1, height: 1 },
+                { id: "b", type: "text", text: "2", x: 0, y: 0, width: 1, height: 1 },
+            ],
+            edges: [],
+        } as unknown as CanvasData;
+
+        const out = canvasJsonFormatter(data);
+        // Two node lines means one newline between the two serialized nodes.
+        expect(out).toContain('"id":"a"');
+        expect(out).toContain('"id":"b"');
+        expect(out.split("\n").length).toBeGreaterThan(2);
+    });
+
+    it("round-trips an empty canvas", () => {
+        const data = { nodes: [], edges: [] } as unknown as CanvasData;
+        const parsed = JSON.parse(canvasJsonFormatter(data));
+        expect(parsed.nodes).toEqual([]);
+        expect(parsed.edges).toEqual([]);
+    });
+});

--- a/test/architecture/plugin/services/ObsidianNativeTypesManager.test.ts
+++ b/test/architecture/plugin/services/ObsidianNativeTypesManager.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { __setMockObsidianApi } from "architecture";
+import { ObsidianNativeTypesManager } from "architecture/plugin/services/ObsidianNativeTypesManager";
+
+function wireVault(typesJson: Record<string, string>) {
+    const read = jest
+        .fn<() => Promise<string>>()
+        .mockResolvedValue(JSON.stringify({ types: typesJson }));
+    const vault = {
+        configDir: ".obsidian",
+        adapter: {
+            exists: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+            read,
+        },
+    };
+    __setMockObsidianApi({ vault: vault as never });
+    return { read, vault };
+}
+
+describe("ObsidianNativeTypesManager caching", () => {
+    beforeEach(() => {
+        ObsidianNativeTypesManager.invalidateTypesCache();
+    });
+
+    it("reads types.json only once across repeated getTypes() calls (cache hit)", async () => {
+        const { read } = wireVault({ author: "text", rating: "number" });
+
+        await ObsidianNativeTypesManager.getTypes();
+        await ObsidianNativeTypesManager.getTypes();
+        await ObsidianNativeTypesManager.getTypes();
+
+        expect(read).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-reads after the cache is invalidated", async () => {
+        const { read } = wireVault({ author: "text" });
+
+        await ObsidianNativeTypesManager.getAllTypes();
+        ObsidianNativeTypesManager.invalidateTypesCache();
+        await ObsidianNativeTypesManager.getAllTypes();
+
+        expect(read).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns a fresh copy so callers mutating the result do not corrupt the cache", async () => {
+        wireVault({ author: "text", tags: "multitext" });
+
+        const first = await ObsidianNativeTypesManager.getAllTypes();
+        delete first["author"]; // mutate the returned object
+
+        const second = await ObsidianNativeTypesManager.getAllTypes();
+        expect(second.author).toBe("text"); // cache untouched
+    });
+
+    it("getTypes() strips the unique tags/aliases keys", async () => {
+        wireVault({ author: "text", tags: "multitext", aliases: "multitext" });
+
+        const types = await ObsidianNativeTypesManager.getTypes();
+        expect(types.author).toBe("text");
+        expect(types.tags).toBeUndefined();
+        expect(types.aliases).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

From a read-only audit of the canvas write and note-build paths. All changes are on the programmatic write side or in pure helpers — **`CanvasPatcher` / the monkey-patch is untouched**.

- **Data-loss fix**: `canvasJsonFormatter` now preserves **all** top-level canvas keys (not just `nodes`/`edges`). Any other field (e.g. a future `metadata`) was silently dropped on every programmatic save. New pure unit test (the formatter had none).
- **Data-integrity fix**: `FlowImpl` no longer stamps a synthetic `extension` field onto persisted nodes — nothing read it (the `.js` decision uses the `TFile` extension), it only polluted the saved `.canvas` JSON.
- **Perf**: `ObsidianNativeTypesManager` caches `types.json` (5s TTL, invalidated on write) instead of reading + parsing the config file on **every** note build; returns a fresh copy so callers can mutate safely. Unit-tested.
- **Perf**: `FrontmatterService.getContent` uses `cachedRead` instead of an uncached `read` for note-build template reads.
- **Robustness**: `NoteBuilder` only schedules the Templater replace-in-file command when Templater is actually installed.
- 299 tests green.

Closes #138

## Test plan

- [ ] `npm run verify` green (299 tests)
- [ ] Save a step in a canvas that has extra top-level keys → keys preserved, no `extension` field added to file nodes
- [ ] Build several notes → `types.json` read once (cached), not per note
- [ ] Without Templater installed → no replace-in-file command scheduled
- [ ] `npm run lint:obsidian` = 0

🤖 Generated with [Claude Code](https://claude.ai/claude-code)