### PR TITLE
ci: dedupe workflow runs (one CI run per change)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,23 @@
 name: CI
 
-# Quality guardrails for every pull request and feature-branch push:
-# type-check, lint and unit tests are BLOCKING; the Obsidian guideline lint is advisory
-# until the tracked violations are fixed (then make it blocking).
+# Quality guardrails: type-check, lint and unit tests are BLOCKING.
+#
+# Triggers are deduped so each change runs the suite ONCE:
+#   - pull_request → the canonical check for every feature/fix branch (branch protection uses it).
+#   - push → only main and release/** (post-merge verification). Feature/fix branches are NOT
+#     built on push; they always land through a PR, so a push trigger here only duplicated the
+#     pull_request run and competed for hosted runners.
+# The concurrency group cancels an in-progress run when the same PR/branch is pushed again.
 on:
   pull_request:
   push:
     branches:
-      - "feature/**"
-      - "fix/**"
+      - main
+      - "release/**"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Every PR was triggering **two identical CI runs** (a `pull_request` run and a `push`-to-`feature/**` run), which doubled hosted-runner demand. One such duplicate recently sat **queued ~15 min and failed** with *"The job was not acquired by Runner of type hosted"* — an infrastructure/runner-availability failure, not a code failure (the sibling run on the same commit passed in ~2 min).

- `push` now builds only `main` and `release/**` (post-merge verification). Feature/fix branches are already covered by their PR's `pull_request` run, so the push trigger was pure duplication.
- Added a `concurrency` group with `cancel-in-progress` so re-pushing an open PR cancels the superseded run instead of stacking.

Net effect: **one CI run per change**, less queue pressure, fewer spurious runner-availability failures.

## Test plan

- [ ] This PR itself shows a single "Type-check, lint & test" check (not two)
- [ ] After merge, a push to `release/2.12.0` still runs CI
- [ ] A new feature PR shows exactly one run; pushing again cancels the prior in-progress run

🤖 Generated with [Claude Code](https://claude.ai/claude-code)