### PR TITLE
fix: high-severity + data-loss bugs from code audit

### DIFF
--- a/src/actions/cssClasses/CssClassesSettings.tsx
+++ b/src/actions/cssClasses/CssClassesSettings.tsx
@@ -18,6 +18,7 @@ export const cssclassesSettings: ActionSetting = (
   const name = t("step_builder_element_type_cssclasses_title");
   const description = t("step_builder_element_type_cssclasses_description");
   navbarAction(contentEl, name, description, action, modal, disableNavbar);
+  cssClassesDetails(contentEl.createDiv(), action);
 };
 
 export function cssClassesDetails(

--- a/src/actions/dynamicSelector/components/MultipleSelectorComponent.tsx
+++ b/src/actions/dynamicSelector/components/MultipleSelectorComponent.tsx
@@ -5,7 +5,7 @@ import { WrappedActionBuilderProps } from "application/components/noteBuilder";
 import React, { useEffect, useState } from "react";
 import { DynamicSelectorElement } from "zettelkasten/typing";
 import { Icon } from "architecture/components/icon";
-import { buildAsyncScriptFunction } from "architecture/api";
+import { buildAsyncScriptFunction, fnsManager } from "architecture/api";
 import { isStringTupleArray } from "../typing";
 
 export function DynamicMultipleSelector(props: WrappedActionBuilderProps) {
@@ -27,46 +27,39 @@ export function DynamicMultipleSelector(props: WrappedActionBuilderProps) {
 
     const fnBody = `return (async () => {
           ${code}
-        })(element);`;
+        })(zf);`;
 
     let isMounted = true;
 
-    try {
-      const scriptFn = buildAsyncScriptFunction(["element"], fnBody);
-
-      const fetchOptions = async () => {
-        try {
-          const result = await scriptFn(element);
-          if (isStringTupleArray(result)) {
-            const dynamicOptions: string[] = result.map(
-              ([key]) => key
-            );
-            if (isMounted) {
-              setAvailableOptions(dynamicOptions);
-              setSelectedOptions([]); // Inicialmente no hay selecciones
-              setError(null);
-            }
-          } else {
-            throw new Error("El formato de las opciones es inválido.");
-          }
-        } catch (err) {
-          console.error("Error al obtener las opciones dinámicas:", err);
+    const fetchOptions = async () => {
+      try {
+        // Mirror the single-selector mode: the user script receives the `zf` API, not the action.
+        const functions = await fnsManager.getFns();
+        const scriptFn = buildAsyncScriptFunction(["zf"], fnBody);
+        const result = await scriptFn(functions);
+        if (isStringTupleArray(result)) {
+          const dynamicOptions: string[] = result.map(([key]) => key);
           if (isMounted) {
-            setError("No se pudieron cargar las opciones.");
+            setAvailableOptions(dynamicOptions);
+            setSelectedOptions([]); // Inicialmente no hay selecciones
+            setError(null);
           }
-        } finally {
-          if (isMounted) {
-            setLoading(false);
-          }
+        } else {
+          throw new Error("El formato de las opciones es inválido.");
         }
-      };
+      } catch (err) {
+        console.error("Error al obtener las opciones dinámicas:", err);
+        if (isMounted) {
+          setError("No se pudieron cargar las opciones.");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
 
-      void fetchOptions();
-    } catch (err) {
-      console.error("Error al inicializar la función dinámica:", err);
-      setError("Error de inicialización.");
-      setLoading(false);
-    }
+    void fetchOptions();
 
     return () => {
       isMounted = false;

--- a/src/actions/script/extensions/autoconfiguration/ScriptStepAutocomplete.ts
+++ b/src/actions/script/extensions/autoconfiguration/ScriptStepAutocomplete.ts
@@ -109,7 +109,9 @@ function customCompletionProvider(context: CompletionContext): CompletionResult 
     }));
 
     return {
-        from: word.from + actualText.lastIndexOf(lastSegment),
+        // Replace only the final segment under the cursor (see Autocompletion.ts): deriving `from`
+        // from the cursor avoids eating a leading delimiter captured by the match.
+        from: context.pos - lastSegment.length,
         options: enhancedCompletions,
         validFor: /^[\w.]*$/
     };

--- a/src/actions/taskManagement/TaskManagementAction.tsx
+++ b/src/actions/taskManagement/TaskManagementAction.tsx
@@ -6,6 +6,7 @@ import { TaskManagementElement } from "./typing";
 import { t } from "architecture/lang";
 import { log } from "architecture";
 import { taskManagementSettingsReader } from "./TaskManagementSettingsReader";
+import { rolloverUnfinishedTodos } from "./taskManagementLogic";
 
 export class TaskManagementAction extends CustomZettelAction {
   private static ICON = "list-checks";
@@ -81,15 +82,10 @@ export class TaskManagementAction extends CustomZettelAction {
 
 const getAllUnfinishedTodos = async (file: TFile, tasksHeader: string) => {
   const contents = await FileService.getContent(file);
-  const contentsForDailyTasks = contents.split(tasksHeader)[1] || contents;
-  const unfinishedTodosRegex = /\t*- \[ \].*/g;
-  const unfinishedTodos = Array.from(
-    contentsForDailyTasks.matchAll(unfinishedTodosRegex)
-  ).map(([todo]) => todo);
-  const fileWithoutTasks = contents.split(/.*\t*- \[ \].*\n?/g).join("");
-  await FileService.modify(file, fileWithoutTasks);
+  const { collected, newContents } = rolloverUnfinishedTodos(contents, tasksHeader);
+  await FileService.modify(file, newContents);
   new Notice(
-    `Rollover ${unfinishedTodos.length} unfinished task/s from ${file.basename}`
+    `Rollover ${collected.length} unfinished task/s from ${file.basename}`
   );
-  return unfinishedTodos;
+  return collected;
 };

--- a/src/actions/taskManagement/taskManagementLogic.ts
+++ b/src/actions/taskManagement/taskManagementLogic.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure string logic for the task-management rollover, extracted so it can be unit-tested without
+ * the Obsidian vault. The previous implementation collected unfinished todos only from the
+ * section *after* the rollover header but then deleted every unfinished-todo line from the whole
+ * file — silently losing todos that lived before the header. This keeps collection and removal in
+ * the same scope.
+ */
+
+/** A single unfinished todo line, e.g. "- [ ] buy milk" (optionally tab-indented). */
+const UNFINISHED_TODO = /\t*- \[ \].*/g;
+/** A full unfinished-todo line including its trailing newline, for removal. */
+const UNFINISHED_TODO_LINE = /.*\t*- \[ \].*\n?/g;
+
+export interface RolloverResult {
+    /** The unfinished todo lines that were rolled over. */
+    collected: string[];
+    /** The file contents with exactly the collected todos removed. */
+    newContents: string;
+}
+
+/**
+ * Collect the unfinished todos to roll over and return the file contents with only those todos
+ * removed.
+ *
+ * - When `tasksHeader` is present and has content after it, only that trailing section is scanned
+ *   and cleaned; everything before the header (including any todos there) is preserved verbatim.
+ * - When the header is absent (or empty), the whole file is used, matching the previous fallback.
+ */
+export function rolloverUnfinishedTodos(contents: string, tasksHeader: string): RolloverResult {
+    const parts = tasksHeader ? contents.split(tasksHeader) : [contents];
+    const after = parts.length > 1 ? parts.slice(1).join(tasksHeader) : "";
+    const hasHeaderSection = parts.length > 1 && after.length > 0;
+
+    const scope = hasHeaderSection ? after : contents;
+    const collected = Array.from(scope.matchAll(UNFINISHED_TODO)).map(([todo]) => todo);
+    const cleanedScope = scope.split(UNFINISHED_TODO_LINE).join("");
+    const newContents = hasHeaderSection ? parts[0] + tasksHeader + cleanedScope : cleanedScope;
+
+    return { collected, newContents };
+}

--- a/src/application/community/CommunityTemplatesModal.tsx
+++ b/src/application/community/CommunityTemplatesModal.tsx
@@ -48,4 +48,10 @@ export class CommunityTemplatesModal extends Modal {
       this.root.render(<StaticTemplatesGallery plugin={this.plugin} />);
     }
   }
+
+  onClose(): void {
+    // Unmount the React tree so its effects/observers/timers stop when the modal closes.
+    this.root?.unmount();
+    this.contentEl.empty();
+  }
 }

--- a/src/application/community/UsedInstalledStepsModal.tsx
+++ b/src/application/community/UsedInstalledStepsModal.tsx
@@ -30,4 +30,9 @@ export class UsedInstalledStepsModal extends Modal {
       />
     );
   }
+
+  onClose(): void {
+    this.root?.unmount();
+    this.contentEl.empty();
+  }
 }

--- a/src/application/community/components/CommunityTemplatesGallery.tsx
+++ b/src/application/community/components/CommunityTemplatesGallery.tsx
@@ -118,7 +118,9 @@ export function CommunityTemplatesGallery(props: PluginComponentProps) {
     };
 
     void getData();
-  }, [skip, targetSearchTerm, filter, plugin.settings, hasMore, isLoading]);
+    // `hasMore`/`isLoading` are read as in-effect guards only — including them in the deps caused
+    // the effect to re-fire every time it toggled `isLoading`, re-fetching page 0 in a loop.
+  }, [skip, targetSearchTerm, filter, plugin.settings]);
 
   // (3) Infinite scroll observer
   useEffect(() => {

--- a/src/architecture/api/lib/FnConstructor.ts
+++ b/src/architecture/api/lib/FnConstructor.ts
@@ -99,7 +99,13 @@ class FnsManager {
 
     public getFns(): Promise<ZettelFlowApp> {
         if (!this.cache) {
-            this.cache = buildTools();
+            // Do NOT cache a rejected build: if it fails (e.g. a bad scripts-folder path) we must
+            // let the next call retry after the user fixes the config, instead of serving the same
+            // rejected promise for the rest of the session.
+            this.cache = buildTools().catch((error) => {
+                this.cache = null;
+                throw error;
+            });
         }
         return this.cache;
     }

--- a/src/architecture/components/core/codeView/CodeView.ts
+++ b/src/architecture/components/core/codeView/CodeView.ts
@@ -57,13 +57,16 @@ export class CodeView extends TextFileView implements HoverParent {
         this.parentDiv = this.contentEl.createDiv();
         this.data = await FileService.getContent(file);
 
-        this.editor = EditService.instance(file)
+        // Seed the edit service with the loaded content so a save is never issued with an
+        // undefined body (which would reject the write / clobber the file).
+        this.editor = EditService.instance(file).setContent(this.data);
         this.view = dispatchEditor(
             this.parentDiv,
             this.data,
             (update) => {
                 if (this.editorJit) window.clearTimeout(this.editorJit);
                 this.editorJit = window.setTimeout(() => {
+                    this.editorJit = null;
                     this.data = update.state.doc.toString();
                     void this.editor
                         .setContent(this.data)
@@ -71,6 +74,19 @@ export class CodeView extends TextFileView implements HoverParent {
                 }, 1000);
             });
         this.file = file;
+    }
+
+    /**
+     * Flush a pending debounced save immediately, if any. Called before the view is torn down or
+     * switched to another file so the (still-current) editor writes the outgoing file's content —
+     * never a stale snapshot into the next file.
+     */
+    private flushPendingSave(): void {
+        if (!this.editorJit) return;
+        window.clearTimeout(this.editorJit);
+        this.editorJit = null;
+        this.data = this.view.state.doc.toString();
+        void this.editor.setContent(this.data).save();
     }
 
     private initActions(): void {
@@ -82,13 +98,16 @@ export class CodeView extends TextFileView implements HoverParent {
     */
     async onClose() {
         await super.onClose();
-        void this.editor.save();
+        this.flushPendingSave();
         this.view.destroy();
         this.parentDiv.remove();
     }
 
     async onUnloadFile(file: TFile) {
         await super.onUnloadFile(file);
+        // Cancel/flush any pending save before the editor is reassigned to the next file, so the
+        // outgoing file's content is never written into the incoming one.
+        this.flushPendingSave();
         this.view.destroy();
     }
 }

--- a/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion.ts
+++ b/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion.ts
@@ -28,7 +28,7 @@ function findCompletions(
     return findCompletionsInTree(segments, node, CODEVIEW_DEFAULTS);
 }
 
-function customCompletionProvider(context: CompletionContext): CompletionResult | null {
+export function customCompletionProvider(context: CompletionContext): CompletionResult | null {
     // Get line content before cursor to check context
     const line = context.state.doc.lineAt(context.pos);
     const lineText = line.text.slice(0, context.pos - line.from);
@@ -115,7 +115,10 @@ function customCompletionProvider(context: CompletionContext): CompletionResult 
     }));
 
     return {
-        from: word.from + actualText.lastIndexOf(lastSegment),
+        // Replace only the final segment under the cursor. Deriving `from` from the cursor keeps
+        // it correct even when `word` includes a leading delimiter (space/`(`/`[`/…), which would
+        // otherwise shift `from` left by one and eat the preceding character on accept.
+        from: context.pos - lastSegment.length,
         options: enhancedCompletions,
         validFor: /^[\w.]*$/
     };

--- a/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/completionTree.ts
+++ b/src/architecture/components/core/codeView/editor/extensions/autoconfiguration/completionTree.ts
@@ -18,6 +18,21 @@ export function isCompletionArray(node: unknown): node is Completion[] {
     return Array.isArray(node);
 }
 
+/**
+ * A node that is itself a {@link Completion} (a `label`+`type` object) is a leaf API member with
+ * no sub-members — e.g. the script `context` object. Without this check it would be walked as a
+ * record and `context.` would wrongly suggest its own metadata keys (`label`, `type`, `info`, …).
+ */
+export function isCompletionLeaf(node: unknown): boolean {
+    return (
+        typeof node === "object" &&
+        node !== null &&
+        !Array.isArray(node) &&
+        "label" in node &&
+        "type" in node
+    );
+}
+
 function keysToCompletions(
     node: Record<string, unknown>,
     defaults: KeyCompletionDefaults
@@ -46,6 +61,9 @@ export function findCompletions(
     defaults: KeyCompletionDefaults
 ): Completion[] | null {
     if (isCompletionArray(node)) return node;
+
+    // A bare Completion leaf has no members to drill into (empty suggestions for `leaf.`).
+    if (isCompletionLeaf(node)) return null;
 
     if (segments.length === 0) {
         return keysToCompletions(node, defaults);

--- a/src/architecture/components/core/search/Search.tsx
+++ b/src/architecture/components/core/search/Search.tsx
@@ -139,10 +139,9 @@ export function Search<T>(props: SearchType<T>) {
             case "Enter": {
               e.preventDefault();
               e.stopPropagation();
-              const [key, value] = getEntryByIndex(
-                filteredOptions,
-                selectedIndex
-              );
+              const entry = getEntryByIndex(filteredOptions, selectedIndex);
+              if (!entry) break; // no match under the cursor (e.g. empty filtered list)
+              const [key, value] = entry;
               setValue(key);
               setSelectedValue(key);
               setFilteredOptions(filterRecordByKey(options, key));
@@ -173,7 +172,7 @@ export function Search<T>(props: SearchType<T>) {
 function getEntryByIndex<T>(
   record: Record<string, T>,
   index: number
-): [string, T] {
+): [string, T] | undefined {
   return Object.entries(record)[index];
 }
 

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -6,6 +6,7 @@ import { t } from "architecture/lang";
 import { log } from "architecture/monitoring/Logger";
 import { FileSuggest, FolderSuggest } from "architecture/settings";
 import { FILE_EXTENSIONS, FileService, activateSidebarView } from "architecture/plugin";
+import { fnsManager } from "architecture/api";
 import { DEFAULT_SETTINGS } from "config";
 import { CommunityTemplatesModal, ManageInstalledTemplatesModal } from "application/community";
 import { createRoot } from "react-dom/client";
@@ -191,6 +192,8 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                                     .onChange(async (value) => {
                                         plugin.settings.jsLibraryFolderPath = value;
                                         await plugin.saveSettings();
+                                        // Rebuild the `zf` script API so it reads from the new folder.
+                                        fnsManager.invalidateCache();
                                     });
                             });
                         },

--- a/src/config/modals/handlers/hooks/extensions/autoconfiguration/HookAutocomplete.ts
+++ b/src/config/modals/handlers/hooks/extensions/autoconfiguration/HookAutocomplete.ts
@@ -206,14 +206,17 @@ function hookCompletionProvider(context: CompletionContext): CompletionResult | 
         }));
 
         return {
-            from: word.from + actualText.lastIndexOf(lastSegment),
+            // Replace only the final segment under the cursor (see Autocompletion.ts): deriving
+            // `from` from the cursor avoids eating a leading delimiter captured by the match.
+            from: context.pos - lastSegment.length,
             options: enhancedCompletions,
             validFor: /^[\w.]*$/
         };
     } else if (rootSegment.startsWith('e') && 'event'.startsWith(rootSegment)) {
         // Provide the 'event' global variable as a completion
         return {
-            from: word.from,
+            // Replace the typed prefix only (not the leading delimiter word.from would include).
+            from: context.pos - rootSegment.length,
             options: eventCompletions.map(c => ({
                 ...c,
                 render: c.render || createHookRenderer(c)

--- a/src/config/typing.ts
+++ b/src/config/typing.ts
@@ -124,8 +124,12 @@ export type InstalledTemplates = {
  */
 export const DEFAULT_SETTINGS: Partial<ZettelFlowSettings> = {
     loggerEnabled: false, // Logging is disabled by default.
+    logLevel: "info", // Default log level; must match a key of the logger's level record.
     uniquePrefixEnabled: false, // Unique prefix is disabled by default.
     uniquePrefix: "YYYYMMDDHHmmss", // Default format for unique prefixes.
+    ribbonCanvas: "", // No ribbon canvas configured until the user picks one.
+    editorCanvas: "", // No editor canvas configured until the user picks one.
+    jsLibraryFolderPath: "", // No JS library folder configured by default.
     foldersFlowsPath: "_ZettelFlow/folders", // Default folder for storing flows.
     installedTemplates: {
         steps: {},   // No step templates are installed by default.

--- a/src/hooks/VaultHooks.ts
+++ b/src/hooks/VaultHooks.ts
@@ -100,7 +100,18 @@ export class VaultHooks {
     };
 
     private onRenameFolder(folder: TFolder, oldPath: string) {
-        const { foldersFlowsPath } = this.plugin.settings;
+        const settings = this.plugin.settings;
+        const { foldersFlowsPath } = settings;
+
+        // The scripts library is a *folder* path, so its rename arrives here (not in onRenameFile).
+        // Keep the setting in sync and refresh the `zf` script API so it reads from the new path.
+        if (oldPath === settings.jsLibraryFolderPath) {
+            settings.jsLibraryFolderPath = folder.path;
+            void this.plugin.saveSettings();
+            fnsManager.invalidateCache();
+            log.info("[VaultHooks] Renamed jsLibraryFolderPath.");
+        }
+
         const oldCanvas = canvasPathFromFolder(foldersFlowsPath, oldPath);
         const candidate = this.plugin.app.vault.getAbstractFileByPath(oldCanvas);
 
@@ -131,11 +142,8 @@ export class VaultHooks {
             settings.ribbonCanvas = file.path;
             void this.plugin.saveSettings();
             log.info("[VaultHooks] Renombrado ribbonCanvas.");
-        } else if (oldPath === settings.jsLibraryFolderPath) {
-            settings.jsLibraryFolderPath = file.path;
-            void this.plugin.saveSettings();
-            log.info("[VaultHooks] Renombrado jsLibraryFolderPath.");
         }
+        // jsLibraryFolderPath is a folder path, so its rename is handled in onRenameFolder.
     }
 
     /**
@@ -171,6 +179,7 @@ export class VaultHooks {
         if (folder.path === settings.jsLibraryFolderPath) {
             settings.jsLibraryFolderPath = "";
             void this.plugin.saveSettings();
+            fnsManager.invalidateCache();
             log.info("[VaultHooks] Removed jsLibraryFolderPath.");
             return;
         }

--- a/test/actions/taskManagement/taskManagementLogic.test.ts
+++ b/test/actions/taskManagement/taskManagementLogic.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "@jest/globals";
+import { rolloverUnfinishedTodos } from "actions/taskManagement/taskManagementLogic";
+
+const join = (...lines: string[]) => lines.join("\n");
+
+describe("rolloverUnfinishedTodos", () => {
+    it("collects only the unfinished todos under the rollover header", () => {
+        const contents = join(
+            "- [ ] before-header",
+            "## Tasks",
+            "- [ ] a",
+            "- [x] done",
+            "- [ ] b"
+        );
+        const { collected } = rolloverUnfinishedTodos(contents, "## Tasks");
+        expect(collected).toEqual(["- [ ] a", "- [ ] b"]);
+    });
+
+    it("does NOT delete unfinished todos outside the rollover section (regression: data loss)", () => {
+        const contents = join("- [ ] before-header", "## Tasks", "- [ ] a");
+        const { newContents } = rolloverUnfinishedTodos(contents, "## Tasks");
+        expect(newContents).toContain("- [ ] before-header");
+        expect(newContents).not.toContain("- [ ] a");
+    });
+
+    it("falls back to the whole file when the header is absent", () => {
+        const contents = join("- [ ] a", "- [x] done", "- [ ] b");
+        const { collected, newContents } = rolloverUnfinishedTodos(contents, "## Tasks");
+        expect(collected).toEqual(["- [ ] a", "- [ ] b"]);
+        expect(newContents).not.toContain("- [ ] a");
+        expect(newContents).not.toContain("- [ ] b");
+        expect(newContents).toContain("- [x] done");
+    });
+});

--- a/test/architecture/components/core/codeView/Autocompletion.test.ts
+++ b/test/architecture/components/core/codeView/Autocompletion.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "@jest/globals";
+import { EditorState } from "@codemirror/state";
+import { CompletionContext } from "@codemirror/autocomplete";
+import { customCompletionProvider } from "architecture/components/core/codeView/editor/extensions/autoconfiguration/Autocompletion";
+
+function contextFor(doc: string, pos: number = doc.length): CompletionContext {
+    const state = EditorState.create({ doc });
+    return new CompletionContext(state, pos, false);
+}
+
+describe("customCompletionProvider — completion insert range", () => {
+    it("replaces only the final segment when the token is preceded by a delimiter", () => {
+        // Regression for the `from` off-by-one: a leading space made `from` point at the dot,
+        // so accepting a completion produced e.g. `zfinternal` instead of `zf.internal`.
+        const ctx = contextFor("const x = zf.in");
+        const result = customCompletionProvider(ctx);
+        expect(result).not.toBeNull();
+        // The replaced range must start at the beginning of "in", i.e. 2 chars before the cursor.
+        expect(result!.from).toBe(ctx.pos - 2);
+        expect(result!.options.map((o) => o.label)).toContain("internal");
+    });
+
+    it("is also correct at the start of a line (no leading delimiter)", () => {
+        const ctx = contextFor("zf.in");
+        const result = customCompletionProvider(ctx);
+        expect(result).not.toBeNull();
+        expect(result!.from).toBe(ctx.pos - 2);
+    });
+});

--- a/test/architecture/components/core/codeView/completionTree.test.ts
+++ b/test/architecture/components/core/codeView/completionTree.test.ts
@@ -63,4 +63,25 @@ describe("findCompletions", () => {
         const weird = { a: { b: "not-an-object" } } as unknown as Record<string, unknown>;
         expect(findCompletions(["a", "b"], weird, DEFAULTS)).toBeNull();
     });
+
+    it("treats a bare Completion object as a leaf (no children), not a record of metadata keys", () => {
+        // Regression: a node that is itself a Completion (e.g. the script `context` object) was
+        // walked as a record, so `context.` suggested its metadata keys (label/type/info/...).
+        const contextLeaf = {
+            label: "context",
+            type: "object",
+            info: "Empty object to share info between script actions",
+            detail: "✨",
+            boost: 1,
+        };
+        const treeWithLeaf = {
+            note: [{ label: "title", type: "property", info: "", detail: "", boost: 99 }] as Completion[],
+            context: contextLeaf as unknown as Record<string, unknown>,
+        };
+        // Drilling into the leaf yields nothing to suggest.
+        expect(findCompletions(["context"], treeWithLeaf, DEFAULTS)).toBeNull();
+        // But the leaf is still listed among its parent's keys.
+        const rootLabels = findCompletions([], treeWithLeaf, DEFAULTS)?.map((c) => c.label);
+        expect(rootLabels).toContain("context");
+    });
 });

--- a/test/config/defaultSettings.test.ts
+++ b/test/config/defaultSettings.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "@jest/globals";
+import { DEFAULT_SETTINGS } from "config/typing";
+
+describe("DEFAULT_SETTINGS", () => {
+    // These keys are declared required on ZettelFlowSettings; missing defaults surface as the
+    // literal string "undefined" in settings fields and break the logger level lookup.
+    it("provides defaults for every scalar setting used before the user edits anything", () => {
+        expect(DEFAULT_SETTINGS.logLevel).toBeDefined();
+        expect(DEFAULT_SETTINGS.ribbonCanvas).toBeDefined();
+        expect(DEFAULT_SETTINGS.editorCanvas).toBeDefined();
+        expect(DEFAULT_SETTINGS.jsLibraryFolderPath).toBeDefined();
+    });
+
+    it("defaults the log level to a known level record key", () => {
+        expect(typeof DEFAULT_SETTINGS.logLevel).toBe("string");
+        expect((DEFAULT_SETTINGS.logLevel as string).length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## What

Fixes the **high-severity and data-loss bugs** surfaced by a full-codebase audit. Base is
`release/2.12.0` (the active line) so the diff is just these 10 fix commits.

Baseline was clean (typecheck / oxlint / obsidian-lint / 306 tests), so every finding is a logic
or edge-case bug. `npm run verify` is green on this branch: **typecheck ✓, oxlint ✓, obsidian lint ✓,
jest 314/314** (+8 new tests, red→green).

## Fixes

| Area | Bug |
|---|---|
| editor | Autocomplete `from` was off by one when a token was preceded by a delimiter, so accepting `zf.in`→`internal` produced `zfinternal` (text corruption). Affected the shared engine shipped in #142. |
| editor | The completion engine walked a bare `Completion` node (the script `context` object) as a record, so `context.` suggested its metadata keys (`label`/`type`/…). |
| scripts | `getFns()` cached a **rejected** `buildTools()` promise forever, breaking every `zf`/script/hook call for the whole session. Also: renaming the JS-library **folder** never updated the setting (only file renames were handled); the `zf` cache is now invalidated on scripts-folder rename/delete/settings change. |
| config | `DEFAULT_SETTINGS` was missing `logLevel`, `ribbonCanvas`, `editorCanvas`, `jsLibraryFolderPath` → literal `"undefined"` in settings fields and a logger that only emitted errors on a fresh install. |
| actions | **Data loss:** task rollover collected unfinished todos from the section after the header but deleted every unfinished-todo line from the whole file. Extracted a pure, unit-tested `rolloverUnfinishedTodos`. |
| actions | Dynamic selector "multiple" mode passed the action config instead of the `zf` API, so any script using `zf` failed to load options. |
| actions | The CSS Classes step never rendered its static-behaviour config in the builder (`cssClassesDetails` was never called in edit mode). |
| community | The templates gallery re-fetched page 0 in an **infinite loop** (`isLoading` in its effect deps); community modals also never unmounted their React roots (leak). |
| core | `Search` crashed on Enter with no matches (destructuring `undefined`). |
| editor | The debounced CodeView save was never cancelled on file switch/close, so it could write the previous file's content into the next one, and could save `undefined` for an opened-but-unedited file. |

## Tests

Real unit tests for the testable logic: autocomplete insert range (real CodeMirror
`EditorState`/`CompletionContext`), the completion-tree leaf handling, `DEFAULT_SETTINGS`
completeness, and the task-rollover string logic. React components / Obsidian views (Search,
CodeView, community gallery, selectors) aren't unit-testable in jest's `node` env and were fixed
defensively, covered by typecheck + lint.

## Not in this PR

The **medium/low-severity** findings from the same audit (warning→fatal escalation, selector
option-key collisions, `editorCanvas` not updated on rename/delete, `startsWith` prefix matching,
`flows.delete` at menu-build time, read-only property-type modal, `Flows.refresh` stale node map,
folgezettel non-numeric parent, hardcoded Spanish strings, `false/0/""` coercion, …) are left for
a focused second pass.

## Docs

No docs change: these restore already-expected/documented behaviour — no new features, config
options, or UI text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
