### PR TITLE
refactor(actions): Actions as cognitive capabilities — categorize the registry (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Vault hooks** | Trigger flows automatically on folder creation events or frontmatter property changes. |
 | **Event-driven workflows** | Let a flow react to vault events (note created/modified, a property or tag change) instead of only running on demand — off by default, throttled, and loop-guarded. |
 | **Visual workflow language** | Compose a reactive flow on the canvas: WHEN a vault event happens, IF a condition holds, run an ACTION, then WAIT for your confirmation — human-in-the-loop pauses, off by default and loop-guarded. |
+| **Action picker by capability** | The action picker groups actions by cognitive capability (Manipulation · Relations · Knowledge · Research · AI) instead of a flat list. |
 | **Community templates** | Browse, install, and share flows, steps, and actions from the community browser. |
 | **.zftemplate export/import** | Bundle a canvas and its step files into a single portable file to share with others. |
 | **Notes history** | Sidebar leaf showing recently built notes with quick-open links. |

--- a/docs/architecture/actions-and-note-builder.md
+++ b/docs/architecture/actions-and-note-builder.md
@@ -276,3 +276,39 @@ The **Dynamic Selector** uses a narrower script contract: called with only `zf`,
 See the step-by-step recipe in
 [Contributing & conventions](../development/contributing-and-conventions.md#adding-a-new-action),
 and the `new-action` harness skill which scaffolds the 4 files and the registration for you.
+
+## 9. Action categories (cognitive capabilities)
+
+Since #152 the action picker groups actions by **what they do to knowledge** rather than showing a
+flat list. There are five closed categories, rendered in this canonical order (emoji is decorative;
+the label is i18n, sentence case):
+
+| Category | Meaning |
+|---|---|
+| 📝 **Manipulation** | create / modify a note, add a property, tag, id, task, css class |
+| 🔗 **Relations** | create / remove / suggest a link between notes |
+| 🧠 **Knowledge** | extract concepts, find contradictions/duplicates, maturity *(actions land here with #153)* |
+| 🔍 **Research** | find / attach sources, extract & compare claims *(#155)* |
+| 🤖 **AI** | optional, provider-agnostic AI capabilities *(#156)* |
+
+**Built-in mapping (behavior-neutral — categorization changed nothing about how actions run):**
+Backlink → 🔗 Relations; every other built-in (Prompt, Number, Checkbox, Calendar, Selector,
+Dynamic selector, Tags, CSS classes, Task management, Script, Zettel ID) → 📝 Manipulation. The
+Knowledge / Research / AI groups ship **empty** and fill in as #153 / #155 / #156 land.
+
+**Declaring a category (third-party actions).** A category is an **optional** `category` field on
+`CustomZettelAction`:
+
+```ts
+export class MyAction extends CustomZettelAction {
+  id = "my-action";
+  category = "relations" as const; // optional — omit to stay uncategorized
+  // …
+}
+```
+
+Omitting it is fully supported (the #33 back-compat contract): the action still registers, runs, and
+appears in the picker under an **"Other"** group. **Empty groups are hidden**, so the uncategorized
+group only shows when at least one action has no category. The vocabulary, the canonical order, the
+grouping helper and the i18n label keys live in the pure, Obsidian-free
+`architecture/api/categories`.

--- a/src/actions/backlink/BackLinkAction.tsx
+++ b/src/actions/backlink/BackLinkAction.tsx
@@ -11,6 +11,7 @@ import { backLinkSettingsReader } from "./BackLinkSettingsReader";
 export class BackLinkAction extends CustomZettelAction {
   private static ICON = "links-coming-in";
   id = "backlink";
+  category = "relations" as const;
   defaultAction = {
     type: this.id,
     hasUI: true,

--- a/src/actions/calendar/CalendarAction.tsx
+++ b/src/actions/calendar/CalendarAction.tsx
@@ -16,6 +16,7 @@ const moment = obsidianMoment as unknown as typeof MomentFn;
 export class CalendarAction extends CustomZettelAction {
   private static ICON = "calendar-days";
   id = "calendar";
+  category = "manipulation" as const;
   defaultAction: Action = {
     type: this.id,
     hasUI: true,

--- a/src/actions/checkbox/CheckboxAction.tsx
+++ b/src/actions/checkbox/CheckboxAction.tsx
@@ -10,6 +10,7 @@ import { checkboxSettingsReader } from "./CheckboxSettingsReader";
 export class CheckboxAction extends CustomZettelAction {
   private static ICON = "check-square";
   id = "checkbox";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     hasUI: true,

--- a/src/actions/cssClasses/CssClassesAction.tsx
+++ b/src/actions/cssClasses/CssClassesAction.tsx
@@ -9,6 +9,7 @@ import { cssClassesSettingsReader } from "./CssClassesSettingsReader";
 export class CssClassesAction extends CustomZettelAction {
   private static ICON = "view";
   id = "cssclasses";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     description: "CSS classes",

--- a/src/actions/dynamicSelector/DynamicSelectorAction.tsx
+++ b/src/actions/dynamicSelector/DynamicSelectorAction.tsx
@@ -12,6 +12,7 @@ import { dynamicSelectorSettingsReader } from "./DynamicSelectorSettingsReader";
 export class DynamicSelectorAction extends CustomZettelAction {
   private static ICON = "square-dashed-mouse-pointer";
   id = "dynamic-selector";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     hasUI: true,

--- a/src/actions/number/NumberAction.tsx
+++ b/src/actions/number/NumberAction.tsx
@@ -11,6 +11,7 @@ import { numberSettingsReader } from "./NumberSettingsReader";
 export class NumberAction extends CustomZettelAction {
   private static ICON = "binary";
   id = "number";
+  category = "manipulation" as const;
 
   defaultAction = {
     type: this.id,

--- a/src/actions/prompt/PromptAction.tsx
+++ b/src/actions/prompt/PromptAction.tsx
@@ -11,6 +11,7 @@ import { promptSettingsReader } from "./PromptSettingsReader";
 export class PromptAction extends CustomZettelAction {
   private static ICON = "form-input";
   id = "prompt";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     hasUI: true,

--- a/src/actions/script/ScriptAction.tsx
+++ b/src/actions/script/ScriptAction.tsx
@@ -6,6 +6,7 @@ import { scriptSettingsReader } from "./ScriptSettingsReader";
 export class ScriptAction extends CustomZettelAction {
   private static ICON = "code-glyph";
   id = "script";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     hasUI: false,

--- a/src/actions/selector/SelectorAction.tsx
+++ b/src/actions/selector/SelectorAction.tsx
@@ -13,6 +13,7 @@ import { selectorSettingsReader } from "./SelectorSettingsReader";
 export class SelectorAction extends CustomZettelAction {
   private static ICON = "square-mouse-pointer";
   id = "selector";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     hasUI: true,

--- a/src/actions/tags/TagsAction.tsx
+++ b/src/actions/tags/TagsAction.tsx
@@ -9,6 +9,7 @@ import { tagsSettingsReader } from "./TagsSettingsReader";
 export class TagsAction extends CustomZettelAction {
   private static ICON = "price-tag-glyph";
   id = "tags";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     description: "Add tags to the note",

--- a/src/actions/taskManagement/TaskManagementAction.tsx
+++ b/src/actions/taskManagement/TaskManagementAction.tsx
@@ -11,6 +11,7 @@ import { rolloverUnfinishedTodos } from "./taskManagementLogic";
 export class TaskManagementAction extends CustomZettelAction {
   private static ICON = "list-checks";
   id = "task-management";
+  category = "manipulation" as const;
   defaultAction = {
     type: this.id,
     description: "Task management",

--- a/src/actions/zettelId/ZettelIdAction.tsx
+++ b/src/actions/zettelId/ZettelIdAction.tsx
@@ -16,6 +16,7 @@ import { Action } from "architecture/api";
 export class ZettelIdAction extends CustomZettelAction {
     private static ICON = "fingerprint";
     id = "zettel-id";
+    category = "manipulation" as const;
     defaultAction: Action = {
         type: this.id,
         hasUI: false,

--- a/src/architecture/api/CustomZettelAction.tsx
+++ b/src/architecture/api/CustomZettelAction.tsx
@@ -6,6 +6,7 @@ import {
   ExecuteInfo,
   ICustomZettelAction,
 } from "./typing";
+import { ActionCategory } from "./categories";
 import React, { JSX } from "react";
 import { TFile } from "obsidian";
 
@@ -19,6 +20,12 @@ export abstract class CustomZettelAction implements ICustomZettelAction {
   abstract settingsReader: ActionSettingReader;
   abstract link: string;
   abstract purpose: string;
+  /**
+   * Optional cognitive-capability category (#152). Self-declared by the action; when absent the
+   * action falls into the "uncategorized" picker group. Optional keeps third-party actions valid
+   * without any change (#33).
+   */
+  category?: ActionCategory;
   async execute(_: ExecuteInfo) {
     // Do nothing by default
   }

--- a/src/architecture/api/categories/categories.ts
+++ b/src/architecture/api/categories/categories.ts
@@ -1,0 +1,69 @@
+/**
+ * The closed vocabulary of **cognitive-capability** categories an Action can belong to (#152) —
+ * grouping the flat action registry by *what an action does to knowledge* rather than by technical
+ * operation. Mirrors the step-phase pattern (#149): a fixed, ordered token set + `isX` guard + i18n
+ * label **keys** (no `t()` here) + decorative emoji. Pure & Obsidian-free. A category is optional on
+ * an action; absence means "uncategorized" (keeps third-party actions valid — #33).
+ */
+
+export type ActionCategory = "manipulation" | "relations" | "knowledge" | "research" | "ai";
+
+/** The five capabilities, in canonical (display) order. */
+export const ACTION_CATEGORIES: readonly ActionCategory[] = [
+    "manipulation",
+    "relations",
+    "knowledge",
+    "research",
+    "ai",
+] as const;
+
+export function isActionCategory(value: unknown): value is ActionCategory {
+    return typeof value === "string" && (ACTION_CATEGORIES as readonly string[]).includes(value);
+}
+
+/** i18n key of each category's sentence-case label. The `t()` lookup lives in the UI layer. */
+export const CATEGORY_LABEL_KEY = {
+    manipulation: "action_category_manipulation_label",
+    relations: "action_category_relations_label",
+    knowledge: "action_category_knowledge_label",
+    research: "action_category_research_label",
+    ai: "action_category_ai_label",
+} as const satisfies Record<ActionCategory, string>;
+
+/** Decorative per-category emoji, rendered before the label in the picker (kept out of i18n). */
+export const CATEGORY_EMOJI = {
+    manipulation: "📝",
+    relations: "🔗",
+    knowledge: "🧠",
+    research: "🔍",
+    ai: "🤖",
+} as const satisfies Record<ActionCategory, string>;
+
+/** A group of items sharing a category; `category: null` is the trailing "uncategorized" group. */
+export interface CategoryGroup<T> {
+    category: ActionCategory | null;
+    items: T[];
+}
+
+/** Normalize an item's category: a valid token, or `null` when absent/invalid (uncategorized). */
+export function getActionCategory(value: unknown): ActionCategory | null {
+    return isActionCategory(value) ? value : null;
+}
+
+/**
+ * Group items by their `category` in canonical order, with the uncategorized group **last**. Empty
+ * categories are omitted, and the uncategorized group is omitted when empty — so the picker only ever
+ * shows populated groups (#152 decision 4).
+ */
+export function groupActionsByCategory<T extends { category?: ActionCategory }>(
+    items: T[]
+): CategoryGroup<T>[] {
+    const groups: CategoryGroup<T>[] = [];
+    for (const category of ACTION_CATEGORIES) {
+        const inCategory = items.filter((item) => getActionCategory(item.category) === category);
+        if (inCategory.length) groups.push({ category, items: inCategory });
+    }
+    const uncategorized = items.filter((item) => getActionCategory(item.category) === null);
+    if (uncategorized.length) groups.push({ category: null, items: uncategorized });
+    return groups;
+}

--- a/src/architecture/api/categories/index.ts
+++ b/src/architecture/api/categories/index.ts
@@ -1,0 +1,1 @@
+export * from "./categories";

--- a/src/architecture/api/index.ts
+++ b/src/architecture/api/index.ts
@@ -1,4 +1,5 @@
 export { CustomZettelAction } from './CustomZettelAction';
+export * from './categories';
 export { actionsStore } from './store/ActionsStore';
 export { ExecuteInfo, Action, ActionSetting, ActionSettingReader } from './typing';
 export { fnsManager, buildAsyncScriptFunction, errorMessage } from './lib/FnConstructor';

--- a/src/architecture/api/typing.ts
+++ b/src/architecture/api/typing.ts
@@ -1,4 +1,5 @@
 import { Literal } from "architecture/plugin";
+import { ActionCategory } from "./categories";
 import { WrappedActionBuilderProps } from "application/components/noteBuilder";
 import { ContentDTO, FinalElement, NoteDTO } from "application/notes"
 import { TFile } from "obsidian";
@@ -34,6 +35,8 @@ export type ActionSettingReader = (
 
 export interface ICustomZettelAction {
     id: string;
+    /** Optional cognitive-capability category (#152); absent ⇒ uncategorized. */
+    category?: ActionCategory;
     component(props: WrappedActionBuilderProps): JSX.Element;
     settings: ActionSetting;
     execute(info: ExecuteInfo): Promise<void>;

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -550,4 +550,11 @@ export default {
     workflow_canvas_when_tooltip: 'Runs automatically on a vault event',
     workflow_canvas_if_tooltip: 'Conditional branch',
     workflow_canvas_wait_tooltip: 'Pauses for your confirmation',
+    // Action categories (#152)
+    action_category_manipulation_label: 'Manipulation',
+    action_category_relations_label: 'Relations',
+    action_category_knowledge_label: 'Knowledge',
+    action_category_research_label: 'Research',
+    action_category_ai_label: 'AI',
+    action_category_uncategorized_label: 'Other',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -550,4 +550,11 @@ export default {
     workflow_canvas_when_tooltip: 'Se ejecuta automáticamente ante un evento de la bóveda',
     workflow_canvas_if_tooltip: 'Rama condicional',
     workflow_canvas_wait_tooltip: 'Pausa para tu confirmación',
+    // Action categories (#152)
+    action_category_manipulation_label: 'Manipulación',
+    action_category_relations_label: 'Relaciones',
+    action_category_knowledge_label: 'Conocimiento',
+    action_category_research_label: 'Investigación',
+    action_category_ai_label: 'IA',
+    action_category_uncategorized_label: 'Otros',
 };

--- a/src/styles/components/actionAddMenu.scss
+++ b/src/styles/components/actionAddMenu.scss
@@ -149,6 +149,10 @@
     padding-bottom: 4px;
 }
 
+.zettelkasten-flow__actions-category-emoji {
+    line-height: 1;
+}
+
 .zettelkasten-flow__actions-category-group>.zettelkasten-flow__actions-management-add-card {
     flex: 1 1 calc(33.333% - 10px);
     /* Tres columnas */

--- a/src/styles/components/actionAddMenu.scss
+++ b/src/styles/components/actionAddMenu.scss
@@ -127,11 +127,29 @@
 
 .zettelkasten-flow__actions-list {
     display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+/* Each cognitive-capability group: a header row + its cards wrapping in three columns (#152). */
+.zettelkasten-flow__actions-category-group {
+    display: flex;
     flex-wrap: wrap;
     gap: 10px;
 }
 
-.zettelkasten-flow__actions-list>.zettelkasten-flow__actions-management-add-card {
+.zettelkasten-flow__actions-category-header {
+    flex-basis: 100%;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--background-modifier-border);
+    padding-bottom: 4px;
+}
+
+.zettelkasten-flow__actions-category-group>.zettelkasten-flow__actions-management-add-card {
     flex: 1 1 calc(33.333% - 10px);
     /* Tres columnas */
     max-width: calc(33.333% - 10px);
@@ -148,7 +166,7 @@
     }
 
         
-    .zettelkasten-flow__actions-list>.zettelkasten-flow__actions-management-add-card {
+    .zettelkasten-flow__actions-category-group>.zettelkasten-flow__actions-management-add-card {
         flex: 1 1 100%;
         max-width: 100%;
     }

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
@@ -117,7 +117,7 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
           >
             <div className={c("actions-category-header")}>
               {group.category && (
-                <span className={c("actions-category-emoji")}>
+                <span className={c("actions-category-emoji")} aria-hidden="true">
                   {CATEGORY_EMOJI[group.category]}
                 </span>
               )}

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from "react";
 import { ActionAddMenuProps, ActionCardInfo } from "./typing";
 import { c } from "architecture";
-import { actionsStore } from "architecture/api";
+import { t } from "architecture/lang";
+import { actionsStore, groupActionsByCategory, CATEGORY_EMOJI, CATEGORY_LABEL_KEY } from "architecture/api";
 import { Icon } from "architecture/components/icon";
 
 /**
@@ -67,17 +68,21 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
         link: rawAction.link,
         purpose: rawAction.purpose,
         id: rawAction.id,
+        category: rawAction.category,
       });
     });
     Object.values(actions).forEach((action) => {
       // Skip template actions whose type no longer exists in the registry
       if (!actionsStore.getActionsKeys().includes(action.type)) return;
+      const baseAction = actionsStore.getAction(action.type);
       array.push({
-        icon: actionsStore.getAction(action.type).getIcon(),
+        icon: baseAction.getIcon(),
         label: action.title,
         purpose: action.description,
         id: action.id,
         isTemplate: true,
+        // A template inherits its base action type's category (#152, FR-8).
+        category: baseAction.category,
       });
     });
     return array;
@@ -105,15 +110,34 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
         }}
       />
       <div className={c("actions-list")}>
-        {filteredCards.map((card) => (
-          <ActionCard
-            key={card.id}
-            card={card}
-            trigger={() => {
-              setFilteredCards(actionsMemo);
-              onChange(card.id, card.isTemplate || false);
-            }}
-          />
+        {groupActionsByCategory(filteredCards).map((group) => (
+          <div
+            key={group.category ?? "uncategorized"}
+            className={c("actions-category-group")}
+          >
+            <div className={c("actions-category-header")}>
+              {group.category && (
+                <span className={c("actions-category-emoji")}>
+                  {CATEGORY_EMOJI[group.category]}
+                </span>
+              )}
+              <label>
+                {group.category
+                  ? t(CATEGORY_LABEL_KEY[group.category])
+                  : t("action_category_uncategorized_label")}
+              </label>
+            </div>
+            {group.items.map((card) => (
+              <ActionCard
+                key={card.id}
+                card={card}
+                trigger={() => {
+                  setFilteredCards(actionsMemo);
+                  onChange(card.id, card.isTemplate || false);
+                }}
+              />
+            ))}
+          </div>
         ))}
       </div>
     </>

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/typing.ts
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/typing.ts
@@ -1,4 +1,5 @@
 import { Action } from "architecture/api";
+import type { ActionCategory } from "architecture/api/categories/categories";
 import { AbstractStepModal } from "zettelkasten/modals/AbstractStepModal";
 
 export type ActionsManagementProps = {
@@ -23,5 +24,7 @@ export type ActionCardInfo = {
     label: string,
     link?: string,
     purpose: string,
-    isTemplate?: boolean
+    isTemplate?: boolean,
+    /** Cognitive-capability category for picker grouping (#152); absent ⇒ uncategorized. */
+    category?: ActionCategory
 };

--- a/test/architecture/api/categories/actionCategoryAssignment.test.ts
+++ b/test/architecture/api/categories/actionCategoryAssignment.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { ACTION_CATEGORIES, isActionCategory } from "architecture/api/categories/categories";
+
+// test/architecture/api/categories → 4 ups → repo root
+const ROOT = join(__dirname, "..", "..", "..", "..");
+const actionSrc = (rel: string) => readFileSync(join(ROOT, "src", "actions", `${rel}.tsx`), "utf8");
+
+/** The locked #152 mapping: Backlink = relations, the other 11 = manipulation, none = ai. */
+const EXPECTED: Record<string, string> = {
+    "backlink/BackLinkAction": "relations",
+    "calendar/CalendarAction": "manipulation",
+    "checkbox/CheckboxAction": "manipulation",
+    "cssClasses/CssClassesAction": "manipulation",
+    "dynamicSelector/DynamicSelectorAction": "manipulation",
+    "number/NumberAction": "manipulation",
+    "prompt/PromptAction": "manipulation",
+    "script/ScriptAction": "manipulation",
+    "selector/SelectorAction": "manipulation",
+    "tags/TagsAction": "manipulation",
+    "taskManagement/TaskManagementAction": "manipulation",
+    "zettelId/ZettelIdAction": "manipulation",
+};
+
+function declaredCategory(source: string): string | undefined {
+    return source.match(/category\s*=\s*"([a-z-]+)"/)?.[1];
+}
+
+describe("built-in action category assignment (#152, AC-1/AC-5/AC-7)", () => {
+    it("assigns exactly the locked mapping, every token valid (AC-1, FR-6)", () => {
+        for (const [rel, expected] of Object.entries(EXPECTED)) {
+            const category = declaredCategory(actionSrc(rel));
+            expect(category).toBe(expected);
+            expect(isActionCategory(category)).toBe(true);
+        }
+    });
+
+    it("ships no AI action — no built-in declares the ai category (AC-7)", () => {
+        for (const rel of Object.keys(EXPECTED)) {
+            expect(declaredCategory(actionSrc(rel))).not.toBe("ai");
+        }
+    });
+
+    it("only uses tokens from the closed vocabulary", () => {
+        for (const rel of Object.keys(EXPECTED)) {
+            expect(ACTION_CATEGORIES as readonly string[]).toContain(declaredCategory(actionSrc(rel)));
+        }
+    });
+
+    it("main.ts registerActions() still registers exactly the twelve known built-ins (AC-5)", () => {
+        const main = readFileSync(join(ROOT, "src", "main.ts"), "utf8");
+        const registered = [...main.matchAll(/registerAction\(new (\w+)\(\)\)/g)].map((m) => m[1]).sort();
+        const expected = Object.keys(EXPECTED)
+            .map((rel) => rel.split("/")[1])
+            .sort();
+        expect(registered).toEqual(expected);
+    });
+});

--- a/test/architecture/api/categories/actionRegistryBackCompat.test.ts
+++ b/test/architecture/api/categories/actionRegistryBackCompat.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { actionsStore, CustomZettelAction } from "architecture/api";
+import type { Action, ActionSetting, ActionSettingReader, ExecuteInfo } from "architecture/api";
+import {
+    groupActionsByCategory,
+    type ActionCategory,
+} from "architecture/api/categories/categories";
+
+/** A minimal action stub — a third-party action may or may not declare a category (#33). */
+class StubAction extends CustomZettelAction {
+    id: string;
+    override category?: ActionCategory;
+    defaultAction: Action = { type: "stub", id: "stub" };
+    settings: ActionSetting = () => undefined;
+    settingsReader: ActionSettingReader = () => undefined;
+    link = "";
+    purpose = "stub";
+    getIcon(): string {
+        return "box";
+    }
+    getLabel(): string {
+        return this.id;
+    }
+    constructor(id: string, category?: ActionCategory) {
+        super();
+        this.id = id;
+        this.category = category;
+    }
+}
+
+describe("action registry back-compat with an optional category (#152, #33, AC-2)", () => {
+    beforeEach(() => actionsStore.unregisterAll());
+
+    it("registers and resolves both a categorized and a category-less action", async () => {
+        actionsStore.registerAction(new StubAction("with-cat", "relations"));
+        actionsStore.registerAction(new StubAction("no-cat")); // third-party, no category
+
+        expect(actionsStore.getActionsKeys().sort()).toEqual(["no-cat", "with-cat"]);
+        // Both resolve and run without throwing (behavior unchanged by the optional field).
+        await expect(
+            actionsStore.getAction("no-cat").execute({} as unknown as ExecuteInfo)
+        ).resolves.toBeUndefined();
+        await expect(
+            actionsStore.getAction("with-cat").execute({} as unknown as ExecuteInfo)
+        ).resolves.toBeUndefined();
+    });
+
+    it("buckets a category-less action into the uncategorized group", () => {
+        actionsStore.registerAction(new StubAction("with-cat", "manipulation"));
+        actionsStore.registerAction(new StubAction("no-cat"));
+
+        const actions = actionsStore.getActionsKeys().map((key) => actionsStore.getAction(key));
+        const groups = groupActionsByCategory(actions);
+
+        const uncategorized = groups.find((group) => group.category === null);
+        expect(uncategorized?.items.map((a) => a.id)).toEqual(["no-cat"]);
+        const manipulation = groups.find((group) => group.category === "manipulation");
+        expect(manipulation?.items.map((a) => a.id)).toEqual(["with-cat"]);
+    });
+});

--- a/test/architecture/api/categories/categories.test.ts
+++ b/test/architecture/api/categories/categories.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    ACTION_CATEGORIES,
+    isActionCategory,
+    CATEGORY_LABEL_KEY,
+    CATEGORY_EMOJI,
+} from "architecture/api/categories/categories";
+
+describe("action category vocabulary (#152, FR-1/FR-2/AC-4)", () => {
+    it("ACTION_CATEGORIES is exactly the five capabilities in canonical order", () => {
+        expect([...ACTION_CATEGORIES]).toEqual([
+            "manipulation",
+            "relations",
+            "knowledge",
+            "research",
+            "ai",
+        ]);
+    });
+
+    it("isActionCategory accepts the five and rejects junk", () => {
+        for (const category of ACTION_CATEGORIES) expect(isActionCategory(category)).toBe(true);
+        for (const junk of ["", "misc", "Manipulation", 1, null, undefined, {}]) {
+            expect(isActionCategory(junk)).toBe(false);
+        }
+    });
+
+    it("defines a non-empty label key and an emoji for every category", () => {
+        for (const category of ACTION_CATEGORIES) {
+            expect(typeof CATEGORY_LABEL_KEY[category]).toBe("string");
+            expect(CATEGORY_LABEL_KEY[category].length).toBeGreaterThan(0);
+            expect(typeof CATEGORY_EMOJI[category]).toBe("string");
+            expect(CATEGORY_EMOJI[category].length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/test/architecture/api/categories/groupByCategory.test.ts
+++ b/test/architecture/api/categories/groupByCategory.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    groupActionsByCategory,
+    getActionCategory,
+    type ActionCategory,
+} from "architecture/api/categories/categories";
+
+type Item = { id: string; category?: ActionCategory };
+
+describe("groupActionsByCategory (#152, AC-2/AC-3)", () => {
+    it("groups by category in canonical order, uncategorized last", () => {
+        const items: Item[] = [
+            { id: "a", category: "relations" },
+            { id: "b", category: "manipulation" },
+            { id: "c" }, // uncategorized
+            { id: "d", category: "manipulation" },
+        ];
+        const groups = groupActionsByCategory(items);
+        expect(groups.map((g) => g.category)).toEqual(["manipulation", "relations", null]);
+        expect(groups[0].items.map((i) => i.id)).toEqual(["b", "d"]);
+        expect(groups[2].items.map((i) => i.id)).toEqual(["c"]);
+    });
+
+    it("omits empty categories (knowledge/research/ai when unused)", () => {
+        const groups = groupActionsByCategory([{ id: "a", category: "manipulation" }]);
+        expect(groups.map((g) => g.category)).toEqual(["manipulation"]);
+    });
+
+    it("omits the uncategorized group when every item has a category", () => {
+        const groups = groupActionsByCategory([{ id: "a", category: "manipulation" }]);
+        expect(groups.some((g) => g.category === null)).toBe(false);
+    });
+
+    it("buckets an item with an absent or invalid category as uncategorized", () => {
+        const items = [
+            { id: "a" },
+            { id: "b", category: "bogus" as unknown as ActionCategory },
+        ];
+        const groups = groupActionsByCategory(items);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].category).toBeNull();
+        expect(groups[0].items.map((i) => i.id)).toEqual(["a", "b"]);
+    });
+
+    it("getActionCategory returns null for an absent or invalid token", () => {
+        expect(getActionCategory("manipulation")).toBe("manipulation");
+        expect(getActionCategory(undefined)).toBeNull();
+        expect(getActionCategory("misc")).toBeNull();
+    });
+});

--- a/test/config/actionCategoryLocale.test.ts
+++ b/test/config/actionCategoryLocale.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+import { ACTION_CATEGORIES, CATEGORY_LABEL_KEY } from "architecture/api/categories/categories";
+
+describe("action category i18n parity (#152, AC-6)", () => {
+    const keys = [
+        ...ACTION_CATEGORIES.map((category) => CATEGORY_LABEL_KEY[category]),
+        "action_category_uncategorized_label",
+    ];
+
+    it("defines all six category keys in both en and es, non-empty", () => {
+        expect(keys.length).toBe(6);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of keys) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Actions as cognitive capabilities — categorize the registry (#152)

Layer 2 (Workflow Engine) of the Knowledge OS epic (#144). Turns the flat action list into a picker grouped by **what an action does to knowledge** — 📝 Manipulation · 🔗 Relations · 🧠 Knowledge · 🔍 Research · 🤖 AI. Behavior-neutral and fully back-compatible.

### What's in it
- **Pure, Obsidian-free vocabulary** `src/architecture/api/categories/` (mirrors the #149 phases pattern): the closed 5-token `ActionCategory`, canonical order, `isActionCategory` guard, i18n label keys, decorative emoji, and `groupActionsByCategory()` (empty groups omitted, uncategorized last).
- **Optional self-declared `category`** on `CustomZettelAction` / `ICustomZettelAction` — the #33 back-compat lever: a third-party action that omits it still registers, runs, and shows under an "Other" group. `ActionsStore.registerAction` and `main.ts registerActions()` are untouched.
- **The 12 built-ins re-homed** behavior-neutrally: Backlink → Relations; the other 11 → Manipulation. Knowledge/Research/AI ship empty (fill in with #153/#155/#156). **No AI action ships here.**
- **The action picker groups by capability** (`ActionAddMenu.tsx`) with an emoji + i18n header per group, canonical order, uncategorized last, empty groups hidden; the existing search runs before grouping.

### Verification
`npm run verify` green — **jest 535** (+15), `lint:obsidian` 0, typecheck + oxlint clean. 7 TDD tasks. Guardrails use the source-scan idiom for the tsx action classes (which can't load under jest) and register stub subclasses to prove the #33 contract. Reviewed by `obsidian-plugin-reviewer`.

Docs: `actions-and-note-builder.md` gains an "Action categories" section (taxonomy, built-in mapping, third-party `category` declaration). README Features row added.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
