### PR TITLE
feat(actions): research actions (#155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   related** and **suggest link** rank notes worth linking by shared graph context (co-citation +
   coupling), and **create semantic relation** writes a typed edge (supports, contradicts, …) to a
   target note. Graph-structural, deterministic, offline.
+- **🔍 Research actions** — actions that make sourcing and claim-checking part of the workflow:
+  **extract claims**, **compare claims** (surface notes that agree with or contradict yours),
+  **find sources** (suggest existing vault sources for an under-sourced note), and **attach
+  source**. Over the claims-and-sources model, deterministic and offline.
 
 > New here? Run **Install Zettelkasten starter flows** from the command palette, or open
 > **Settings → ZettelFlow** to launch these tools.
@@ -101,7 +105,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | Feature | Description |
 |---|---|
 | **Canvas-based flows** | Use Obsidian's native canvas as the workflow engine — no custom DSL to learn. |
-| **19 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question — and 🔗 relation actions — find related, suggest link, create semantic relation. |
+| **23 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question — 🔗 relation actions — find related, suggest link, create semantic relation — and 🔍 research actions — extract claims, compare claims, find sources, attach source. |
 | **Conditional edges** | Label a canvas arrow `if: frontmatter.type === "meeting"` to branch the workflow at runtime. |
 | **Dynamic templates** | Use `{{title}}`, `{{date}}`, `{{frontmatter.key}}`, `{{canvas.name}}` in step body templates. |
 | **Live body preview** | See the rendered note body while editing a step's template (desktop). |

--- a/docs/actions/AttachSource.md
+++ b/docs/actions/AttachSource.md
@@ -1,0 +1,25 @@
+# Attach source action
+
+🔍 A **Research** action (#155). Attaches a **source** — a `[[wikilink]]` to a note or free text
+(URL / DOI / citation) — to the **note being built**, written under the `source` frontmatter key so
+the [knowledge model](../architecture/knowledge-model.md) (#148) indexes it and the note's
+`hasSources` signal flips on re-index. Deterministic and offline.
+
+## Options
+
+- **Source** — the wikilink or free text to attach. An empty value is a **safe no-op** (nothing is
+  written).
+- **Write to** — `Frontmatter` (recommended — indexed promptly) or `Context`.
+
+## Result
+
+A `source: <value>` field on the note being built (also exposed as `{{source}}`), plus a `Notice`.
+After re-index the model derives a claim carrying the source and reports the note as sourced.
+
+Writing to an **existing foreign note** is out of scope for this action (it only writes the note
+being built).
+
+## Capabilities
+
+File-system write of a single `source` frontmatter field on the note being built (the same surface
+as every action). **No network, no AI.**

--- a/docs/actions/CompareClaims.md
+++ b/docs/actions/CompareClaims.md
@@ -1,0 +1,37 @@
+# Compare claims action
+
+🔍 A **Research** action (#155). Given a note, surfaces which other notes' claims **agree with** or
+**contradict** its claims, over the [knowledge model](../architecture/knowledge-model.md) (#145).
+Deterministic and offline — **no text-similarity AI**.
+
+## How comparison works
+
+- **Agreement** — another note asserts the **identical** claim once normalized (trim, lower-case,
+  collapse whitespace, strip surrounding quotes and trailing punctuation).
+- **Contradiction** — either:
+  1. **Structural** — the two notes are joined by a `contradicts` [semantic relation](../architecture/knowledge-model.md)
+     (#147, either direction); the paired claims are flagged regardless of text.
+  2. **Textual negation** — the *same* proposition asserted with opposite polarity, over a fixed,
+     closed bilingual marker set (`not · no · never · n't · nunca · jamás · tampoco`).
+
+!!! note "Limitation"
+    The textual rule catches clean polarity flips where the rest of the sentence is otherwise
+    identical (e.g. *"coffee is healthy"* vs *"coffee is not healthy"*). Richer grammatical negation
+    relies on the structural `contradicts` relation — declare it with the
+    [create semantic relation](CreateSemanticRelation.md) action for reliable results.
+
+## Options
+
+- **Result property** — where the comparison is written (default `claimComparison`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+- **Source note (optional)** — the note to compare; empty ⇒ the note being built.
+
+## Result
+
+A `{ agreeing: [...], contradicting: [...] }` object — each a deduped, path-sorted list of
+`[[wikilinks]]` to the matching notes — plus a `Notice` with the two counts. Empty sets are a valid
+result. If the index isn't ready, the action safely no-ops.
+
+## Capabilities
+
+File-system read + the disclosed result-property write. **No network, no AI.**

--- a/docs/actions/ExtractClaims.md
+++ b/docs/actions/ExtractClaims.md
@@ -1,0 +1,23 @@
+# Extract claims action
+
+🔍 A **Research** action (#155). Surfaces the **claims** (and their sources) a note declares, read
+from the [knowledge model](../architecture/knowledge-model.md)'s `ClaimSourceSchema` parse (#148).
+Read-only, deterministic, offline.
+
+## Options
+
+- **Result property** — where the extracted claims are written (default `claims`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+- **Source note (optional)** — the note to read; empty ⇒ the note being built.
+
+## Result
+
+A `{ claim: [...], source: [...] }` object — the claim texts and the note-level sources (a link
+source as an extensionless `[[wikilink]]`, free text verbatim), plus a `Notice` with the claim
+count. The shape round-trips: feeding it back through `ClaimSourceSchema` reproduces the same
+claims. A claim-less note yields an empty result. If the index isn't ready, the action safely
+no-ops.
+
+## Capabilities
+
+File-system read + the disclosed result-property write. **No network, no AI.**

--- a/docs/actions/FindSources.md
+++ b/docs/actions/FindSources.md
@@ -1,0 +1,24 @@
+# Find sources action
+
+🔍 A **Research** action (#155). For an **under-sourced** note, suggests candidate **sources already
+present in the vault** — drawn from the note's graph neighbours' sources and the vault's
+most-referenced sources ([`sourcesByReferenceCount`](../architecture/knowledge-model.md), #145).
+**Vault-local and offline — not a web search** (external/AI source discovery is the 🤖 AI category).
+
+## Options
+
+- **Result property** — where the candidate sources are written (default `candidateSources`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+- **Source note (optional)** — the note to suggest sources for; empty ⇒ the note being built.
+- **Max results** — how many candidates to keep (default 5).
+
+## Result
+
+A ranked list of candidate sources (link sources as extensionless `[[wikilinks]]`, free text
+verbatim), ordered by how widely each is already cited in the vault, plus a `Notice` with the
+count. **The note must be unsourced** — an already-sourced / unknown target, or an empty model,
+yields an empty result. If the index isn't ready, the action safely no-ops.
+
+## Capabilities
+
+File-system read + the disclosed result-property write. **No network, no AI.**

--- a/docs/actions/FindSources.md
+++ b/docs/actions/FindSources.md
@@ -15,9 +15,10 @@ most-referenced sources ([`sourcesByReferenceCount`](../architecture/knowledge-m
 ## Result
 
 A ranked list of candidate sources (link sources as extensionless `[[wikilinks]]`, free text
-verbatim), ordered by how widely each is already cited in the vault, plus a `Notice` with the
-count. **The note must be unsourced** — an already-sourced / unknown target, or an empty model,
-yields an empty result. If the index isn't ready, the action safely no-ops.
+verbatim): sources cited by the note's **graph neighbours** come first (topically relevant), then by
+how widely each is already cited in the vault — plus a `Notice` with the count. **The note must be
+unsourced** — an already-sourced / unknown target, or an empty model, yields an empty result. If the
+index isn't ready, the action safely no-ops.
 
 ## Capabilities
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,10 @@ nav:
       - 2.17 Find related: actions/FindRelated.md
       - 2.18 Suggest link: actions/SuggestLink.md
       - 2.19 Create semantic relation: actions/CreateSemanticRelation.md
+      - 2.20 Extract claims: actions/ExtractClaims.md
+      - 2.21 Compare claims: actions/CompareClaims.md
+      - 2.22 Find sources: actions/FindSources.md
+      - 2.23 Attach source: actions/AttachSource.md
   - 3. Vault Hooks:
       - 3.1 Property Hooks:
           - 3.1.1 Overview: vault-hooks/property-hooks/overview.md

--- a/src/actions/attachSource/AttachSourceAction.tsx
+++ b/src/actions/attachSource/AttachSourceAction.tsx
@@ -1,0 +1,43 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { log } from "architecture";
+import { t } from "architecture/lang";
+import { Notice } from "obsidian";
+import { ResearchActionElement } from "zettelkasten";
+import { sourceField } from "./attachSourceLogic";
+import { makeAttachSourceSettings, writeKnowledgeResult } from "../research/researchActionShared";
+
+const { settings, settingsReader } = makeAttachSourceSettings(
+    "research_attach_source_label",
+    "research_attach_source_desc"
+);
+
+/** 🔍 Attaches a source (wikilink or free text) to the note being built, so the model sources it. #155. */
+export class AttachSourceAction extends CustomZettelAction {
+    private static ICON = "paperclip";
+    id = "attach-source";
+    category = "research" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, source: "", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/AttachSource";
+    purpose = "Attach a source to the note being built.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as ResearchActionElement;
+        const field = sourceField(el.source ?? "");
+        if (!field) {
+            log.debug("[attach-source] no source value — skipping");
+            return;
+        }
+        writeKnowledgeResult(info, { ...el, key: field.key }, field.value);
+        new Notice(t("research_attach_source_notice", field.value));
+    }
+
+    getIcon(): string {
+        return AttachSourceAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("research_attach_source_label");
+    }
+}

--- a/src/actions/attachSource/attachSourceLogic.ts
+++ b/src/actions/attachSource/attachSourceLogic.ts
@@ -1,0 +1,19 @@
+import { SOURCE_KEYS } from "architecture/knowledge/claims/keys";
+
+/** A source as a frontmatter field: the `source` key and the raw value the user supplied. */
+export interface SourceField {
+    key: string;
+    value: string;
+}
+
+/**
+ * Pure builder for `attach-source` (#155, FR-4/D3). Given a raw source value — a `[[wikilink]]` to a
+ * note or free text (URL / DOI / citation) — returns the frontmatter field `{ key: "source", value }`
+ * (value kept verbatim), which `ClaimSourceSchema` then classifies as a note-level source (AC-1).
+ * An empty/blank value is a safe no-op (`null`, nothing written). Obsidian-free and deterministic.
+ */
+export function sourceField(raw: string): SourceField | null {
+    const value = (raw ?? "").trim();
+    if (!value) return null;
+    return { key: SOURCE_KEYS[0], value };
+}

--- a/src/actions/compareClaims/CompareClaimsAction.tsx
+++ b/src/actions/compareClaims/CompareClaimsAction.tsx
@@ -1,0 +1,70 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { log } from "architecture";
+import { t } from "architecture/lang";
+import { Notice } from "obsidian";
+import { ResearchActionElement } from "zettelkasten";
+import { compareClaims, ClaimMatch } from "./compareClaimsLogic";
+import {
+    makeResearchSettings,
+    readyModel,
+    resolveTargetPath,
+    writeKnowledgeResult,
+} from "../research/researchActionShared";
+
+const { settings, settingsReader } = makeResearchSettings(
+    "research_compare_claims_label",
+    "research_compare_claims_desc"
+);
+
+/** 🔍 Surfaces notes whose claims agree with or contradict this note's claims. #155, deterministic/offline. */
+export class CompareClaimsAction extends CustomZettelAction {
+    private static ICON = "scale";
+    id = "compare-claims";
+    category = "research" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "claimComparison", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/CompareClaims";
+    purpose = "Find notes whose claims agree with or contradict this note's claims.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as ResearchActionElement;
+        const model = readyModel();
+        if (!model) {
+            log.debug("[compare-claims] knowledge index not ready — skipping");
+            return;
+        }
+        const path = resolveTargetPath(info, el);
+        if (!path) {
+            log.debug("[compare-claims] no target note — skipping");
+            return;
+        }
+        const { agreeing, contradicting } = compareClaims(model, path);
+        const agreeingLinks = toNoteLinks(agreeing);
+        const contradictingLinks = toNoteLinks(contradicting);
+        writeKnowledgeResult(info, el, { agreeing: agreeingLinks, contradicting: contradictingLinks });
+        new Notice(
+            t("research_compare_claims_notice", String(agreeingLinks.length), String(contradictingLinks.length))
+        );
+    }
+
+    getIcon(): string {
+        return CompareClaimsAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("research_compare_claims_label");
+    }
+}
+
+/** Dedupe claim matches to one extensionless `[[wikilink]]` per note, preserving path order. */
+function toNoteLinks(matches: ClaimMatch[]): string[] {
+    const seen = new Set<string>();
+    const links: string[] = [];
+    for (const match of matches) {
+        if (seen.has(match.path)) continue;
+        seen.add(match.path);
+        links.push(`[[${match.path.replace(/\.md$/i, "")}]]`);
+    }
+    return links;
+}

--- a/src/actions/compareClaims/compareClaimsLogic.ts
+++ b/src/actions/compareClaims/compareClaimsLogic.ts
@@ -1,0 +1,95 @@
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import { findContradictions } from "../findContradiction/findContradictionLogic";
+
+/** One matched claim, paired with the path of the note that owns it. */
+export interface ClaimMatch {
+    path: string;
+    text: string;
+}
+
+/** The two deterministic sets `compareClaims` produces. */
+export interface ClaimComparison {
+    agreeing: ClaimMatch[];
+    contradicting: ClaimMatch[];
+}
+
+/** Closed, bilingual negation markers (whole-word), plus the `n't` contraction (D4). */
+const NEGATION_MARKERS: ReadonlySet<string> = new Set([
+    "not", "no", "never", "nunca", "jamas", "jamás", "tampoco",
+]);
+
+/** trim → lowercase → collapse whitespace → strip surrounding quotes and trailing sentence punctuation. */
+export function normalize(text: string): string {
+    let t = text.trim().toLowerCase().replace(/\s+/g, " ");
+    t = t.replace(/^["'“”‘’]+/, "").replace(/["'“”‘’]+$/, "");
+    t = t.replace(/[.!?;；]+$/, "");
+    return t.trim();
+}
+
+/** True when a normalized claim carries any negation marker (or the `n't` contraction). */
+export function hasNegation(normalized: string): boolean {
+    if (normalized.includes("n't")) return true;
+    return normalized.split(" ").some((token) => NEGATION_MARKERS.has(token));
+}
+
+/** Remove negation markers from a normalized claim so opposite-polarity claims share a base. */
+export function stripNegation(normalized: string): string {
+    return normalized
+        .replace(/n't/g, " ")
+        .split(" ")
+        .filter((token) => token.length > 0 && !NEGATION_MARKERS.has(token))
+        .join(" ");
+}
+
+/**
+ * Pure claim comparison (#155, FR-3/D4). Compares a target note's claims against every other note's
+ * claims in the model and returns the **agreeing** and **contradicting** claim matches. Agreement =
+ * identical normalized text. Contradiction = either the two owning notes are joined by a
+ * `contradicts` relation (structural, reusing the #153 primitive) OR the same proposition asserted
+ * with opposite polarity (textual negation). Structural/textual contradiction takes precedence over
+ * agreement. Deterministic (sorted by path then text), excludes self, never throws; unknown/claimless
+ * target ⇒ empty sets. Obsidian-free.
+ */
+export function compareClaims(model: KnowledgeModel, path: string): ClaimComparison {
+    const agreeing: ClaimMatch[] = [];
+    const contradicting: ClaimMatch[] = [];
+
+    const target = model.get(path);
+    if (!target || target.claims.length === 0) return { agreeing, contradicting };
+
+    const targetClaims = target.claims.map((claim) => {
+        const norm = normalize(claim.text);
+        return { norm, stripped: stripNegation(norm), negated: hasNegation(norm) };
+    });
+    const structurallyOpposed = new Set(findContradictions(model, path));
+
+    for (const idea of model.all()) {
+        if (idea.path === path) continue;
+        const structural = structurallyOpposed.has(idea.path);
+        for (const claim of idea.claims) {
+            const norm = normalize(claim.text);
+            const stripped = stripNegation(norm);
+            const negated = hasNegation(norm);
+
+            let agrees = false;
+            let contradicts = structural;
+            for (const q of targetClaims) {
+                if (norm === q.norm) agrees = true;
+                if (stripped === q.stripped && negated !== q.negated) contradicts = true;
+            }
+
+            if (contradicts) contradicting.push({ path: idea.path, text: claim.text });
+            else if (agrees) agreeing.push({ path: idea.path, text: claim.text });
+        }
+    }
+
+    agreeing.sort(byPathThenText);
+    contradicting.sort(byPathThenText);
+    return { agreeing, contradicting };
+}
+
+function byPathThenText(a: ClaimMatch, b: ClaimMatch): number {
+    if (a.path !== b.path) return a.path < b.path ? -1 : 1;
+    if (a.text !== b.text) return a.text < b.text ? -1 : 1;
+    return 0;
+}

--- a/src/actions/compareClaims/compareClaimsLogic.ts
+++ b/src/actions/compareClaims/compareClaimsLogic.ts
@@ -20,10 +20,10 @@ const NEGATION_MARKERS: ReadonlySet<string> = new Set([
 
 /** trim → lowercase → collapse whitespace → strip surrounding quotes and trailing sentence punctuation. */
 export function normalize(text: string): string {
-    let t = text.trim().toLowerCase().replace(/\s+/g, " ");
-    t = t.replace(/^["'“”‘’]+/, "").replace(/["'“”‘’]+$/, "");
-    t = t.replace(/[.!?;；]+$/, "");
-    return t.trim();
+    let out = text.trim().toLowerCase().replace(/\s+/g, " ");
+    out = out.replace(/^["'“”‘’]+/, "").replace(/["'“”‘’]+$/, "");
+    out = out.replace(/[.!?;；]+$/, "");
+    return out.trim();
 }
 
 /** True when a normalized claim carries any negation marker (or the `n't` contraction). */

--- a/src/actions/extractClaims/ExtractClaimsAction.tsx
+++ b/src/actions/extractClaims/ExtractClaimsAction.tsx
@@ -1,0 +1,59 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { log } from "architecture";
+import { t } from "architecture/lang";
+import { Notice } from "obsidian";
+import { ResearchActionElement } from "zettelkasten";
+import { serializeClaims } from "./extractClaimsLogic";
+import {
+    makeResearchSettings,
+    readyModel,
+    resolveTargetPath,
+    writeKnowledgeResult,
+} from "../research/researchActionShared";
+
+const { settings, settingsReader } = makeResearchSettings(
+    "research_extract_claims_label",
+    "research_extract_claims_desc"
+);
+
+/** 🔍 Surfaces the claims (and their sources) a note declares, via ClaimSourceSchema. #155. */
+export class ExtractClaimsAction extends CustomZettelAction {
+    private static ICON = "quote";
+    id = "extract-claims";
+    category = "research" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "claims", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/ExtractClaims";
+    purpose = "Surface the claims and sources a note declares.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as ResearchActionElement;
+        const model = readyModel();
+        if (!model) {
+            log.debug("[extract-claims] knowledge index not ready — skipping");
+            return;
+        }
+        const path = resolveTargetPath(info, el);
+        if (!path) {
+            log.debug("[extract-claims] no target note — skipping");
+            return;
+        }
+        const idea = model.get(path);
+        if (!idea) {
+            log.debug(`[extract-claims] "${path}" not indexed — skipping`);
+            return;
+        }
+        const serialized = serializeClaims(idea.claims);
+        writeKnowledgeResult(info, el, serialized);
+        new Notice(t("research_extract_claims_notice", String(serialized.claim.length)));
+    }
+
+    getIcon(): string {
+        return ExtractClaimsAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("research_extract_claims_label");
+    }
+}

--- a/src/actions/extractClaims/extractClaimsLogic.ts
+++ b/src/actions/extractClaims/extractClaimsLogic.ts
@@ -1,0 +1,38 @@
+import type { Claim, Source } from "architecture/knowledge/model/Idea";
+
+/** The `{ claim, source }` frontmatter shape `ClaimSourceSchema` round-trips (#148). */
+export interface SerializedClaims {
+    claim: string[];
+    source: string[];
+}
+
+function basename(path: string): string {
+    const file = path.split("/").pop() ?? path;
+    return file.replace(/\.md$/i, "");
+}
+
+function sourceToken(source: Source): string {
+    return source.kind === "link" ? `[[${basename(source.ref)}]]` : source.ref;
+}
+
+/**
+ * Pure serializer for `extract-claims` (#155, FR-2/D7). Turns a note's model {@link Claim}s into the
+ * `{ claim: string[], source: string[] }` frontmatter shape — claim texts, note-level sources with
+ * link kind as an extensionless `[[basename]]` and text kind verbatim, deduped. Feeding the result
+ * back through `ClaimSourceSchema.parse` reproduces the original claims (AC-1). Obsidian-free.
+ */
+export function serializeClaims(claims: Claim[]): SerializedClaims {
+    const claim: string[] = [];
+    const source: string[] = [];
+    const seen = new Set<string>();
+    for (const entry of claims) {
+        if (entry.text) claim.push(entry.text);
+        for (const src of entry.sources) {
+            const key = src.kind === "link" ? `link:${src.ref}` : `text:${src.ref.toLowerCase()}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            source.push(sourceToken(src));
+        }
+    }
+    return { claim, source };
+}

--- a/src/actions/findSources/FindSourcesAction.tsx
+++ b/src/actions/findSources/FindSourcesAction.tsx
@@ -1,0 +1,65 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { log } from "architecture";
+import { t } from "architecture/lang";
+import { Notice } from "obsidian";
+import { ResearchActionElement } from "zettelkasten";
+import type { Source } from "architecture/knowledge/model/Idea";
+import { findSources } from "./findSourcesLogic";
+import {
+    makeResearchSettings,
+    readyModel,
+    resolveTargetPath,
+    writeKnowledgeResult,
+} from "../research/researchActionShared";
+
+const DEFAULT_LIMIT = 5;
+
+const { settings, settingsReader } = makeResearchSettings(
+    "research_find_sources_label",
+    "research_find_sources_desc",
+    { withLimit: true }
+);
+
+/** 🔍 Suggests existing vault sources for an under-sourced note (offline, read-only). #155. */
+export class FindSourcesAction extends CustomZettelAction {
+    private static ICON = "book-marked";
+    id = "find-sources";
+    category = "research" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "candidateSources", zone: "frontmatter", limit: DEFAULT_LIMIT };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/FindSources";
+    purpose = "Suggest existing vault sources for an under-sourced note.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as ResearchActionElement;
+        const model = readyModel();
+        if (!model) {
+            log.debug("[find-sources] knowledge index not ready — skipping");
+            return;
+        }
+        const path = resolveTargetPath(info, el);
+        if (!path) {
+            log.debug("[find-sources] no target note — skipping");
+            return;
+        }
+        const candidates = findSources(model, path, { limit: el.limit ?? DEFAULT_LIMIT });
+        writeKnowledgeResult(info, el, candidates.map(sourceToken));
+        new Notice(t("research_find_sources_notice", String(candidates.length)));
+    }
+
+    getIcon(): string {
+        return FindSourcesAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("research_find_sources_label");
+    }
+}
+
+/** A link source becomes an extensionless `[[wikilink]]`; free text is kept verbatim. */
+function sourceToken(source: Source): string {
+    if (source.kind !== "link") return source.ref;
+    const file = source.ref.split("/").pop() ?? source.ref;
+    return `[[${file.replace(/\.md$/i, "")}]]`;
+}

--- a/src/actions/findSources/findSourcesLogic.ts
+++ b/src/actions/findSources/findSourcesLogic.ts
@@ -16,11 +16,11 @@ function sourceKey(source: Source): string {
 
 /**
  * Pure vault-local source suggestion (#155, FR-5/D5). For an **unsourced** target note, returns a
- * deterministically-ranked list of candidate {@link Source}s already present in the model — the
- * union of the target's graph neighbours' sources and the vault's most-referenced sources
- * (`sourcesByReferenceCount`, #145) — ranked by reference count descending, ties broken by source
- * key ascending, capped to the top-K. An already-sourced / unknown target or an empty model ⇒ `[]`.
- * Read-only, offline, deterministic, never throws. Obsidian-free.
+ * deterministically-ranked list of candidate {@link Source}s already present in the model — every
+ * source the vault already cites (`sourcesByReferenceCount`, #145). Sources cited by the target's
+ * graph **neighbours** rank first (topically relevant), then by reference count descending, ties
+ * broken by source key ascending, capped to the top-K. An already-sourced / unknown target or an
+ * empty model ⇒ `[]`. Read-only, offline, deterministic, never throws. Obsidian-free.
  */
 export function findSources(
     model: KnowledgeModel,
@@ -30,32 +30,28 @@ export function findSources(
     const target = model.get(path);
     if (!target || target.maturitySignals.hasSources) return [];
 
-    const countByKey = new Map<string, number>();
-    const sourceByKey = new Map<string, Source>();
-    for (const { source, count } of sourcesByReferenceCount(model)) {
-        const key = sourceKey(source);
-        countByKey.set(key, count);
-        sourceByKey.set(key, source);
-    }
-
-    const candidateKeys = new Set<string>();
+    const neighbourKeys = new Set<string>();
     const neighbours = new Set<string>([...model.inNeighbors(path), ...model.outNeighbors(path)]);
     for (const neighbour of neighbours) {
         const idea = model.get(neighbour);
         if (!idea) continue;
         for (const claim of idea.claims) {
-            for (const source of claim.sources) candidateKeys.add(sourceKey(source));
+            for (const source of claim.sources) neighbourKeys.add(sourceKey(source));
         }
     }
-    for (const key of countByKey.keys()) candidateKeys.add(key);
 
     const limit = opts.limit !== undefined && opts.limit > 0 ? Math.floor(opts.limit) : DEFAULT_LIMIT;
-    const ranked: { key: string; source: Source; count: number }[] = [];
-    for (const key of candidateKeys) {
-        const source = sourceByKey.get(key);
-        if (!source) continue;
-        ranked.push({ key, source, count: countByKey.get(key) ?? 0 });
-    }
-    ranked.sort((a, b) => b.count - a.count || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+    const ranked = sourcesByReferenceCount(model).map(({ source, count }) => ({
+        source,
+        count,
+        key: sourceKey(source),
+        neighbour: neighbourKeys.has(sourceKey(source)),
+    }));
+    ranked.sort(
+        (a, b) =>
+            Number(b.neighbour) - Number(a.neighbour) ||
+            b.count - a.count ||
+            (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
+    );
     return ranked.slice(0, limit).map((entry) => entry.source);
 }

--- a/src/actions/findSources/findSourcesLogic.ts
+++ b/src/actions/findSources/findSourcesLogic.ts
@@ -1,0 +1,61 @@
+import type { Source } from "architecture/knowledge/model/Idea";
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import { sourcesByReferenceCount } from "architecture/knowledge/query/queries";
+
+/** Options for {@link findSources}. */
+export interface FindSourcesOptions {
+    /** Cap the result to the top-K. Absent or non-positive ⇒ 5. */
+    limit?: number;
+}
+
+const DEFAULT_LIMIT = 5;
+
+function sourceKey(source: Source): string {
+    return source.kind === "link" ? `link:${source.ref}` : `text:${source.ref.trim().toLowerCase()}`;
+}
+
+/**
+ * Pure vault-local source suggestion (#155, FR-5/D5). For an **unsourced** target note, returns a
+ * deterministically-ranked list of candidate {@link Source}s already present in the model — the
+ * union of the target's graph neighbours' sources and the vault's most-referenced sources
+ * (`sourcesByReferenceCount`, #145) — ranked by reference count descending, ties broken by source
+ * key ascending, capped to the top-K. An already-sourced / unknown target or an empty model ⇒ `[]`.
+ * Read-only, offline, deterministic, never throws. Obsidian-free.
+ */
+export function findSources(
+    model: KnowledgeModel,
+    path: string,
+    opts: FindSourcesOptions = {}
+): Source[] {
+    const target = model.get(path);
+    if (!target || target.maturitySignals.hasSources) return [];
+
+    const countByKey = new Map<string, number>();
+    const sourceByKey = new Map<string, Source>();
+    for (const { source, count } of sourcesByReferenceCount(model)) {
+        const key = sourceKey(source);
+        countByKey.set(key, count);
+        sourceByKey.set(key, source);
+    }
+
+    const candidateKeys = new Set<string>();
+    const neighbours = new Set<string>([...model.inNeighbors(path), ...model.outNeighbors(path)]);
+    for (const neighbour of neighbours) {
+        const idea = model.get(neighbour);
+        if (!idea) continue;
+        for (const claim of idea.claims) {
+            for (const source of claim.sources) candidateKeys.add(sourceKey(source));
+        }
+    }
+    for (const key of countByKey.keys()) candidateKeys.add(key);
+
+    const limit = opts.limit !== undefined && opts.limit > 0 ? Math.floor(opts.limit) : DEFAULT_LIMIT;
+    const ranked: { key: string; source: Source; count: number }[] = [];
+    for (const key of candidateKeys) {
+        const source = sourceByKey.get(key);
+        if (!source) continue;
+        ranked.push({ key, source, count: countByKey.get(key) ?? 0 });
+    }
+    ranked.sort((a, b) => b.count - a.count || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+    return ranked.slice(0, limit).map((entry) => entry.source);
+}

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -20,3 +20,4 @@ export { SuggestLinkAction } from './suggestLink/SuggestLinkAction';
 export { CreateSemanticRelationAction } from './createSemanticRelation/CreateSemanticRelationAction';
 export { ExtractClaimsAction } from './extractClaims/ExtractClaimsAction';
 export { CompareClaimsAction } from './compareClaims/CompareClaimsAction';
+export { FindSourcesAction } from './findSources/FindSourcesAction';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -19,3 +19,4 @@ export { FindRelatedAction } from './findRelated/FindRelatedAction';
 export { SuggestLinkAction } from './suggestLink/SuggestLinkAction';
 export { CreateSemanticRelationAction } from './createSemanticRelation/CreateSemanticRelationAction';
 export { ExtractClaimsAction } from './extractClaims/ExtractClaimsAction';
+export { CompareClaimsAction } from './compareClaims/CompareClaimsAction';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -21,3 +21,4 @@ export { CreateSemanticRelationAction } from './createSemanticRelation/CreateSem
 export { ExtractClaimsAction } from './extractClaims/ExtractClaimsAction';
 export { CompareClaimsAction } from './compareClaims/CompareClaimsAction';
 export { FindSourcesAction } from './findSources/FindSourcesAction';
+export { AttachSourceAction } from './attachSource/AttachSourceAction';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -18,3 +18,4 @@ export { FindUnansweredQuestionAction } from './findUnansweredQuestion/FindUnans
 export { FindRelatedAction } from './findRelated/FindRelatedAction';
 export { SuggestLinkAction } from './suggestLink/SuggestLinkAction';
 export { CreateSemanticRelationAction } from './createSemanticRelation/CreateSemanticRelationAction';
+export { ExtractClaimsAction } from './extractClaims/ExtractClaimsAction';

--- a/src/actions/research/researchActionShared.ts
+++ b/src/actions/research/researchActionShared.ts
@@ -1,0 +1,134 @@
+import { Setting } from "obsidian";
+import { Action, ActionSetting, ActionSettingReader } from "architecture/api";
+import { navbarAction } from "architecture/components/settings";
+import { t } from "architecture/lang";
+import type { ResearchActionElement } from "zettelkasten";
+import {
+    readyModel,
+    resolveTargetPath,
+    writeKnowledgeResult,
+} from "../knowledge/knowledgeActionShared";
+
+/**
+ * Shared plumbing for the #155 🔍 research actions. Two authoring forms — an **analysis** form
+ * (result property + zone + optional source note + optional max-results) for extract-claims /
+ * compare-claims / find-sources, and an **attach** form (source value + zone) for attach-source —
+ * plus a re-export of the #153 model guard / target resolver / result writer so the action classes
+ * stay thin over their pure logic. Deterministic and offline.
+ */
+
+type LocaleKey = Parameters<typeof t>[0];
+
+// The #153 knowledge helpers are reused as-is (D6-style) so all categories share one write path.
+export { readyModel, resolveTargetPath, writeKnowledgeResult };
+
+/** Build the `settings`/`settingsReader` pair for an analysis action (extract/compare/find). */
+export function makeResearchSettings(
+    nameKey: LocaleKey,
+    descKey: LocaleKey,
+    opts: { withLimit?: boolean } = {}
+): { settings: ActionSetting; settingsReader: ActionSettingReader } {
+    const settings: ActionSetting = (contentEl, modal, action, disableNavbar) => {
+        navbarAction(contentEl, t(nameKey), t(descKey), action, modal, disableNavbar);
+        analysisForm(contentEl.createDiv(), action, false, opts.withLimit ?? false);
+    };
+    const settingsReader: ActionSettingReader = (contentEl, action) => {
+        analysisForm(contentEl, action, true, opts.withLimit ?? false);
+    };
+    return { settings, settingsReader };
+}
+
+/** Build the `settings`/`settingsReader` pair for the attach-source action. */
+export function makeAttachSourceSettings(
+    nameKey: LocaleKey,
+    descKey: LocaleKey
+): { settings: ActionSetting; settingsReader: ActionSettingReader } {
+    const settings: ActionSetting = (contentEl, modal, action, disableNavbar) => {
+        navbarAction(contentEl, t(nameKey), t(descKey), action, modal, disableNavbar);
+        attachForm(contentEl.createDiv(), action, false);
+    };
+    const settingsReader: ActionSettingReader = (contentEl, action) => {
+        attachForm(contentEl, action, true);
+    };
+    return { settings, settingsReader };
+}
+
+function analysisForm(contentEl: HTMLElement, action: Action, readonly: boolean, withLimit: boolean): void {
+    const el = action as ResearchActionElement;
+
+    new Setting(contentEl)
+        .setName(t("research_action_property_name"))
+        .setDesc(t("research_action_property_desc"))
+        .addText((text) =>
+            text
+                .setValue(el.key ?? "")
+                .setDisabled(readonly)
+                .onChange((value) => {
+                    action.key = value;
+                })
+        );
+
+    zoneSetting(contentEl, action, readonly);
+
+    new Setting(contentEl)
+        .setName(t("research_action_target_name"))
+        .setDesc(t("research_action_target_desc"))
+        .addText((text) =>
+            text
+                .setValue(el.target ?? "")
+                .setDisabled(readonly)
+                .onChange((value) => {
+                    action.target = value;
+                })
+        );
+
+    if (withLimit) {
+        new Setting(contentEl)
+            .setName(t("research_action_limit_name"))
+            .setDesc(t("research_action_limit_desc"))
+            .addText((text) =>
+                text
+                    .setValue(el.limit !== undefined ? String(el.limit) : "")
+                    .setDisabled(readonly)
+                    .onChange((value) => {
+                        const parsed = Math.floor(Number(value));
+                        action.limit = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+                    })
+            );
+    }
+}
+
+function attachForm(contentEl: HTMLElement, action: Action, readonly: boolean): void {
+    const el = action as ResearchActionElement;
+
+    new Setting(contentEl)
+        .setName(t("research_action_source_value_name"))
+        .setDesc(t("research_action_source_value_desc"))
+        .addText((text) =>
+            text
+                .setValue(el.source ?? "")
+                .setDisabled(readonly)
+                .onChange((value) => {
+                    action.source = value;
+                })
+        );
+
+    zoneSetting(contentEl, action, readonly);
+}
+
+function zoneSetting(contentEl: HTMLElement, action: Action, readonly: boolean): void {
+    const el = action as ResearchActionElement;
+    new Setting(contentEl)
+        .setName(t("research_action_zone_name"))
+        .setDesc(t("research_action_zone_desc"))
+        .addDropdown((dropdown) =>
+            dropdown
+                .addOption("frontmatter", t("research_action_zone_frontmatter"))
+                .addOption("context", t("research_action_zone_context"))
+                .setValue(el.zone ?? "frontmatter")
+                .setDisabled(readonly)
+                .onChange((value) => {
+                    action.zone = value;
+                })
+        );
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -607,4 +607,17 @@ export default {
     relation_find_related_notice: 'Found {0} related note(s).',
     relation_suggest_link_notice: 'Suggested {0} link(s).',
     relation_create_relation_notice: 'Wrote a {0} relation.',
+    // Research actions (#155)
+    research_action_property_name: 'Result property',
+    research_action_property_desc: 'Frontmatter property (or context key) the result is written to.',
+    research_action_zone_name: 'Write to',
+    research_action_zone_desc: 'Where the result goes: the note frontmatter or the workflow context.',
+    research_action_zone_frontmatter: 'Frontmatter',
+    research_action_zone_context: 'Context',
+    research_action_target_name: 'Source note (optional)',
+    research_action_target_desc: 'Note to analyze; leave empty to use the note being built.',
+    research_action_limit_name: 'Max results',
+    research_action_limit_desc: 'How many candidate sources to keep, most-referenced first.',
+    research_action_source_value_name: 'Source',
+    research_action_source_value_desc: 'A wikilink to a note or free text (URL, DOI, citation) to attach as a source.',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -623,4 +623,7 @@ export default {
     research_extract_claims_label: 'Extract claims',
     research_extract_claims_desc: 'Surface the claims and sources a note declares.',
     research_extract_claims_notice: 'Extracted {0} claim(s).',
+    research_compare_claims_label: 'Compare claims',
+    research_compare_claims_desc: "Find notes whose claims agree with or contradict this note's claims.",
+    research_compare_claims_notice: '{0} agreeing, {1} contradicting note(s).',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -629,4 +629,7 @@ export default {
     research_find_sources_label: 'Find sources',
     research_find_sources_desc: 'Suggest existing vault sources for an under-sourced note.',
     research_find_sources_notice: 'Suggested {0} source(s).',
+    research_attach_source_label: 'Attach source',
+    research_attach_source_desc: 'Attach a source (wikilink or free text) to the note being built.',
+    research_attach_source_notice: 'Attached source {0}.',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -626,4 +626,7 @@ export default {
     research_compare_claims_label: 'Compare claims',
     research_compare_claims_desc: "Find notes whose claims agree with or contradict this note's claims.",
     research_compare_claims_notice: '{0} agreeing, {1} contradicting note(s).',
+    research_find_sources_label: 'Find sources',
+    research_find_sources_desc: 'Suggest existing vault sources for an under-sourced note.',
+    research_find_sources_notice: 'Suggested {0} source(s).',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -620,4 +620,7 @@ export default {
     research_action_limit_desc: 'How many candidate sources to keep, most-referenced first.',
     research_action_source_value_name: 'Source',
     research_action_source_value_desc: 'A wikilink to a note or free text (URL, DOI, citation) to attach as a source.',
+    research_extract_claims_label: 'Extract claims',
+    research_extract_claims_desc: 'Surface the claims and sources a note declares.',
+    research_extract_claims_notice: 'Extracted {0} claim(s).',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -620,4 +620,7 @@ export default {
     research_action_limit_desc: 'Cuántas fuentes candidatas conservar, de más a menos referenciadas.',
     research_action_source_value_name: 'Fuente',
     research_action_source_value_desc: 'Un wikilink a una nota o texto libre (URL, DOI, cita) para adjuntar como fuente.',
+    research_extract_claims_label: 'Extraer afirmaciones',
+    research_extract_claims_desc: 'Muestra las afirmaciones y fuentes que declara una nota.',
+    research_extract_claims_notice: 'Se han extraído {0} afirmación(es).',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -626,4 +626,7 @@ export default {
     research_compare_claims_label: 'Comparar afirmaciones',
     research_compare_claims_desc: 'Encuentra notas cuyas afirmaciones concuerdan o contradicen las de esta nota.',
     research_compare_claims_notice: '{0} concordante(s), {1} contradictoria(s).',
+    research_find_sources_label: 'Buscar fuentes',
+    research_find_sources_desc: 'Sugiere fuentes existentes en la bóveda para una nota poco documentada.',
+    research_find_sources_notice: 'Se han sugerido {0} fuente(s).',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -607,4 +607,17 @@ export default {
     relation_find_related_notice: 'Se han encontrado {0} nota(s) relacionada(s).',
     relation_suggest_link_notice: 'Se han sugerido {0} enlace(s).',
     relation_create_relation_notice: 'Se ha escrito una relación {0}.',
+    // Acciones de investigación (#155)
+    research_action_property_name: 'Propiedad de resultado',
+    research_action_property_desc: 'Propiedad del frontmatter (o clave de contexto) donde se escribe el resultado.',
+    research_action_zone_name: 'Escribir en',
+    research_action_zone_desc: 'Dónde va el resultado: el frontmatter de la nota o el contexto del flujo.',
+    research_action_zone_frontmatter: 'Frontmatter',
+    research_action_zone_context: 'Contexto',
+    research_action_target_name: 'Nota origen (opcional)',
+    research_action_target_desc: 'Nota a analizar; déjalo vacío para usar la nota que se está creando.',
+    research_action_limit_name: 'Máximo de resultados',
+    research_action_limit_desc: 'Cuántas fuentes candidatas conservar, de más a menos referenciadas.',
+    research_action_source_value_name: 'Fuente',
+    research_action_source_value_desc: 'Un wikilink a una nota o texto libre (URL, DOI, cita) para adjuntar como fuente.',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -623,4 +623,7 @@ export default {
     research_extract_claims_label: 'Extraer afirmaciones',
     research_extract_claims_desc: 'Muestra las afirmaciones y fuentes que declara una nota.',
     research_extract_claims_notice: 'Se han extraído {0} afirmación(es).',
+    research_compare_claims_label: 'Comparar afirmaciones',
+    research_compare_claims_desc: 'Encuentra notas cuyas afirmaciones concuerdan o contradicen las de esta nota.',
+    research_compare_claims_notice: '{0} concordante(s), {1} contradictoria(s).',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -629,4 +629,7 @@ export default {
     research_find_sources_label: 'Buscar fuentes',
     research_find_sources_desc: 'Sugiere fuentes existentes en la bóveda para una nota poco documentada.',
     research_find_sources_notice: 'Se han sugerido {0} fuente(s).',
+    research_attach_source_label: 'Adjuntar fuente',
+    research_attach_source_desc: 'Adjunta una fuente (wikilink o texto libre) a la nota que se está creando.',
+    research_attach_source_notice: 'Se ha adjuntado la fuente {0}.',
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,8 @@ import {
 	CssClassesAction, DynamicSelectorAction, NumberAction, PromptAction, ScriptAction, SelectorAction,
 	TagsAction, TaskManagementAction, ZettelIdAction,
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
-	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction
+	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
+	ExtractClaimsAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -109,5 +110,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new FindRelatedAction());
 		actionsStore.registerAction(new SuggestLinkAction());
 		actionsStore.registerAction(new CreateSemanticRelationAction());
+		actionsStore.registerAction(new ExtractClaimsAction());
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 	TagsAction, TaskManagementAction, ZettelIdAction,
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
-	ExtractClaimsAction, CompareClaimsAction
+	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -112,5 +112,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new CreateSemanticRelationAction());
 		actionsStore.registerAction(new ExtractClaimsAction());
 		actionsStore.registerAction(new CompareClaimsAction());
+		actionsStore.registerAction(new FindSourcesAction());
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 	TagsAction, TaskManagementAction, ZettelIdAction,
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
-	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction
+	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction, AttachSourceAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -113,5 +113,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new ExtractClaimsAction());
 		actionsStore.registerAction(new CompareClaimsAction());
 		actionsStore.registerAction(new FindSourcesAction());
+		actionsStore.registerAction(new AttachSourceAction());
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 	TagsAction, TaskManagementAction, ZettelIdAction,
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
-	ExtractClaimsAction
+	ExtractClaimsAction, CompareClaimsAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -111,5 +111,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new SuggestLinkAction());
 		actionsStore.registerAction(new CreateSemanticRelationAction());
 		actionsStore.registerAction(new ExtractClaimsAction());
+		actionsStore.registerAction(new CompareClaimsAction());
 	}
 }

--- a/src/zettelkasten/index.ts
+++ b/src/zettelkasten/index.ts
@@ -4,7 +4,7 @@ export {
     SectionInfo, ZoneOption, AditionBaseElement,
     PromptElement, NumberElement, CalendarElement,
     SelectorElement, CheckboxElement, TagsElement,
-    ZettelIdElement, KnowledgeActionElement, RelationActionElement
+    ZettelIdElement, KnowledgeActionElement, RelationActionElement, ResearchActionElement
 } from './typing';
 export { StepBuilderModal } from './modals/StepBuilderModal';
 export { SelectorMenuModal } from './modals/SelectorMenuModal';

--- a/src/zettelkasten/typing.ts
+++ b/src/zettelkasten/typing.ts
@@ -139,6 +139,19 @@ export type RelationActionElement = {
     relationType?: string,
 } & Action;
 
+/**
+ * Config shared by the #155 research actions. The analysis actions (extract-claims / compare-claims
+ * / find-sources) use `key`/`zone`/`target` (target = the source note to analyze) plus an optional
+ * `limit` (find-sources top-K); attach-source uses `source` (the raw value to attach) + `zone`.
+ */
+export type ResearchActionElement = {
+    key: string,
+    zone: ZoneOption,
+    target?: string,
+    limit?: number,
+    source?: string,
+} & Action;
+
 export type { ZettelIdStrategy, FolgezettelRelationship };
 export type ZettelIdElement = {
     strategy?: ZettelIdStrategy;

--- a/test/actions/research/attachSourceLogic.test.ts
+++ b/test/actions/research/attachSourceLogic.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "@jest/globals";
+import { sourceField } from "actions/attachSource/attachSourceLogic";
+import { ClaimSourceSchema } from "architecture/knowledge/claims/ClaimSourceSchema";
+import { deriveIdea } from "architecture/knowledge/model/Idea";
+
+describe("sourceField (#155, FR-4, D3, AC-1)", () => {
+    it("keeps a wikilink source verbatim under the source key", () => {
+        expect(sourceField("[[Ref]]")).toEqual({ key: "source", value: "[[Ref]]" });
+    });
+
+    it("keeps free-text (URL/DOI/citation) verbatim", () => {
+        expect(sourceField("https://doi.org/10.1/x")).toEqual({ key: "source", value: "https://doi.org/10.1/x" });
+    });
+
+    it("returns null for an empty or whitespace source", () => {
+        expect(sourceField("")).toBeNull();
+        expect(sourceField("   ")).toBeNull();
+    });
+
+    it("writes a field the model derives into a sourced claim (AC-1 attach leg)", () => {
+        const field = sourceField("[[Ref]]");
+        expect(field).not.toBeNull();
+        const idea = deriveIdea(
+            {
+                path: "note.md",
+                title: "note",
+                created: 0,
+                modified: 0,
+                frontmatter: { [field!.key]: field!.value },
+                tags: [],
+                outgoingLinks: [],
+                inlineFields: [],
+                resolvedTargets: { Ref: "refs/Ref.md" },
+            },
+            { claims: new ClaimSourceSchema() }
+        );
+        expect(idea.maturitySignals.hasSources).toBe(true);
+        expect(idea.claims[0].sources).toContainEqual({ ref: "refs/Ref.md", kind: "link" });
+    });
+});

--- a/test/actions/research/compareClaimsLogic.test.ts
+++ b/test/actions/research/compareClaimsLogic.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    compareClaims,
+    normalize,
+    hasNegation,
+    stripNegation,
+} from "actions/compareClaims/compareClaimsLogic";
+import { ideaWithClaims, buildModel } from "./support/researchFixture";
+
+describe("compareClaims helpers (#155, FR-3, D4)", () => {
+    it("normalizes: trim, lowercase, collapse spaces, strip quotes and trailing punctuation", () => {
+        expect(normalize('  "Coffee   is Healthy."  ')).toBe("coffee is healthy");
+    });
+
+    it("detects negation over the closed bilingual marker set", () => {
+        expect(hasNegation("coffee is not healthy")).toBe(true);
+        expect(hasNegation("el cafe no es sano")).toBe(true);
+        expect(hasNegation("nunca duermo")).toBe(true);
+        expect(hasNegation("coffee is healthy")).toBe(false);
+    });
+
+    it("strips negation markers so opposite-polarity propositions share a base", () => {
+        expect(stripNegation("coffee is not healthy")).toBe("coffee is healthy");
+    });
+});
+
+describe("compareClaims (#155, FR-3, D4, AC-2)", () => {
+    it("flags a structural contradiction via a contradicts relation, regardless of text", () => {
+        const model = buildModel([
+            ideaWithClaims("a.md", [{ text: "Sleep improves memory" }], [{ to: "b.md", type: "contradicts" }]),
+            ideaWithClaims("b.md", [{ text: "Something entirely unrelated" }]),
+        ]);
+        const result = compareClaims(model, "a.md");
+        expect(result.contradicting).toEqual([{ path: "b.md", text: "Something entirely unrelated" }]);
+        expect(result.agreeing).toEqual([]);
+    });
+
+    it("flags a textual contradiction on an opposite-polarity copular claim", () => {
+        const model = buildModel([
+            ideaWithClaims("a.md", [{ text: "Coffee is healthy" }]),
+            ideaWithClaims("c.md", [{ text: "Coffee is not healthy" }]),
+        ]);
+        expect(compareClaims(model, "a.md").contradicting).toEqual([
+            { path: "c.md", text: "Coffee is not healthy" },
+        ]);
+    });
+
+    it("flags agreement on identical normalized claim text", () => {
+        const model = buildModel([
+            ideaWithClaims("a.md", [{ text: "Coffee is healthy" }]),
+            ideaWithClaims("d.md", [{ text: "coffee is healthy." }]),
+        ]);
+        const result = compareClaims(model, "a.md");
+        expect(result.agreeing).toEqual([{ path: "d.md", text: "coffee is healthy." }]);
+        expect(result.contradicting).toEqual([]);
+    });
+
+    it("leaves an unrelated claim in neither set", () => {
+        const model = buildModel([
+            ideaWithClaims("a.md", [{ text: "Coffee is healthy" }]),
+            ideaWithClaims("e.md", [{ text: "Grass is green" }]),
+        ]);
+        const result = compareClaims(model, "a.md");
+        expect(result.agreeing).toEqual([]);
+        expect(result.contradicting).toEqual([]);
+    });
+
+    it("is deterministic and sorted by path across runs", () => {
+        const model = buildModel([
+            ideaWithClaims("a.md", [{ text: "Coffee is healthy" }]),
+            ideaWithClaims("z.md", [{ text: "coffee is healthy" }]),
+            ideaWithClaims("d.md", [{ text: "coffee is healthy" }]),
+        ]);
+        const first = compareClaims(model, "a.md");
+        expect(first.agreeing.map((m) => m.path)).toEqual(["d.md", "z.md"]);
+        expect(compareClaims(model, "a.md")).toEqual(first);
+    });
+
+    it("returns empty sets for an unknown target without throwing", () => {
+        const model = buildModel([ideaWithClaims("a.md", [{ text: "x" }])]);
+        expect(compareClaims(model, "missing.md")).toEqual({ agreeing: [], contradicting: [] });
+    });
+});

--- a/test/actions/research/extractClaimsLogic.test.ts
+++ b/test/actions/research/extractClaimsLogic.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "@jest/globals";
+import { serializeClaims } from "actions/extractClaims/extractClaimsLogic";
+import { ClaimSourceSchema } from "architecture/knowledge/claims/ClaimSourceSchema";
+import type { Claim } from "architecture/knowledge/model/Idea";
+
+const claims: Claim[] = [
+    { text: "Sleep improves memory", sources: [{ ref: "refs/Paper.md", kind: "link" }, { ref: "https://doi.org/10.1/x", kind: "text" }] },
+    { text: "Naps help too", sources: [{ ref: "refs/Paper.md", kind: "link" }, { ref: "https://doi.org/10.1/x", kind: "text" }] },
+];
+
+describe("serializeClaims (#155, FR-2, D7, AC-1)", () => {
+    it("maps claim texts to the claim[] field", () => {
+        expect(serializeClaims(claims).claim).toEqual(["Sleep improves memory", "Naps help too"]);
+    });
+
+    it("serializes a link source as an extensionless wikilink and text verbatim, deduped", () => {
+        expect(serializeClaims(claims).source).toEqual(["[[Paper]]", "https://doi.org/10.1/x"]);
+    });
+
+    it("yields empty arrays for a claim-less note", () => {
+        expect(serializeClaims([])).toEqual({ claim: [], source: [] });
+    });
+
+    it("round-trips through ClaimSourceSchema.parse back to the original claims (AC-1)", () => {
+        const serialized = serializeClaims(claims);
+        const reparsed = new ClaimSourceSchema().parse({
+            path: "note.md",
+            frontmatter: { claim: serialized.claim, source: serialized.source },
+            inlineFields: [],
+            resolvedTargets: { Paper: "refs/Paper.md" },
+        });
+        expect(reparsed).toEqual(claims);
+    });
+});

--- a/test/actions/research/findSourcesLogic.test.ts
+++ b/test/actions/research/findSourcesLogic.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "@jest/globals";
+import { findSources } from "actions/findSources/findSourcesLogic";
+import { ideaWithClaims, buildModel } from "./support/researchFixture";
+
+const src = (ref: string) => ({ ref, kind: "text" as const });
+
+// Vault reference counts: src3 = 3, src1 = 2, src2 = 1. Target t.md is unsourced, neighbour cites src1.
+const model = buildModel([
+    ideaWithClaims("t.md", [{ text: "needs sourcing" }], [{ to: "n1.md" }]),
+    ideaWithClaims("n1.md", [{ text: "c", sources: [src("src1")] }]),
+    ideaWithClaims("x1.md", [{ text: "c", sources: [src("src1")] }]),
+    ideaWithClaims("x2.md", [{ text: "c", sources: [src("src2")] }]),
+    ideaWithClaims("y1.md", [{ text: "c", sources: [src("src3")] }]),
+    ideaWithClaims("y2.md", [{ text: "c", sources: [src("src3")] }]),
+    ideaWithClaims("y3.md", [{ text: "c", sources: [src("src3")] }]),
+]);
+
+describe("findSources (#155, FR-5, D5, AC-3)", () => {
+    it("ranks vault candidate sources by reference count descending", () => {
+        expect(findSources(model, "t.md").map((s) => s.ref)).toEqual(["src3", "src1", "src2"]);
+    });
+
+    it("caps to the top-K limit", () => {
+        expect(findSources(model, "t.md", { limit: 1 }).map((s) => s.ref)).toEqual(["src3"]);
+    });
+
+    it("returns [] for an already-sourced target", () => {
+        const sourced = buildModel([
+            ideaWithClaims("s.md", [{ text: "c", sources: [src("done")] }]),
+            ideaWithClaims("o.md", [{ text: "c", sources: [src("other")] }]),
+        ]);
+        expect(findSources(sourced, "s.md")).toEqual([]);
+    });
+
+    it("returns [] for an unknown target and an empty model", () => {
+        expect(findSources(model, "missing.md")).toEqual([]);
+        expect(findSources(buildModel([]), "anything.md")).toEqual([]);
+    });
+
+    it("breaks reference-count ties by source key ascending", () => {
+        const tie = buildModel([
+            ideaWithClaims("qt.md", [{ text: "needs sourcing" }]),
+            ideaWithClaims("q1.md", [{ text: "c", sources: [src("bbb")] }]),
+            ideaWithClaims("q2.md", [{ text: "c", sources: [src("aaa")] }]),
+        ]);
+        expect(findSources(tie, "qt.md").map((s) => s.ref)).toEqual(["aaa", "bbb"]);
+    });
+
+    it("is deterministic across runs", () => {
+        expect(findSources(model, "t.md")).toEqual(findSources(model, "t.md"));
+    });
+});

--- a/test/actions/research/findSourcesLogic.test.ts
+++ b/test/actions/research/findSourcesLogic.test.ts
@@ -16,12 +16,13 @@ const model = buildModel([
 ]);
 
 describe("findSources (#155, FR-5, D5, AC-3)", () => {
-    it("ranks vault candidate sources by reference count descending", () => {
-        expect(findSources(model, "t.md").map((s) => s.ref)).toEqual(["src3", "src1", "src2"]);
+    it("ranks a neighbour's source first, then by reference count descending", () => {
+        // src1 is cited by the neighbour n1.md, so it leads despite src3's higher vault count.
+        expect(findSources(model, "t.md").map((s) => s.ref)).toEqual(["src1", "src3", "src2"]);
     });
 
     it("caps to the top-K limit", () => {
-        expect(findSources(model, "t.md", { limit: 1 }).map((s) => s.ref)).toEqual(["src3"]);
+        expect(findSources(model, "t.md", { limit: 1 }).map((s) => s.ref)).toEqual(["src1"]);
     });
 
     it("returns [] for an already-sourced target", () => {

--- a/test/actions/research/researchActionsRegistration.test.ts
+++ b/test/actions/research/researchActionsRegistration.test.ts
@@ -11,12 +11,14 @@ const ACTION_FILES = [
     "src/actions/extractClaims/ExtractClaimsAction.tsx",
     "src/actions/compareClaims/CompareClaimsAction.tsx",
     "src/actions/findSources/FindSourcesAction.tsx",
+    "src/actions/attachSource/AttachSourceAction.tsx",
 ];
 
 const LOGIC_FILES = [
     "src/actions/extractClaims/extractClaimsLogic.ts",
     "src/actions/compareClaims/compareClaimsLogic.ts",
     "src/actions/findSources/findSourcesLogic.ts",
+    "src/actions/attachSource/attachSourceLogic.ts",
 ];
 
 const ALL_RESEARCH_SOURCES = [
@@ -29,6 +31,7 @@ const REGISTERED_CLASSES = [
     "ExtractClaimsAction",
     "CompareClaimsAction",
     "FindSourcesAction",
+    "AttachSourceAction",
 ];
 
 describe("research action guardrails (#155, AC-4/AC-5/FR-6)", () => {

--- a/test/actions/research/researchActionsRegistration.test.ts
+++ b/test/actions/research/researchActionsRegistration.test.ts
@@ -10,11 +10,13 @@ const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
 const ACTION_FILES = [
     "src/actions/extractClaims/ExtractClaimsAction.tsx",
     "src/actions/compareClaims/CompareClaimsAction.tsx",
+    "src/actions/findSources/FindSourcesAction.tsx",
 ];
 
 const LOGIC_FILES = [
     "src/actions/extractClaims/extractClaimsLogic.ts",
     "src/actions/compareClaims/compareClaimsLogic.ts",
+    "src/actions/findSources/findSourcesLogic.ts",
 ];
 
 const ALL_RESEARCH_SOURCES = [
@@ -26,6 +28,7 @@ const ALL_RESEARCH_SOURCES = [
 const REGISTERED_CLASSES = [
     "ExtractClaimsAction",
     "CompareClaimsAction",
+    "FindSourcesAction",
 ];
 
 describe("research action guardrails (#155, AC-4/AC-5/FR-6)", () => {

--- a/test/actions/research/researchActionsRegistration.test.ts
+++ b/test/actions/research/researchActionsRegistration.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// test/actions/research → 3 ups → repo root
+const ROOT = join(__dirname, "..", "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+// Grows across T6–T9 as each research action lands.
+const ACTION_FILES = [
+    "src/actions/extractClaims/ExtractClaimsAction.tsx",
+];
+
+const LOGIC_FILES = [
+    "src/actions/extractClaims/extractClaimsLogic.ts",
+];
+
+const ALL_RESEARCH_SOURCES = [
+    ...ACTION_FILES,
+    ...LOGIC_FILES,
+    "src/actions/research/researchActionShared.ts",
+];
+
+const REGISTERED_CLASSES = [
+    "ExtractClaimsAction",
+];
+
+describe("research action guardrails (#155, AC-4/AC-5/FR-6)", () => {
+    it("each action declares the research category (AC-4)", () => {
+        for (const file of ACTION_FILES) {
+            expect(read(file)).toMatch(/category\s*=\s*"research"\s+as const/);
+        }
+    });
+
+    it("main.ts registers every research action (AC-4)", () => {
+        const main = read("src/main.ts");
+        for (const cls of REGISTERED_CLASSES) {
+            expect(main).toContain(`registerAction(new ${cls}())`);
+        }
+    });
+
+    it("no research source makes a network call or imports an AI provider (FR-6)", () => {
+        for (const file of ALL_RESEARCH_SOURCES) {
+            const source = read(file);
+            expect(source).not.toMatch(/\brequestUrl\b/);
+            expect(source).not.toMatch(/\bfetch\s*\(/);
+            expect(source).not.toMatch(/openai|anthropic|@google|langchain/i);
+        }
+    });
+
+    it("no research source mutates a foreign note (AC-5) — writes go through the DTO", () => {
+        for (const file of ALL_RESEARCH_SOURCES) {
+            const source = read(file);
+            expect(source).not.toMatch(/processFrontMatter/);
+            expect(source).not.toMatch(/\.modify\s*\(/);
+            expect(source).not.toMatch(/\.create\s*\(/);
+            expect(source).not.toMatch(/\.rename\s*\(/);
+            expect(source).not.toMatch(/\.trash\s*\(/);
+        }
+    });
+
+    it("each pure logic module is Obsidian-free and avoids the knowledge barrel", () => {
+        for (const file of LOGIC_FILES) {
+            const source = read(file);
+            expect(source).not.toMatch(/from\s+["']obsidian["']/);
+            expect(source).not.toMatch(/from\s+["']architecture\/knowledge["']/);
+        }
+    });
+});

--- a/test/actions/research/researchActionsRegistration.test.ts
+++ b/test/actions/research/researchActionsRegistration.test.ts
@@ -9,10 +9,12 @@ const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
 // Grows across T6–T9 as each research action lands.
 const ACTION_FILES = [
     "src/actions/extractClaims/ExtractClaimsAction.tsx",
+    "src/actions/compareClaims/CompareClaimsAction.tsx",
 ];
 
 const LOGIC_FILES = [
     "src/actions/extractClaims/extractClaimsLogic.ts",
+    "src/actions/compareClaims/compareClaimsLogic.ts",
 ];
 
 const ALL_RESEARCH_SOURCES = [
@@ -23,6 +25,7 @@ const ALL_RESEARCH_SOURCES = [
 
 const REGISTERED_CLASSES = [
     "ExtractClaimsAction",
+    "CompareClaimsAction",
 ];
 
 describe("research action guardrails (#155, AC-4/AC-5/FR-6)", () => {

--- a/test/actions/research/support/researchFixture.ts
+++ b/test/actions/research/support/researchFixture.ts
@@ -1,0 +1,36 @@
+import { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import type { Idea, Source } from "architecture/knowledge/model/Idea";
+
+/**
+ * Shared fixture for the #155 research-action logic tests. `build()` recomputes degree, so seeded
+ * signals are irrelevant — only claims, sources and relation shape matter.
+ */
+export function ideaWithClaims(
+    path: string,
+    claims: { text: string; sources?: Source[] }[],
+    relations: { to: string; type?: string }[] = []
+): Idea {
+    const rels = relations.map((r) => ({ type: r.type ?? "link", from: path, to: r.to }));
+    const cls = claims.map((c) => ({ text: c.text, sources: c.sources ?? [] }));
+    return {
+        path,
+        title: path,
+        created: 0,
+        modified: 0,
+        state: "permanent",
+        relations: rels,
+        claims: cls,
+        maturitySignals: {
+            inDegree: 0,
+            outDegree: rels.length,
+            degree: rels.length,
+            hasSources: cls.some((c) => c.sources.length > 0),
+        },
+    };
+}
+
+export function buildModel(ideas: Idea[]): KnowledgeModel {
+    const model = new KnowledgeModel();
+    model.build(ideas);
+    return model;
+}

--- a/test/config/researchActionsLocale.test.ts
+++ b/test/config/researchActionsLocale.test.ts
@@ -25,6 +25,10 @@ const KEYS = [
     "research_compare_claims_label",
     "research_compare_claims_desc",
     "research_compare_claims_notice",
+    // find-sources (T8)
+    "research_find_sources_label",
+    "research_find_sources_desc",
+    "research_find_sources_notice",
 ];
 
 describe("research action i18n parity (#155, AC-7)", () => {

--- a/test/config/researchActionsLocale.test.ts
+++ b/test/config/researchActionsLocale.test.ts
@@ -21,6 +21,10 @@ const KEYS = [
     "research_extract_claims_label",
     "research_extract_claims_desc",
     "research_extract_claims_notice",
+    // compare-claims (T7)
+    "research_compare_claims_label",
+    "research_compare_claims_desc",
+    "research_compare_claims_notice",
 ];
 
 describe("research action i18n parity (#155, AC-7)", () => {

--- a/test/config/researchActionsLocale.test.ts
+++ b/test/config/researchActionsLocale.test.ts
@@ -29,7 +29,17 @@ const KEYS = [
     "research_find_sources_label",
     "research_find_sources_desc",
     "research_find_sources_notice",
+    // attach-source (T9)
+    "research_attach_source_label",
+    "research_attach_source_desc",
+    "research_attach_source_notice",
 ];
+
+describe("research action i18n key count (#155)", () => {
+    it("ships all 24 research keys", () => {
+        expect(KEYS.length).toBe(24);
+    });
+});
 
 describe("research action i18n parity (#155, AC-7)", () => {
     it("defines every research key in both en and es, non-empty", () => {

--- a/test/config/researchActionsLocale.test.ts
+++ b/test/config/researchActionsLocale.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+// Grows across T6–T9 with each action's label/desc/notice (24 keys total when complete).
+const KEYS = [
+    // shared settings-form keys (T5)
+    "research_action_property_name",
+    "research_action_property_desc",
+    "research_action_zone_name",
+    "research_action_zone_desc",
+    "research_action_zone_frontmatter",
+    "research_action_zone_context",
+    "research_action_target_name",
+    "research_action_target_desc",
+    "research_action_limit_name",
+    "research_action_limit_desc",
+    "research_action_source_value_name",
+    "research_action_source_value_desc",
+];
+
+describe("research action i18n parity (#155, AC-7)", () => {
+    it("defines every research key in both en and es, non-empty", () => {
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/test/config/researchActionsLocale.test.ts
+++ b/test/config/researchActionsLocale.test.ts
@@ -17,6 +17,10 @@ const KEYS = [
     "research_action_limit_desc",
     "research_action_source_value_name",
     "research_action_source_value_desc",
+    // extract-claims (T6)
+    "research_extract_claims_label",
+    "research_extract_claims_desc",
+    "research_extract_claims_notice",
 ];
 
 describe("research action i18n parity (#155, AC-7)", () => {


### PR DESCRIPTION
## Summary

The 🔍 **research** action category — four actions that make sourcing and claim-checking part of the workflow, over the #148 claims-&-sources model:

- **ExtractClaims** (`extract-claims`) — surfaces a note's declared claims + sources as a `{ claim, source }` field that round-trips through `ClaimSourceSchema` (AC-1).
- **CompareClaims** (`compare-claims`) — surfaces notes whose claims **agree with** or **contradict** the target's. Contradiction = structural `contradicts` relation (#147, either direction, reusing the #153 primitive) OR an opposite-polarity textual negation over a closed bilingual marker set. Deterministic, sorted, exclude-self.
- **FindSources** (`find-sources`) — for an **unsourced** note, suggests existing vault sources; a note's graph-neighbour sources rank first, then by vault reference count. Offline, read-only — not a web search.
- **AttachSource** (`attach-source`) — writes a `source` field (wikilink or free text) onto the **note being built**, so the model sources it on re-index.

## Design decisions (see the issue's "Design decisions" comment)

- All four ship (none destructive). `attach-source` writes **only the note being built** (foreign-note mutation out of scope). `find-sources` is vault-local/offline; external/AI discovery stays #156.
- `compare-claims` contradiction is structural-first (reliable) with a documented best-effort textual-negation fallback; whole-model scope; one structured `{ agreeing, contradicting }` output.

## Technical notes

- Four pure, Obsidian-free cores: `serializeClaims`, `compareClaims` (+`normalize`/`hasNegation`/`stripNegation`), `findSources`, `sourceField`.
- Shared `researchActionShared.ts` reuses the #153 `readyModel`/`resolveTargetPath`/`writeKnowledgeResult` (one write path across categories).
- New `ResearchActionElement` type; 4 actions registered in `main.ts` (**23 built-ins** total).
- 24 i18n keys in both `en.ts` and `es.ts` (sentence case, parity-tested).
- Docs: 4 new pages + mkdocs nav (2.20–2.23); README Features row 19 → 23 + 🔍 toolkit bullet.

## Test plan

- [x] `npm run verify` green (typecheck + oxlint + lint:obsidian 0 + **610 jest tests**)
- [x] AC-1 round-trip via `ClaimSourceSchema.parse` (extract + attach legs)
- [x] AC-2 both contradiction mechanisms + agreement, deterministic
- [x] AC-3 find-sources unsourced-gate + neighbour-first ranking
- [x] AC-4 category + registration guardrails; AC-5 no foreign-note mutation; AC-7 i18n parity
- [x] `obsidian-plugin-reviewer` verdict: **RAISE** (no blocking, no score issues); neighbour-boost + de-shadow nits applied

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)