### PR TITLE
feat(actions): AI as an optional, provider-agnostic action category (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   **extract claims**, **compare claims** (surface notes that agree with or contradict yours),
   **find sources** (suggest existing vault sources for an under-sourced note), and **attach
   source**. Over the claims-and-sources model, deterministic and offline.
+- **🤖 AI actions — optional, off by default** — AI is *one action category, never the core*: the
+  whole plugin works fully with AI disabled. Opt in with your own OpenAI-compatible provider
+  (endpoint + key + model — OpenAI, OpenRouter, LM Studio, Ollama…) to **summarize**, **classify**,
+  and **generate questions**. No bundled key, no telemetry; the note content is sent only to the
+  endpoint you configure. See [AI provider setup](https://rafaelgb.github.io/Obsidian-ZettelFlow/development/ai-provider-setup/).
 
 > New here? Run **Install Zettelkasten starter flows** from the command palette, or open
 > **Settings → ZettelFlow** to launch these tools.
@@ -105,7 +110,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | Feature | Description |
 |---|---|
 | **Canvas-based flows** | Use Obsidian's native canvas as the workflow engine — no custom DSL to learn. |
-| **23 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question — 🔗 relation actions — find related, suggest link, create semantic relation — and 🔍 research actions — extract claims, compare claims, find sources, attach source. |
+| **26 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question — 🔗 relation actions — find related, suggest link, create semantic relation — 🔍 research actions — extract claims, compare claims, find sources, attach source — and 🤖 optional AI actions (off by default) — summarize, classify, generate questions. |
 | **Conditional edges** | Label a canvas arrow `if: frontmatter.type === "meeting"` to branch the workflow at runtime. |
 | **Dynamic templates** | Use `{{title}}`, `{{date}}`, `{{frontmatter.key}}`, `{{canvas.name}}` in step body templates. |
 | **Live body preview** | See the rendered note body while editing a step's template (desktop). |

--- a/docs/actions/Classify.md
+++ b/docs/actions/Classify.md
@@ -1,0 +1,21 @@
+# Classify action
+
+🤖 An **AI** action (#156). Suggests topic tags for the note being built via your configured AI
+provider. **Optional and off by default** — see
+[AI provider setup](../development/ai-provider-setup.md).
+
+## Options
+
+- **Result property** — where the tags are written (default `classification`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+
+## Result
+
+An array of short tag labels (parsed from the provider's response — trimmed, de-duplicated), plus a
+`Notice` with the count. If AI is disabled or not configured, the action no-ops with a clear notice
+and makes no network request; a provider/network failure degrades to a notice with nothing written.
+
+## Capabilities
+
+Sends the **note content** to the single AI endpoint you configure (opt-in). No bundled key, no
+telemetry, no other endpoint. See [Capabilities & privacy](../development/capabilities-and-privacy.md).

--- a/docs/actions/GenerateQuestions.md
+++ b/docs/actions/GenerateQuestions.md
@@ -1,0 +1,22 @@
+# Generate questions action
+
+🤖 An **AI** action (#156). Generates the open questions the note being built raises, via your
+configured AI provider. **Optional and off by default** — see
+[AI provider setup](../development/ai-provider-setup.md).
+
+## Options
+
+- **Result property** — where the questions are written (default `questions`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+
+## Result
+
+A list of questions (parsed from the provider's response — one per line, list markers stripped),
+plus a `Notice` with the count. If AI is disabled or not configured, the action no-ops with a clear
+notice and makes no network request; a provider/network failure degrades to a notice with nothing
+written.
+
+## Capabilities
+
+Sends the **note content** to the single AI endpoint you configure (opt-in). No bundled key, no
+telemetry, no other endpoint. See [Capabilities & privacy](../development/capabilities-and-privacy.md).

--- a/docs/actions/Summarize.md
+++ b/docs/actions/Summarize.md
@@ -1,0 +1,20 @@
+# Summarize action
+
+🤖 An **AI** action (#156). Summarizes the note being built via your configured AI provider.
+**Optional and off by default** — see [AI provider setup](../development/ai-provider-setup.md).
+
+## Options
+
+- **Result property** — where the summary is written (default `summary`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+
+## Result
+
+A short summary string written to the result property, plus a `Notice`. If AI is disabled or not
+configured, the action no-ops with a clear notice and makes no network request; a provider/network
+failure degrades to a notice with nothing written.
+
+## Capabilities
+
+Sends the **note content** to the single AI endpoint you configure (opt-in). No bundled key, no
+telemetry, no other endpoint. See [Capabilities & privacy](../development/capabilities-and-privacy.md).

--- a/docs/development/ai-provider-setup.md
+++ b/docs/development/ai-provider-setup.md
@@ -1,0 +1,46 @@
+# AI provider setup
+
+The 🤖 **AI action category** (#156) is **optional and off by default**. ZettelFlow works fully with
+AI disabled — every other feature is deterministic and offline. When you opt in, you bring your own
+**OpenAI-compatible** provider; ZettelFlow ships no key and no default endpoint.
+
+## Turning it on
+
+**Settings → ZettelFlow → AI (optional):**
+
+1. **Enable AI actions** — off by default. While off, no AI action ever makes a network request.
+2. **Endpoint URL** — the full OpenAI-compatible chat-completions URL. Examples:
+   - OpenAI — `https://api.openai.com/v1/chat/completions`
+   - OpenRouter — `https://openrouter.ai/api/v1/chat/completions`
+   - LM Studio (local) — `http://localhost:1234/v1/chat/completions`
+   - Ollama (local, OpenAI-compat) — `http://localhost:11434/v1/chat/completions`
+3. **Model** — the model name your provider expects (e.g. `gpt-4o-mini`).
+4. **API key** — your provider key. Stored in this vault's plugin data (`.obsidian/plugins/zettelflow/data.json`),
+   sent **only** as a `Bearer` header to the endpoint above, and **never logged**.
+
+Any of endpoint / model / key left blank means the provider is not usable, and AI actions no-op with
+a clear notice.
+
+## What is sent, and where
+
+When you run an AI action, ZettelFlow sends the **content of the note being built** as the prompt to
+the **single endpoint you configured** — and nothing else. There is **no telemetry, no bundled key,
+no default endpoint, and no second endpoint**. See [Capabilities & privacy](capabilities-and-privacy.md).
+
+## The actions
+
+The category ships three actions, each a thin wrapper over one completion call:
+
+- [Summarize](../actions/Summarize.md) — a short summary of the note.
+- [Classify](../actions/Classify.md) — suggested topic tags.
+- [Generate questions](../actions/GenerateQuestions.md) — the open questions the note raises.
+
+If a request fails (network error, bad config, malformed response), the action degrades to a clear
+notice and writes nothing — it never crashes the flow.
+
+## Provider-agnostic by design
+
+ZettelFlow depends on no specific vendor: a single `AiProvider` interface (`complete(prompt)`) with
+one built-in OpenAI-compatible client (`src/architecture/ai/`). The OpenAI-compatible shape already
+covers OpenAI, OpenRouter, LM Studio and Ollama. Native SDKs, embeddings/RAG, streaming and agentic
+loops are intentionally out of scope.

--- a/docs/development/capabilities-and-privacy.md
+++ b/docs/development/capabilities-and-privacy.md
@@ -10,14 +10,16 @@ telemetry** and transmits **no personal data or vault contents**.
 |---|---|---|---|
 | **File system (vault)** | Always | Read your Canvas flow files; create and edit notes as the output of a flow; install community templates into your vault. | Obsidian's `Vault` API and `FileManager` — no hardcoded `.obsidian` paths, path-normalised, desktop **and** mobile. |
 | **Network** | Opt-in | Only the **community templates** browser: fetch example flows/steps/actions and preview images from the ZettelFlow community source, and — if you configure one — your own community backend URL (authenticated with the token you set). | `request`/`requestUrl` in `src/application/community/`. No requests are made unless you open the community browser. |
+| **AI provider (external)** | Opt-in, off by default | The optional **🤖 AI action category** (`summarize`, `classify`, `generate-questions`). When you enable it and run an AI action, the **note content** is sent to the single OpenAI-compatible endpoint **you configure** to get a completion back. | `requestUrl` in `src/architecture/ai/OpenAiCompatibleProvider.ts` only. No bundled key, no default endpoint, no other endpoint, no telemetry. Off by default — with the switch off, no AI request is ever made. See [AI provider setup](ai-provider-setup.md). |
 | **Script execution** | Opt-in | The **Script** action and JavaScript step files execute **JavaScript you author** as part of a flow. | The `.js` code editor (`CodeView`) and the script action. Runs with the plugin's vault access — run only scripts you trust. |
 | **Clipboard** | No | — | ZettelFlow does not read or write the system clipboard. |
 
 ## No telemetry
 
 ZettelFlow does not embed analytics, crash reporting, or any phone-home. The only outbound
-requests are the opt-in community fetches above. Nothing about your notes leaves your machine
-unless *you* publish a template to a community backend you configured.
+requests are the opt-in community fetches and the opt-in AI provider above. Nothing about your notes
+leaves your machine unless *you* publish a template to a community backend you configured, or *you*
+enable AI and run an AI action (which sends the note content only to the endpoint you set).
 
 ## Self-hosting the community backend
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,9 @@ nav:
       - 2.21 Compare claims: actions/CompareClaims.md
       - 2.22 Find sources: actions/FindSources.md
       - 2.23 Attach source: actions/AttachSource.md
+      - 2.24 Summarize: actions/Summarize.md
+      - 2.25 Classify: actions/Classify.md
+      - 2.26 Generate questions: actions/GenerateQuestions.md
   - 3. Vault Hooks:
       - 3.1 Property Hooks:
           - 3.1.1 Overview: vault-hooks/property-hooks/overview.md
@@ -70,5 +73,6 @@ nav:
       - 7.10 Map of content builder: development/moc-builder.md
       - 7.11 Connection resurfacing: development/connection-resurfacing.md
       - 7.12 Atomicity split assist: development/atomicity-split.md
+      - 7.13 AI provider setup: development/ai-provider-setup.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/actions/ai/ClassifyAction.tsx
+++ b/src/actions/ai/ClassifyAction.tsx
@@ -1,0 +1,36 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { t } from "architecture/lang";
+import { AiActionElement } from "zettelkasten";
+import { buildClassifyPrompt, parseClassification } from "./classifyLogic";
+import { makeAiSettings, runAiAction } from "./aiActionShared";
+
+const { settings, settingsReader } = makeAiSettings("ai_classify_label", "ai_classify_desc");
+
+/** 🤖 Suggests topic tags for the note being built via the configured AI provider (opt-in). #156. */
+export class ClassifyAction extends CustomZettelAction {
+    private static ICON = "tags";
+    id = "classify";
+    category = "ai" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "classification", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/Classify";
+    purpose = "Suggest topic tags for the note with AI.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as AiActionElement;
+        await runAiAction(info, el, {
+            buildPrompt: buildClassifyPrompt,
+            transform: (raw) => parseClassification(raw),
+            notice: (value) => t("ai_classify_notice", String((value as string[]).length)),
+        });
+    }
+
+    getIcon(): string {
+        return ClassifyAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("ai_classify_label");
+    }
+}

--- a/src/actions/ai/GenerateQuestionsAction.tsx
+++ b/src/actions/ai/GenerateQuestionsAction.tsx
@@ -1,0 +1,39 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { t } from "architecture/lang";
+import { AiActionElement } from "zettelkasten";
+import { buildQuestionsPrompt, parseQuestions } from "./generateQuestionsLogic";
+import { makeAiSettings, runAiAction } from "./aiActionShared";
+
+const { settings, settingsReader } = makeAiSettings(
+    "ai_generate_questions_label",
+    "ai_generate_questions_desc"
+);
+
+/** 🤖 Generates the open questions the note being built raises, via the AI provider (opt-in). #156. */
+export class GenerateQuestionsAction extends CustomZettelAction {
+    private static ICON = "help-circle";
+    id = "generate-questions";
+    category = "ai" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "questions", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/GenerateQuestions";
+    purpose = "Generate open questions the note raises with AI.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as AiActionElement;
+        await runAiAction(info, el, {
+            buildPrompt: buildQuestionsPrompt,
+            transform: (raw) => parseQuestions(raw),
+            notice: (value) => t("ai_generate_questions_notice", String((value as string[]).length)),
+        });
+    }
+
+    getIcon(): string {
+        return GenerateQuestionsAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("ai_generate_questions_label");
+    }
+}

--- a/src/actions/ai/SummarizeAction.tsx
+++ b/src/actions/ai/SummarizeAction.tsx
@@ -1,0 +1,35 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { t } from "architecture/lang";
+import { AiActionElement } from "zettelkasten";
+import { buildSummarizePrompt } from "./summarizeLogic";
+import { makeAiSettings, runAiAction } from "./aiActionShared";
+
+const { settings, settingsReader } = makeAiSettings("ai_summarize_label", "ai_summarize_desc");
+
+/** 🤖 Summarizes the note being built via the configured AI provider (opt-in, off by default). #156. */
+export class SummarizeAction extends CustomZettelAction {
+    private static ICON = "sparkles";
+    id = "summarize";
+    category = "ai" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "summary", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/Summarize";
+    purpose = "Summarize the note being built with AI.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as AiActionElement;
+        await runAiAction(info, el, {
+            buildPrompt: buildSummarizePrompt,
+            notice: () => t("ai_summarize_notice"),
+        });
+    }
+
+    getIcon(): string {
+        return SummarizeAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("ai_summarize_label");
+    }
+}

--- a/src/actions/ai/aiActionShared.ts
+++ b/src/actions/ai/aiActionShared.ts
@@ -1,0 +1,113 @@
+import { Notice, Setting } from "obsidian";
+import { Action, ActionSetting, ActionSettingReader, ExecuteInfo } from "architecture/api";
+import { log } from "architecture";
+import { navbarAction } from "architecture/components/settings";
+import { t } from "architecture/lang";
+import { AiService } from "architecture/ai/AiService";
+import type { AiActionElement } from "zettelkasten";
+import { resolveTargetPath, writeKnowledgeResult } from "../knowledge/knowledgeActionShared";
+
+/**
+ * Shared plumbing for the #156 🤖 AI actions: the authoring form (result property + zone) and the
+ * single enabled/config **gate** every AI action runs through. Deterministic control flow; the only
+ * network call is delegated to {@link AiService}'s provider. Disabled ⇒ no call. The API key is
+ * never touched here or logged.
+ */
+
+type LocaleKey = Parameters<typeof t>[0];
+
+// Reused #153 write path so AI results land like every other action's.
+export { resolveTargetPath, writeKnowledgeResult };
+
+/** How an AI action turns note content into a prompt, post-processes the completion, and notices. */
+export interface AiActionSpec {
+    buildPrompt(content: string): string;
+    /** Post-process the raw completion before writing (e.g. parse labels/questions). Default: identity. */
+    transform?(raw: string): unknown;
+    /** Success `Notice` text from the written value. */
+    notice(value: unknown): string;
+}
+
+/** Build the `settings`/`settingsReader` pair for an AI action from its i18n name/desc keys. */
+export function makeAiSettings(
+    nameKey: LocaleKey,
+    descKey: LocaleKey
+): { settings: ActionSetting; settingsReader: ActionSettingReader } {
+    const settings: ActionSetting = (contentEl, modal, action, disableNavbar) => {
+        navbarAction(contentEl, t(nameKey), t(descKey), action, modal, disableNavbar);
+        aiSettingsForm(contentEl.createDiv(), action, false);
+    };
+    const settingsReader: ActionSettingReader = (contentEl, action) => {
+        aiSettingsForm(contentEl, action, true);
+    };
+    return { settings, settingsReader };
+}
+
+function aiSettingsForm(contentEl: HTMLElement, action: Action, readonly: boolean): void {
+    const el = action as AiActionElement;
+
+    new Setting(contentEl)
+        .setName(t("ai_action_property_name"))
+        .setDesc(t("ai_action_property_desc"))
+        .addText((text) =>
+            text
+                .setValue(el.key ?? "")
+                .setDisabled(readonly)
+                .onChange((value) => {
+                    action.key = value;
+                })
+        );
+
+    new Setting(contentEl)
+        .setName(t("ai_action_zone_name"))
+        .setDesc(t("ai_action_zone_desc"))
+        .addDropdown((dropdown) =>
+            dropdown
+                .addOption("frontmatter", t("ai_action_zone_frontmatter"))
+                .addOption("context", t("ai_action_zone_context"))
+                .setValue(el.zone ?? "frontmatter")
+                .setDisabled(readonly)
+                .onChange((value) => {
+                    action.zone = value;
+                })
+        );
+}
+
+/**
+ * The single gate every AI action runs through (#156, D3/AC-1/AC-2). Off ⇒ `Notice` + `log.debug`,
+ * no network. Misconfigured ⇒ `Notice` + `log.error`. Otherwise builds the prompt from the
+ * note-being-built content, calls the provider, and on failure degrades to `Notice` + `log.error`
+ * (message only, never the key) with no write. On success it writes via the DTO and notices.
+ */
+export async function runAiAction(
+    info: ExecuteInfo,
+    el: AiActionElement,
+    spec: AiActionSpec
+): Promise<void> {
+    const service = AiService.getInstance();
+    const state = service.gate();
+    if (state === "disabled") {
+        log.debug("[ai] disabled — skipping");
+        new Notice(t("ai_disabled_notice"));
+        return;
+    }
+    if (state === "unconfigured") {
+        log.error("[ai] provider not configured — skipping");
+        new Notice(t("ai_not_configured_notice"));
+        return;
+    }
+
+    const prompt = spec.buildPrompt(info.content.get());
+    let raw: string;
+    try {
+        raw = await service.getProvider().complete(prompt);
+    } catch (error) {
+        log.error(`[ai] request failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        new Notice(t("ai_request_failed_notice"));
+        return;
+    }
+
+    const value = spec.transform ? spec.transform(raw) : raw;
+    writeKnowledgeResult(info, el, value);
+    new Notice(spec.notice(value));
+}

--- a/src/actions/ai/aiActionShared.ts
+++ b/src/actions/ai/aiActionShared.ts
@@ -5,7 +5,7 @@ import { navbarAction } from "architecture/components/settings";
 import { t } from "architecture/lang";
 import { AiService } from "architecture/ai/AiService";
 import type { AiActionElement } from "zettelkasten";
-import { resolveTargetPath, writeKnowledgeResult } from "../knowledge/knowledgeActionShared";
+import { writeKnowledgeResult } from "../knowledge/knowledgeActionShared";
 
 /**
  * Shared plumbing for the #156 🤖 AI actions: the authoring form (result property + zone) and the
@@ -17,7 +17,7 @@ import { resolveTargetPath, writeKnowledgeResult } from "../knowledge/knowledgeA
 type LocaleKey = Parameters<typeof t>[0];
 
 // Reused #153 write path so AI results land like every other action's.
-export { resolveTargetPath, writeKnowledgeResult };
+export { writeKnowledgeResult };
 
 /** How an AI action turns note content into a prompt, post-processes the completion, and notices. */
 export interface AiActionSpec {
@@ -87,8 +87,8 @@ export async function runAiAction(
     const service = AiService.getInstance();
     const state = service.gate();
     if (state === "disabled") {
+        // Silent no-op: these actions auto-run in a flow, so a per-build notice would be noise.
         log.debug("[ai] disabled — skipping");
-        new Notice(t("ai_disabled_notice"));
         return;
     }
     if (state === "unconfigured") {

--- a/src/actions/ai/classifyLogic.ts
+++ b/src/actions/ai/classifyLogic.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure prompt builder for `classify` (#156, FR-6/D5). Asks the provider for a short list of topic
+ * tags for the note-being-built content. Obsidian-free and deterministic.
+ */
+export function buildClassifyPrompt(content: string): string {
+    return (
+        "Suggest 3-5 topic tags for the following note. " +
+        "Respond with a comma-separated list of short lowercase tags and nothing else.\n\n" +
+        content.trim()
+    );
+}
+
+/**
+ * Pure parser (#156, AC-2) turning the provider's comma/newline text into trimmed, de-duplicated
+ * labels (list markers stripped). Empty input ⇒ `[]`.
+ */
+export function parseClassification(text: string): string[] {
+    const seen = new Set<string>();
+    const labels: string[] = [];
+    for (const raw of text.split(/[,\n]/)) {
+        const label = raw.trim().replace(/^[-*#•]+\s*/, "").trim();
+        if (!label) continue;
+        const key = label.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        labels.push(label);
+    }
+    return labels;
+}

--- a/src/actions/ai/generateQuestionsLogic.ts
+++ b/src/actions/ai/generateQuestionsLogic.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure prompt builder for `generate-questions` (#156, FR-6/D5). Asks the provider for the open
+ * questions the note-being-built content raises, one per line. Obsidian-free and deterministic.
+ */
+export function buildQuestionsPrompt(content: string): string {
+    return (
+        "Generate a few open questions this note raises. " +
+        "Respond with one question per line and nothing else.\n\n" +
+        content.trim()
+    );
+}
+
+/**
+ * Pure parser (#156, AC-2) turning the provider's line/number/bullet list into questions with the
+ * list markers stripped. Blank lines dropped; empty input ⇒ `[]`.
+ */
+export function parseQuestions(text: string): string[] {
+    const questions: string[] = [];
+    for (const raw of text.split(/\r?\n/)) {
+        const question = raw.trim().replace(/^(\d+[.)]|[-*•])\s*/, "").trim();
+        if (question) questions.push(question);
+    }
+    return questions;
+}

--- a/src/actions/ai/summarizeLogic.ts
+++ b/src/actions/ai/summarizeLogic.ts
@@ -1,0 +1,11 @@
+/**
+ * Pure prompt builder for `summarize` (#156, FR-6/D5). Wraps the note-being-built content in a
+ * summarize instruction. Obsidian-free and deterministic.
+ */
+export function buildSummarizePrompt(content: string): string {
+    return (
+        "Summarize the following note in a few clear sentences. " +
+        "Respond with only the summary, no preamble.\n\n" +
+        content.trim()
+    );
+}

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -23,3 +23,4 @@ export { CompareClaimsAction } from './compareClaims/CompareClaimsAction';
 export { FindSourcesAction } from './findSources/FindSourcesAction';
 export { AttachSourceAction } from './attachSource/AttachSourceAction';
 export { SummarizeAction } from './ai/SummarizeAction';
+export { ClassifyAction } from './ai/ClassifyAction';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -24,3 +24,4 @@ export { FindSourcesAction } from './findSources/FindSourcesAction';
 export { AttachSourceAction } from './attachSource/AttachSourceAction';
 export { SummarizeAction } from './ai/SummarizeAction';
 export { ClassifyAction } from './ai/ClassifyAction';
+export { GenerateQuestionsAction } from './ai/GenerateQuestionsAction';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -22,3 +22,4 @@ export { ExtractClaimsAction } from './extractClaims/ExtractClaimsAction';
 export { CompareClaimsAction } from './compareClaims/CompareClaimsAction';
 export { FindSourcesAction } from './findSources/FindSourcesAction';
 export { AttachSourceAction } from './attachSource/AttachSourceAction';
+export { SummarizeAction } from './ai/SummarizeAction';

--- a/src/architecture/ai/AiProvider.ts
+++ b/src/architecture/ai/AiProvider.ts
@@ -1,0 +1,8 @@
+/**
+ * Provider-agnostic AI interface (#156, FR-2). One method: turn a prompt into a completion string.
+ * Implementations are bring-your-own; ZettelFlow ships a single OpenAI-compatible client. Kept tiny
+ * on purpose so the plugin never couples to a specific vendor.
+ */
+export interface AiProvider {
+    complete(prompt: string): Promise<string>;
+}

--- a/src/architecture/ai/AiService.ts
+++ b/src/architecture/ai/AiService.ts
@@ -1,0 +1,32 @@
+import { ObsidianApi } from "architecture/plugin/ObsidianAPI";
+import { AiProvider } from "./AiProvider";
+import { aiGateDecision, AiGateState, AiSettings } from "./aiGate";
+import { OpenAiCompatibleProvider } from "./OpenAiCompatibleProvider";
+
+/**
+ * Runtime entry point for the optional AI category (#156). Reads the opt-in `ai` settings, exposes
+ * the {@link aiGateDecision} gate, and builds the OpenAI-compatible provider from the current
+ * config. `getInstance()` singleton, matching the rest of the runtime.
+ */
+export class AiService {
+    private static instance: AiService;
+
+    public static getInstance(): AiService {
+        if (!AiService.instance) AiService.instance = new AiService();
+        return AiService.instance;
+    }
+
+    private settings(): AiSettings {
+        return ObsidianApi.getOwnPlugin().settings.ai;
+    }
+
+    /** The current gate state — `disabled` (off), `unconfigured`, or `ready`. */
+    public gate(): AiGateState {
+        return aiGateDecision(this.settings());
+    }
+
+    /** A provider built from the current settings. Only call when {@link gate} is `ready`. */
+    public getProvider(): AiProvider {
+        return new OpenAiCompatibleProvider(this.settings());
+    }
+}

--- a/src/architecture/ai/OpenAiCompatibleProvider.ts
+++ b/src/architecture/ai/OpenAiCompatibleProvider.ts
@@ -3,6 +3,18 @@ import { AiProvider } from "./AiProvider";
 import type { AiSettings } from "./aiGate";
 import { buildChatRequestBody, parseChatCompletion } from "./openaiCompatibleLogic";
 
+/** Bound each request so a hung/misconfigured endpoint fails with a clear error instead of pending. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    return Promise.race([
+        promise,
+        new Promise<T>((_resolve, reject) =>
+            setTimeout(() => reject(new Error(`AI request timed out after ${ms}ms`)), ms)
+        ),
+    ]);
+}
+
 /**
  * The single built-in {@link AiProvider} (#156, FR-2/FR-3): an OpenAI-compatible chat-completions
  * client. POSTs to the user-configured endpoint via Obsidian `requestUrl` (never `fetch`), sends the
@@ -13,16 +25,19 @@ export class OpenAiCompatibleProvider implements AiProvider {
     constructor(private readonly settings: AiSettings) {}
 
     async complete(prompt: string): Promise<string> {
-        const response = await requestUrl({
-            url: this.settings.endpoint,
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${this.settings.apiKey}`,
-            },
-            body: JSON.stringify(buildChatRequestBody(this.settings.model, prompt)),
-            throw: false,
-        });
+        const response = await withTimeout(
+            requestUrl({
+                url: this.settings.endpoint,
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${this.settings.apiKey}`,
+                },
+                body: JSON.stringify(buildChatRequestBody(this.settings.model, prompt)),
+                throw: false,
+            }),
+            REQUEST_TIMEOUT_MS
+        );
         if (response.status < 200 || response.status >= 300) {
             throw new Error(`AI request failed with status ${response.status}`);
         }

--- a/src/architecture/ai/OpenAiCompatibleProvider.ts
+++ b/src/architecture/ai/OpenAiCompatibleProvider.ts
@@ -1,0 +1,31 @@
+import { requestUrl } from "obsidian";
+import { AiProvider } from "./AiProvider";
+import type { AiSettings } from "./aiGate";
+import { buildChatRequestBody, parseChatCompletion } from "./openaiCompatibleLogic";
+
+/**
+ * The single built-in {@link AiProvider} (#156, FR-2/FR-3): an OpenAI-compatible chat-completions
+ * client. POSTs to the user-configured endpoint via Obsidian `requestUrl` (never `fetch`), sends the
+ * key only as a `Bearer` header, and never logs it. A non-2xx status throws a status-only error (no
+ * key, no body) so the shared gate can degrade gracefully.
+ */
+export class OpenAiCompatibleProvider implements AiProvider {
+    constructor(private readonly settings: AiSettings) {}
+
+    async complete(prompt: string): Promise<string> {
+        const response = await requestUrl({
+            url: this.settings.endpoint,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${this.settings.apiKey}`,
+            },
+            body: JSON.stringify(buildChatRequestBody(this.settings.model, prompt)),
+            throw: false,
+        });
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(`AI request failed with status ${response.status}`);
+        }
+        return parseChatCompletion(response.json as unknown);
+    }
+}

--- a/src/architecture/ai/aiGate.ts
+++ b/src/architecture/ai/aiGate.ts
@@ -1,0 +1,25 @@
+/** The opt-in AI provider configuration (#156). Off by default; blank fields ⇒ not usable. */
+export interface AiSettings {
+    /** Master switch — while false, no AI action ever reaches the network. */
+    enabled: boolean;
+    /** Full OpenAI-compatible chat-completions endpoint URL (bring-your-own; no default). */
+    endpoint: string;
+    /** API key (bring-your-own; stored in the plugin data.json; never logged). */
+    apiKey: string;
+    /** Model name passed to the provider. */
+    model: string;
+}
+
+/** The three observable states of the AI gate. */
+export type AiGateState = "disabled" | "unconfigured" | "ready";
+
+/**
+ * Pure gate decision (#156, FR-1/AC-1). `disabled` when the master switch is off — regardless of
+ * config, so a disabled switch can never reach the provider; `unconfigured` when any of
+ * endpoint/apiKey/model is blank; `ready` only when enabled and fully configured. Obsidian-free.
+ */
+export function aiGateDecision(ai: AiSettings): AiGateState {
+    if (!ai.enabled) return "disabled";
+    if (!ai.endpoint.trim() || !ai.apiKey.trim() || !ai.model.trim()) return "unconfigured";
+    return "ready";
+}

--- a/src/architecture/ai/index.ts
+++ b/src/architecture/ai/index.ts
@@ -1,0 +1,9 @@
+export { aiGateDecision } from "./aiGate";
+export type { AiSettings, AiGateState } from "./aiGate";
+export type { AiProvider } from "./AiProvider";
+export {
+    buildChatRequestBody,
+    parseChatCompletion,
+    AiResponseError,
+} from "./openaiCompatibleLogic";
+export type { ChatRequestBody } from "./openaiCompatibleLogic";

--- a/src/architecture/ai/openaiCompatibleLogic.ts
+++ b/src/architecture/ai/openaiCompatibleLogic.ts
@@ -1,0 +1,40 @@
+/** Raised when an AI provider response cannot be parsed into a completion string. */
+export class AiResponseError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "AiResponseError";
+    }
+}
+
+/** The OpenAI-compatible chat-completions request body. */
+export interface ChatRequestBody {
+    model: string;
+    messages: { role: string; content: string }[];
+}
+
+/** Pure builder for a single-user-message chat request (#156, FR-2). Obsidian-free. */
+export function buildChatRequestBody(model: string, prompt: string): ChatRequestBody {
+    return { model, messages: [{ role: "user", content: prompt }] };
+}
+
+/**
+ * Pure parser for an OpenAI-compatible chat-completions response (#156, FR-2/AC-2). Returns the
+ * first choice's message content, or throws {@link AiResponseError} on any malformed shape (not an
+ * object, missing/empty `choices`, missing `message`, missing/empty `content`). Obsidian-free.
+ */
+export function parseChatCompletion(json: unknown): string {
+    const choices = asRecord(json)?.choices;
+    if (!Array.isArray(choices) || choices.length === 0) {
+        throw new AiResponseError("AI response had no choices");
+    }
+    const message = asRecord(choices[0] as unknown)?.message;
+    const content = asRecord(message)?.content;
+    if (typeof content !== "string" || content.length === 0) {
+        throw new AiResponseError("AI response had no message content");
+    }
+    return content;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+    return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -632,4 +632,14 @@ export default {
     research_attach_source_label: 'Attach source',
     research_attach_source_desc: 'Attach a source (wikilink or free text) to the note being built.',
     research_attach_source_notice: 'Attached source {0}.',
+    // AI actions (#156)
+    ai_action_property_name: 'Result property',
+    ai_action_property_desc: 'Frontmatter property (or context key) the AI result is written to.',
+    ai_action_zone_name: 'Write to',
+    ai_action_zone_desc: 'Where the result goes: the note frontmatter or the workflow context.',
+    ai_action_zone_frontmatter: 'Frontmatter',
+    ai_action_zone_context: 'Context',
+    ai_disabled_notice: 'AI is off — enable it in ZettelFlow settings.',
+    ai_not_configured_notice: 'Configure the AI endpoint, key and model in ZettelFlow settings.',
+    ai_request_failed_notice: 'The AI request failed — see the console for details.',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -651,4 +651,18 @@ export default {
     ai_generate_questions_label: 'Generate questions',
     ai_generate_questions_desc: 'Generate open questions the note raises with AI.',
     ai_generate_questions_notice: 'Wrote {0} AI question(s).',
+    // AI settings (#156)
+    settings_ai_heading: 'AI (optional)',
+    settings_ai_intro: 'AI is one optional action category — the whole plugin works with it off. It is off by default.',
+    settings_ai_enable_name: 'Enable AI actions',
+    settings_ai_enable_desc: 'Allow AI actions to call your configured provider. Off by default.',
+    settings_ai_endpoint_name: 'Endpoint URL',
+    settings_ai_endpoint_desc: 'Full OpenAI-compatible chat-completions URL (OpenAI, OpenRouter, LM Studio, Ollama, …).',
+    settings_ai_endpoint_placeholder: 'https://api.openai.com/v1/chat/completions',
+    settings_ai_apikey_name: 'API key',
+    settings_ai_apikey_desc: "Your provider key, stored in this vault's plugin data. Sent only to your endpoint.",
+    settings_ai_model_name: 'Model',
+    settings_ai_model_desc: 'The model name your provider expects.',
+    settings_ai_model_placeholder: 'gpt-4o-mini',
+    settings_ai_disclosure: 'When you run an AI action, the note content is sent only to the endpoint above. No telemetry, no bundled key, no other endpoint.',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -645,4 +645,7 @@ export default {
     ai_summarize_label: 'Summarize',
     ai_summarize_desc: 'Summarize the note being built with AI.',
     ai_summarize_notice: 'Wrote an AI summary.',
+    ai_classify_label: 'Classify',
+    ai_classify_desc: 'Suggest topic tags for the note with AI.',
+    ai_classify_notice: 'Wrote {0} AI tag(s).',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -642,4 +642,7 @@ export default {
     ai_disabled_notice: 'AI is off — enable it in ZettelFlow settings.',
     ai_not_configured_notice: 'Configure the AI endpoint, key and model in ZettelFlow settings.',
     ai_request_failed_notice: 'The AI request failed — see the console for details.',
+    ai_summarize_label: 'Summarize',
+    ai_summarize_desc: 'Summarize the note being built with AI.',
+    ai_summarize_notice: 'Wrote an AI summary.',
 };

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -641,7 +641,7 @@ export default {
     ai_action_zone_context: 'Context',
     ai_disabled_notice: 'AI is off — enable it in ZettelFlow settings.',
     ai_not_configured_notice: 'Configure the AI endpoint, key and model in ZettelFlow settings.',
-    ai_request_failed_notice: 'The AI request failed — see the console for details.',
+    ai_request_failed_notice: 'The AI request failed. Check your provider endpoint, key and model.',
     ai_summarize_label: 'Summarize',
     ai_summarize_desc: 'Summarize the note being built with AI.',
     ai_summarize_notice: 'Wrote an AI summary.',

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -648,4 +648,7 @@ export default {
     ai_classify_label: 'Classify',
     ai_classify_desc: 'Suggest topic tags for the note with AI.',
     ai_classify_notice: 'Wrote {0} AI tag(s).',
+    ai_generate_questions_label: 'Generate questions',
+    ai_generate_questions_desc: 'Generate open questions the note raises with AI.',
+    ai_generate_questions_notice: 'Wrote {0} AI question(s).',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -642,4 +642,7 @@ export default {
     ai_disabled_notice: 'La IA está desactivada — actívala en los ajustes de ZettelFlow.',
     ai_not_configured_notice: 'Configura el endpoint, la clave y el modelo de IA en los ajustes de ZettelFlow.',
     ai_request_failed_notice: 'La petición a la IA ha fallado — revisa la consola para más detalles.',
+    ai_summarize_label: 'Resumir',
+    ai_summarize_desc: 'Resume la nota que se está creando con IA.',
+    ai_summarize_notice: 'Se ha escrito un resumen con IA.',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -651,4 +651,18 @@ export default {
     ai_generate_questions_label: 'Generar preguntas',
     ai_generate_questions_desc: 'Genera preguntas abiertas que plantea la nota con IA.',
     ai_generate_questions_notice: 'Se han escrito {0} pregunta(s) con IA.',
+    // Ajustes de IA (#156)
+    settings_ai_heading: 'IA (opcional)',
+    settings_ai_intro: 'La IA es una categoría de acciones opcional — el plugin funciona por completo con ella desactivada. Está desactivada por defecto.',
+    settings_ai_enable_name: 'Activar acciones de IA',
+    settings_ai_enable_desc: 'Permite que las acciones de IA llamen a tu proveedor configurado. Desactivada por defecto.',
+    settings_ai_endpoint_name: 'URL del endpoint',
+    settings_ai_endpoint_desc: 'URL completa de chat-completions compatible con OpenAI (OpenAI, OpenRouter, LM Studio, Ollama, …).',
+    settings_ai_endpoint_placeholder: 'https://api.openai.com/v1/chat/completions',
+    settings_ai_apikey_name: 'Clave de API',
+    settings_ai_apikey_desc: 'Tu clave del proveedor, guardada en los datos del plugin de esta bóveda. Se envía solo a tu endpoint.',
+    settings_ai_model_name: 'Modelo',
+    settings_ai_model_desc: 'El nombre del modelo que espera tu proveedor.',
+    settings_ai_model_placeholder: 'gpt-4o-mini',
+    settings_ai_disclosure: 'Al ejecutar una acción de IA, el contenido de la nota se envía solo al endpoint de arriba. Sin telemetría, sin clave incluida, sin ningún otro endpoint.',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -632,4 +632,14 @@ export default {
     research_attach_source_label: 'Adjuntar fuente',
     research_attach_source_desc: 'Adjunta una fuente (wikilink o texto libre) a la nota que se está creando.',
     research_attach_source_notice: 'Se ha adjuntado la fuente {0}.',
+    // Acciones de IA (#156)
+    ai_action_property_name: 'Propiedad de resultado',
+    ai_action_property_desc: 'Propiedad del frontmatter (o clave de contexto) donde se escribe el resultado de la IA.',
+    ai_action_zone_name: 'Escribir en',
+    ai_action_zone_desc: 'Dónde va el resultado: el frontmatter de la nota o el contexto del flujo.',
+    ai_action_zone_frontmatter: 'Frontmatter',
+    ai_action_zone_context: 'Contexto',
+    ai_disabled_notice: 'La IA está desactivada — actívala en los ajustes de ZettelFlow.',
+    ai_not_configured_notice: 'Configura el endpoint, la clave y el modelo de IA en los ajustes de ZettelFlow.',
+    ai_request_failed_notice: 'La petición a la IA ha fallado — revisa la consola para más detalles.',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -641,7 +641,7 @@ export default {
     ai_action_zone_context: 'Contexto',
     ai_disabled_notice: 'La IA está desactivada — actívala en los ajustes de ZettelFlow.',
     ai_not_configured_notice: 'Configura el endpoint, la clave y el modelo de IA en los ajustes de ZettelFlow.',
-    ai_request_failed_notice: 'La petición a la IA ha fallado — revisa la consola para más detalles.',
+    ai_request_failed_notice: 'La petición a la IA ha fallado. Revisa el endpoint, la clave y el modelo del proveedor.',
     ai_summarize_label: 'Resumir',
     ai_summarize_desc: 'Resume la nota que se está creando con IA.',
     ai_summarize_notice: 'Se ha escrito un resumen con IA.',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -645,4 +645,7 @@ export default {
     ai_summarize_label: 'Resumir',
     ai_summarize_desc: 'Resume la nota que se está creando con IA.',
     ai_summarize_notice: 'Se ha escrito un resumen con IA.',
+    ai_classify_label: 'Clasificar',
+    ai_classify_desc: 'Sugiere etiquetas temáticas para la nota con IA.',
+    ai_classify_notice: 'Se han escrito {0} etiqueta(s) con IA.',
 };

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -648,4 +648,7 @@ export default {
     ai_classify_label: 'Clasificar',
     ai_classify_desc: 'Sugiere etiquetas temáticas para la nota con IA.',
     ai_classify_notice: 'Se han escrito {0} etiqueta(s) con IA.',
+    ai_generate_questions_label: 'Generar preguntas',
+    ai_generate_questions_desc: 'Genera preguntas abiertas que plantea la nota con IA.',
+    ai_generate_questions_notice: 'Se han escrito {0} pregunta(s) con IA.',
 };

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -22,6 +22,7 @@ import { CommunityTemplatesModal, ManageInstalledTemplatesModal } from "applicat
 import { createRoot } from "react-dom/client";
 import React from "react";
 import { PropertyHooksManager } from "./handlers/hooks/components/PropertyHooksManager";
+import { aiSettingsGroup } from "./handlers/aiSettingsGroup";
 import { createExampleFlow } from "application/notes/onboardingService";
 import { SlipboxHealthView } from "architecture/components/core/slipboxHealth/SlipboxHealthView";
 import { ResurfaceView } from "architecture/components/core/resurface/ResurfaceView";
@@ -436,6 +437,8 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                     },
                 ],
             },
+            // ── AI (optional, off by default) ─────────────────────────────────
+            aiSettingsGroup(plugin),
             // ── Zettelkasten toolkit ──────────────────────────────────────────
             {
                 type: "group",

--- a/src/config/modals/handlers/aiSettingsGroup.ts
+++ b/src/config/modals/handlers/aiSettingsGroup.ts
@@ -1,0 +1,90 @@
+import { SettingDefinitionItem } from "obsidian";
+import ZettelFlow from "main";
+import { c } from "architecture";
+import { t } from "architecture/lang";
+
+/**
+ * Declarative AI settings group (#156, FR-8/AC-3) for `ZettelFlowSettingsTab.getSettingDefinitions()`.
+ * An off-by-default enable toggle plus bring-your-own endpoint / model / API-key fields, and a
+ * visible data-disclosure note (what is sent, only-your-endpoint, key in data.json, no telemetry).
+ * Mirrors the declarative shape of the `events` group.
+ */
+export function aiSettingsGroup(plugin: ZettelFlow): SettingDefinitionItem {
+    return {
+        type: "group",
+        heading: t("settings_ai_heading"),
+        items: [
+            {
+                name: t("settings_ai_intro"),
+                render: (setting) => {
+                    setting.setClass(c("readable-setting-item"));
+                },
+            },
+            {
+                name: t("settings_ai_enable_name"),
+                desc: t("settings_ai_enable_desc"),
+                render: (setting) => {
+                    setting.addToggle((toggle) =>
+                        toggle
+                            .setValue(plugin.settings.ai.enabled)
+                            .onChange(async (value) => {
+                                plugin.settings.ai = { ...plugin.settings.ai, enabled: value };
+                                await plugin.saveSettings();
+                            })
+                    );
+                },
+            },
+            {
+                name: t("settings_ai_endpoint_name"),
+                desc: t("settings_ai_endpoint_desc"),
+                render: (setting) => {
+                    setting.addText((text) =>
+                        text
+                            .setPlaceholder(t("settings_ai_endpoint_placeholder"))
+                            .setValue(plugin.settings.ai.endpoint)
+                            .onChange(async (value) => {
+                                plugin.settings.ai = { ...plugin.settings.ai, endpoint: value.trim() };
+                                await plugin.saveSettings();
+                            })
+                    );
+                },
+            },
+            {
+                name: t("settings_ai_model_name"),
+                desc: t("settings_ai_model_desc"),
+                render: (setting) => {
+                    setting.addText((text) =>
+                        text
+                            .setPlaceholder(t("settings_ai_model_placeholder"))
+                            .setValue(plugin.settings.ai.model)
+                            .onChange(async (value) => {
+                                plugin.settings.ai = { ...plugin.settings.ai, model: value.trim() };
+                                await plugin.saveSettings();
+                            })
+                    );
+                },
+            },
+            {
+                name: t("settings_ai_apikey_name"),
+                desc: t("settings_ai_apikey_desc"),
+                render: (setting) => {
+                    setting.addText((text) => {
+                        text
+                            .setValue(plugin.settings.ai.apiKey)
+                            .onChange(async (value) => {
+                                plugin.settings.ai = { ...plugin.settings.ai, apiKey: value };
+                                await plugin.saveSettings();
+                            });
+                        text.inputEl.type = "password";
+                    });
+                },
+            },
+            {
+                name: t("settings_ai_disclosure"),
+                render: (setting) => {
+                    setting.setClass(c("readable-setting-item"));
+                },
+            },
+        ],
+    };
+}

--- a/src/config/typing.ts
+++ b/src/config/typing.ts
@@ -7,6 +7,7 @@ import {
     DEFAULT_CREATED_PROPERTY,
     DEFAULT_LAST_REVIEWED_PROPERTY,
 } from "architecture/knowledge/lifecycle/states";
+import type { AiSettings } from "architecture/ai";
 
 export type PropertyHookSettings = {
     /** Script to execute when the property changes */
@@ -84,6 +85,12 @@ export interface ZettelFlowSettings {
          */
         enabled: boolean;
     };
+
+    /**
+     * Optional, provider-agnostic AI (#156). OFF by default: while `enabled` is false no AI action
+     * ever reaches the network. Bring-your-own OpenAI-compatible endpoint + key + model.
+     */
+    ai: AiSettings;
 
     /** Notes created by ZettelFlow, most-recent first. Capped at 50. */
     history: HistoryEntry[];
@@ -183,6 +190,7 @@ export const DEFAULT_SETTINGS: Partial<ZettelFlowSettings> = {
     },
     relations: {}, // parseInlineRelations resolved at runtime: on desktop, off mobile.
     events: { enabled: false }, // Event-driven workflows are opt-in (#150).
+    ai: { enabled: false, endpoint: "", apiKey: "", model: "" }, // AI is opt-in, off by default (#156).
     history: [],
     hasSeenWelcome: false,
     createInCurrentFolder: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import {
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
 	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction, AttachSourceAction,
-	SummarizeAction, ClassifyAction
+	SummarizeAction, ClassifyAction, GenerateQuestionsAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -117,5 +117,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new AttachSourceAction());
 		actionsStore.registerAction(new SummarizeAction());
 		actionsStore.registerAction(new ClassifyAction());
+		actionsStore.registerAction(new GenerateQuestionsAction());
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import {
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
 	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction, AttachSourceAction,
-	SummarizeAction
+	SummarizeAction, ClassifyAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -116,5 +116,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new FindSourcesAction());
 		actionsStore.registerAction(new AttachSourceAction());
 		actionsStore.registerAction(new SummarizeAction());
+		actionsStore.registerAction(new ClassifyAction());
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,8 @@ import {
 	TagsAction, TaskManagementAction, ZettelIdAction,
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
-	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction, AttachSourceAction
+	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction, AttachSourceAction,
+	SummarizeAction
 } from 'actions';
 import { log } from 'architecture';
 import { t } from 'architecture/lang';
@@ -114,5 +115,6 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new CompareClaimsAction());
 		actionsStore.registerAction(new FindSourcesAction());
 		actionsStore.registerAction(new AttachSourceAction());
+		actionsStore.registerAction(new SummarizeAction());
 	}
 }

--- a/src/zettelkasten/index.ts
+++ b/src/zettelkasten/index.ts
@@ -4,7 +4,8 @@ export {
     SectionInfo, ZoneOption, AditionBaseElement,
     PromptElement, NumberElement, CalendarElement,
     SelectorElement, CheckboxElement, TagsElement,
-    ZettelIdElement, KnowledgeActionElement, RelationActionElement, ResearchActionElement
+    ZettelIdElement, KnowledgeActionElement, RelationActionElement, ResearchActionElement,
+    AiActionElement
 } from './typing';
 export { StepBuilderModal } from './modals/StepBuilderModal';
 export { SelectorMenuModal } from './modals/SelectorMenuModal';

--- a/src/zettelkasten/typing.ts
+++ b/src/zettelkasten/typing.ts
@@ -152,6 +152,12 @@ export type ResearchActionElement = {
     source?: string,
 } & Action;
 
+/** Config shared by the #156 AI actions: the result `key` and the `zone` it's written to. */
+export type AiActionElement = {
+    key: string,
+    zone: ZoneOption,
+} & Action;
+
 export type { ZettelIdStrategy, FolgezettelRelationship };
 export type ZettelIdElement = {
     strategy?: ZettelIdStrategy;

--- a/test/actions/ai/aiActionsRegistration.test.ts
+++ b/test/actions/ai/aiActionsRegistration.test.ts
@@ -71,6 +71,10 @@ describe("ai infrastructure guardrails (#156, AC-4/FR-3/FR-5)", () => {
         }
     });
 
+    it("the settings group surfaces the data-disclosure text (AC-3)", () => {
+        expect(read("src/config/modals/handlers/aiSettingsGroup.ts")).toMatch(/settings_ai_disclosure/);
+    });
+
     it("no AI source mutates a foreign note — writes go through the DTO", () => {
         for (const file of ALL_AI_SOURCES) {
             const source = read(file);

--- a/test/actions/ai/aiActionsRegistration.test.ts
+++ b/test/actions/ai/aiActionsRegistration.test.ts
@@ -17,11 +17,13 @@ const PURE_LOGIC = [
 const ACTION_FILES = [
     "src/actions/ai/SummarizeAction.tsx",
     "src/actions/ai/ClassifyAction.tsx",
+    "src/actions/ai/GenerateQuestionsAction.tsx",
 ];
 
 const REGISTERED_CLASSES = [
     "SummarizeAction",
     "ClassifyAction",
+    "GenerateQuestionsAction",
 ];
 
 const ALL_AI_SOURCES = [

--- a/test/actions/ai/aiActionsRegistration.test.ts
+++ b/test/actions/ai/aiActionsRegistration.test.ts
@@ -13,7 +13,15 @@ const PURE_LOGIC = [
     "src/architecture/ai/openaiCompatibleLogic.ts",
 ];
 
-// Grows in T9+ with the three action files.
+// Grows across T9–T11 as each AI action lands.
+const ACTION_FILES = [
+    "src/actions/ai/SummarizeAction.tsx",
+];
+
+const REGISTERED_CLASSES = [
+    "SummarizeAction",
+];
+
 const ALL_AI_SOURCES = [
     "src/architecture/ai/aiGate.ts",
     "src/architecture/ai/openaiCompatibleLogic.ts",
@@ -21,9 +29,23 @@ const ALL_AI_SOURCES = [
     "src/architecture/ai/OpenAiCompatibleProvider.ts",
     "src/architecture/ai/AiService.ts",
     "src/actions/ai/aiActionShared.ts",
+    ...ACTION_FILES,
 ];
 
 describe("ai infrastructure guardrails (#156, AC-4/FR-3/FR-5)", () => {
+    it("each action declares the ai category (AC-4)", () => {
+        for (const file of ACTION_FILES) {
+            expect(read(file)).toMatch(/category\s*=\s*"ai"\s+as const/);
+        }
+    });
+
+    it("main.ts registers every AI action (AC-4)", () => {
+        const main = read("src/main.ts");
+        for (const cls of REGISTERED_CLASSES) {
+            expect(main).toContain(`registerAction(new ${cls}())`);
+        }
+    });
+
     it("only the provider module reaches the network via requestUrl, and never fetch", () => {
         for (const file of ALL_AI_SOURCES) {
             const source = read(file);

--- a/test/actions/ai/aiActionsRegistration.test.ts
+++ b/test/actions/ai/aiActionsRegistration.test.ts
@@ -13,13 +13,14 @@ const PURE_LOGIC = [
     "src/architecture/ai/openaiCompatibleLogic.ts",
 ];
 
-// Grows in T8+ with the shared helper and the three action files.
+// Grows in T9+ with the three action files.
 const ALL_AI_SOURCES = [
     "src/architecture/ai/aiGate.ts",
     "src/architecture/ai/openaiCompatibleLogic.ts",
     "src/architecture/ai/AiProvider.ts",
     "src/architecture/ai/OpenAiCompatibleProvider.ts",
     "src/architecture/ai/AiService.ts",
+    "src/actions/ai/aiActionShared.ts",
 ];
 
 describe("ai infrastructure guardrails (#156, AC-4/FR-3/FR-5)", () => {
@@ -41,6 +42,17 @@ describe("ai infrastructure guardrails (#156, AC-4/FR-3/FR-5)", () => {
     it("pure logic modules are Obsidian-free", () => {
         for (const file of PURE_LOGIC) {
             expect(read(file)).not.toMatch(/from\s+["']obsidian["']/);
+        }
+    });
+
+    it("no AI source mutates a foreign note — writes go through the DTO", () => {
+        for (const file of ALL_AI_SOURCES) {
+            const source = read(file);
+            expect(source).not.toMatch(/processFrontMatter/);
+            expect(source).not.toMatch(/\.modify\s*\(/);
+            expect(source).not.toMatch(/\.create\s*\(/);
+            expect(source).not.toMatch(/\.rename\s*\(/);
+            expect(source).not.toMatch(/\.trash\s*\(/);
         }
     });
 });

--- a/test/actions/ai/aiActionsRegistration.test.ts
+++ b/test/actions/ai/aiActionsRegistration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// test/actions/ai → 3 ups → repo root
+const ROOT = join(__dirname, "..", "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+const PROVIDER = "src/architecture/ai/OpenAiCompatibleProvider.ts";
+
+const PURE_LOGIC = [
+    "src/architecture/ai/aiGate.ts",
+    "src/architecture/ai/openaiCompatibleLogic.ts",
+];
+
+// Grows in T8+ with the shared helper and the three action files.
+const ALL_AI_SOURCES = [
+    "src/architecture/ai/aiGate.ts",
+    "src/architecture/ai/openaiCompatibleLogic.ts",
+    "src/architecture/ai/AiProvider.ts",
+    "src/architecture/ai/OpenAiCompatibleProvider.ts",
+    "src/architecture/ai/AiService.ts",
+];
+
+describe("ai infrastructure guardrails (#156, AC-4/FR-3/FR-5)", () => {
+    it("only the provider module reaches the network via requestUrl, and never fetch", () => {
+        for (const file of ALL_AI_SOURCES) {
+            const source = read(file);
+            if (file === PROVIDER) expect(source).toMatch(/\brequestUrl\b/);
+            else expect(source).not.toMatch(/\brequestUrl\b/);
+            expect(source).not.toMatch(/\bfetch\s*\(/);
+        }
+    });
+
+    it("no AI source logs the API key", () => {
+        for (const file of ALL_AI_SOURCES) {
+            expect(read(file)).not.toMatch(/log\.\w+\([^)]*apiKey/);
+        }
+    });
+
+    it("pure logic modules are Obsidian-free", () => {
+        for (const file of PURE_LOGIC) {
+            expect(read(file)).not.toMatch(/from\s+["']obsidian["']/);
+        }
+    });
+});

--- a/test/actions/ai/aiActionsRegistration.test.ts
+++ b/test/actions/ai/aiActionsRegistration.test.ts
@@ -16,10 +16,12 @@ const PURE_LOGIC = [
 // Grows across T9–T11 as each AI action lands.
 const ACTION_FILES = [
     "src/actions/ai/SummarizeAction.tsx",
+    "src/actions/ai/ClassifyAction.tsx",
 ];
 
 const REGISTERED_CLASSES = [
     "SummarizeAction",
+    "ClassifyAction",
 ];
 
 const ALL_AI_SOURCES = [

--- a/test/actions/ai/classifyLogic.test.ts
+++ b/test/actions/ai/classifyLogic.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "@jest/globals";
+import { buildClassifyPrompt, parseClassification } from "actions/ai/classifyLogic";
+
+describe("classify logic (#156, FR-6, AC-2)", () => {
+    it("embeds the note content and asks for tags", () => {
+        const prompt = buildClassifyPrompt("A note about sleep and memory.");
+        expect(prompt).toContain("A note about sleep and memory.");
+        expect(prompt.toLowerCase()).toContain("tag");
+    });
+
+    it("parses a comma or newline list into trimmed, deduped labels", () => {
+        expect(parseClassification("sleep, memory ,  sleep\nbiology")).toEqual(["sleep", "memory", "biology"]);
+    });
+
+    it("strips list markers and returns [] on empty", () => {
+        expect(parseClassification("- sleep\n* memory")).toEqual(["sleep", "memory"]);
+        expect(parseClassification("   ")).toEqual([]);
+    });
+});

--- a/test/actions/ai/generateQuestionsLogic.test.ts
+++ b/test/actions/ai/generateQuestionsLogic.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "@jest/globals";
+import { buildQuestionsPrompt, parseQuestions } from "actions/ai/generateQuestionsLogic";
+
+describe("generate-questions logic (#156, FR-6, AC-2)", () => {
+    it("embeds the note content and asks for questions", () => {
+        const prompt = buildQuestionsPrompt("A note about sleep and memory.");
+        expect(prompt).toContain("A note about sleep and memory.");
+        expect(prompt.toLowerCase()).toContain("question");
+    });
+
+    it("parses a numbered or bulleted list, stripping markers", () => {
+        expect(parseQuestions("1. Why sleep?\n2) How much?\n- What if not?")).toEqual([
+            "Why sleep?",
+            "How much?",
+            "What if not?",
+        ]);
+    });
+
+    it("returns [] on empty input", () => {
+        expect(parseQuestions("\n  \n")).toEqual([]);
+    });
+});

--- a/test/actions/ai/summarizeLogic.test.ts
+++ b/test/actions/ai/summarizeLogic.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "@jest/globals";
+import { buildSummarizePrompt } from "actions/ai/summarizeLogic";
+
+describe("buildSummarizePrompt (#156, FR-6, D5)", () => {
+    it("embeds the note content and a summarize instruction", () => {
+        const prompt = buildSummarizePrompt("The mitochondria is the powerhouse of the cell.");
+        expect(prompt).toContain("The mitochondria is the powerhouse of the cell.");
+        expect(prompt.toLowerCase()).toContain("summar");
+    });
+});

--- a/test/architecture/ai/aiGate.test.ts
+++ b/test/architecture/ai/aiGate.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "@jest/globals";
+import { aiGateDecision, AiSettings } from "architecture/ai/aiGate";
+
+const ready: AiSettings = {
+    enabled: true,
+    endpoint: "https://api.example.com/v1/chat/completions",
+    apiKey: "sk-test",
+    model: "gpt-4o-mini",
+};
+
+describe("aiGateDecision (#156, FR-1, AC-1)", () => {
+    it("is disabled when the switch is off, even with a full config", () => {
+        expect(aiGateDecision({ ...ready, enabled: false })).toBe("disabled");
+    });
+
+    it("is unconfigured when any of endpoint/apiKey/model is blank", () => {
+        expect(aiGateDecision({ ...ready, endpoint: "" })).toBe("unconfigured");
+        expect(aiGateDecision({ ...ready, apiKey: "   " })).toBe("unconfigured");
+        expect(aiGateDecision({ ...ready, model: "" })).toBe("unconfigured");
+    });
+
+    it("is ready only when enabled and fully configured", () => {
+        expect(aiGateDecision(ready)).toBe("ready");
+    });
+});

--- a/test/architecture/ai/openaiCompatibleLogic.test.ts
+++ b/test/architecture/ai/openaiCompatibleLogic.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    buildChatRequestBody,
+    parseChatCompletion,
+    AiResponseError,
+} from "architecture/ai/openaiCompatibleLogic";
+
+describe("openai-compatible logic (#156, FR-2, AC-2)", () => {
+    it("builds a single-user-message chat request body", () => {
+        expect(buildChatRequestBody("gpt-4o-mini", "hello")).toEqual({
+            model: "gpt-4o-mini",
+            messages: [{ role: "user", content: "hello" }],
+        });
+    });
+
+    it("parses the first choice's message content", () => {
+        const json = { choices: [{ message: { role: "assistant", content: "the answer" } }] };
+        expect(parseChatCompletion(json)).toBe("the answer");
+    });
+
+    it("throws AiResponseError on a malformed response", () => {
+        expect(() => parseChatCompletion(null)).toThrow(AiResponseError);
+        expect(() => parseChatCompletion({})).toThrow(AiResponseError);
+        expect(() => parseChatCompletion({ choices: [] })).toThrow(AiResponseError);
+        expect(() => parseChatCompletion({ choices: [{ message: {} }] })).toThrow(AiResponseError);
+        expect(() => parseChatCompletion({ choices: [{ message: { content: "" } }] })).toThrow(AiResponseError);
+    });
+});

--- a/test/config/aiActionsLocale.test.ts
+++ b/test/config/aiActionsLocale.test.ts
@@ -15,6 +15,10 @@ const KEYS = [
     "ai_disabled_notice",
     "ai_not_configured_notice",
     "ai_request_failed_notice",
+    // summarize (T9)
+    "ai_summarize_label",
+    "ai_summarize_desc",
+    "ai_summarize_notice",
 ];
 
 describe("ai action i18n parity (#156, AC-5)", () => {

--- a/test/config/aiActionsLocale.test.ts
+++ b/test/config/aiActionsLocale.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+// Grows across T9–T12 with each action's keys and the settings keys.
+const KEYS = [
+    // shared settings-form keys
+    "ai_action_property_name",
+    "ai_action_property_desc",
+    "ai_action_zone_name",
+    "ai_action_zone_desc",
+    "ai_action_zone_frontmatter",
+    "ai_action_zone_context",
+    // gate notices
+    "ai_disabled_notice",
+    "ai_not_configured_notice",
+    "ai_request_failed_notice",
+];
+
+describe("ai action i18n parity (#156, AC-5)", () => {
+    it("defines every AI key in both en and es, non-empty", () => {
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/test/config/aiActionsLocale.test.ts
+++ b/test/config/aiActionsLocale.test.ts
@@ -27,7 +27,27 @@ const KEYS = [
     "ai_generate_questions_label",
     "ai_generate_questions_desc",
     "ai_generate_questions_notice",
+    // settings UI + disclosure (T12)
+    "settings_ai_heading",
+    "settings_ai_intro",
+    "settings_ai_enable_name",
+    "settings_ai_enable_desc",
+    "settings_ai_endpoint_name",
+    "settings_ai_endpoint_desc",
+    "settings_ai_endpoint_placeholder",
+    "settings_ai_apikey_name",
+    "settings_ai_apikey_desc",
+    "settings_ai_model_name",
+    "settings_ai_model_desc",
+    "settings_ai_model_placeholder",
+    "settings_ai_disclosure",
 ];
+
+describe("ai key count (#156)", () => {
+    it("ships all 31 AI keys", () => {
+        expect(KEYS.length).toBe(31);
+    });
+});
 
 describe("ai action i18n parity (#156, AC-5)", () => {
     it("defines every AI key in both en and es, non-empty", () => {

--- a/test/config/aiActionsLocale.test.ts
+++ b/test/config/aiActionsLocale.test.ts
@@ -23,6 +23,10 @@ const KEYS = [
     "ai_classify_label",
     "ai_classify_desc",
     "ai_classify_notice",
+    // generate-questions (T11)
+    "ai_generate_questions_label",
+    "ai_generate_questions_desc",
+    "ai_generate_questions_notice",
 ];
 
 describe("ai action i18n parity (#156, AC-5)", () => {

--- a/test/config/aiActionsLocale.test.ts
+++ b/test/config/aiActionsLocale.test.ts
@@ -19,6 +19,10 @@ const KEYS = [
     "ai_summarize_label",
     "ai_summarize_desc",
     "ai_summarize_notice",
+    // classify (T10)
+    "ai_classify_label",
+    "ai_classify_desc",
+    "ai_classify_notice",
 ];
 
 describe("ai action i18n parity (#156, AC-5)", () => {

--- a/test/config/aiSettingsDefaults.test.ts
+++ b/test/config/aiSettingsDefaults.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "@jest/globals";
+import { DEFAULT_SETTINGS } from "config/typing";
+
+describe("AI settings defaults (#156, FR-1, AC-1)", () => {
+    it("ships AI off by default with an empty provider config", () => {
+        expect(DEFAULT_SETTINGS.ai).toEqual({
+            enabled: false,
+            endpoint: "",
+            apiKey: "",
+            model: "",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The 🤖 **AI** action category — the epic's most architecturally sensitive change and the first to touch the network / an external provider. AI is **one optional Action category, never the core**: the whole plugin works fully with AI disabled.

**Infrastructure (the real deliverable):**
- `ai: { enabled:false, endpoint, apiKey, model }` settings block — **off by default** (mirrors `events.enabled`).
- Provider-agnostic `AiProvider` interface (`complete(prompt)`) + one built-in **OpenAI-compatible** client over Obsidian `requestUrl` (BYO endpoint/key/model — OpenAI, OpenRouter, LM Studio, Ollama…). No bundled key, no default endpoint.
- Pure `aiGateDecision` (`disabled`/`unconfigured`/`ready`) — the testable heart of "disabled ⇒ zero calls".
- `AiService` singleton + a single shared `runAiAction` **gate** every AI action runs through.
- Settings UI section with the full data-flow **disclosure**; capability disclosed in README + `capabilities-and-privacy.md` + a new `ai-provider-setup.md`.

**Three actions** (thin wrappers over one completion call): `summarize`, `classify` (parsed labels), `generate-questions` (parsed list). → **26 built-in actions**.

## Security properties (all verified by the reviewer)

- Off by default ⇒ **no network call** while disabled (gate returns before `getProvider()`); upgrade-safe via the defaults merge.
- Network **only** via `requestUrl` in `OpenAiCompatibleProvider.ts`, never `fetch`.
- API key sent only as a `Bearer` header, **never logged**, never in a Notice/error (status-only errors).
- Writes go through the note DTO only — **no foreign-note mutation**.
- Graceful degradation: missing config / network failure / malformed response → `log.error` + `Notice`, no crash, no partial write. Requests are timeout-bounded.

## Scope

Ships the infrastructure + 3 actions. `challenge-idea` / `synthesize` / `suggest-connections` are deferred to fast-follow **#184**.

## Test plan

- [x] `npm run verify` green (typecheck + oxlint + lint:obsidian 0 + **633 jest tests**)
- [x] AC-1 pure `aiGateDecision` (disabled even fully-configured); AC-2 request build + response parse incl. malformed
- [x] AC-4 category + registration + network-discipline + no-key-log + no-foreign-mutation guardrail
- [x] AC-5 i18n parity (31 keys en+es); #153/#154/#155 offline guardrails + #152 category test stay green
- [x] `obsidian-plugin-reviewer` verdict: **RAISE** (7/7 security properties confirmed, no blocking); 4 nits applied (timeout, quieter disabled no-op, clearer failure copy, drop dead re-export)

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)