### PR TITLE
feat(engine): first-class Literature → Permanent workflow (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
 - **🩺 Slip-box health dashboard** — a sidebar that surfaces **orphan** and **dead-end** notes
   so link-debt never piles up unseen.
 - **🚀 Starter flows** — one-click, ready-made flows for the four classic note types
-  (fleeting, literature, permanent, structure/MOC).
+  (fleeting, literature, permanent, structure/MOC), plus a **Literature → Permanent** composed
+  showcase that chains the cognitive actions (extract claims → find related → suggest connections →
+  identify contradictions → promote) into one runnable, fully-editable flow.
 - **🗺️ Map-of-content builder** — gather notes by tag/folder into a MOC and refresh it safely;
   re-runs never touch your own prose.
 - **✨ Connection resurfacing** — "talk to your slip-box": for the note you're reading, see
@@ -117,7 +119,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Companion pane** | Live note preview + connection suggestions while the wizard runs — link before you file. |
 | **Zettel ID action** | Stable unique IDs per note: sortable timestamp or Folgezettel branching (`21 → 21a → 21a1`). |
 | **Slip-box health** | Sidebar dashboard surfacing orphan (no outgoing links) and dead-end (no backlinks) notes. |
-| **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes. |
+| **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes, plus a **Literature → Permanent** composed showcase that chains the cognitive actions. |
 | **Map-of-content builder** | Gather notes by tag/folder into a MOC; re-runs update a managed region and keep your prose. |
 | **Connection resurfacing** | Ranked older/related notes for the active note, with a daily-spark serendipity surface. |
 | **Atomicity split** | Split a multi-topic note into linked atomic notes, leaving the source as an index/hub. |

--- a/docs/development/zettelkasten-starter-flows.md
+++ b/docs/development/zettelkasten-starter-flows.md
@@ -1,9 +1,10 @@
 # Zettelkasten starter flows
 
 Zettelkasten starter flows give newcomers **ready-made, runnable flows** for the four classic
-note types instead of building a canvas from scratch. Each starter is a complete ZettelFlow flow:
-a canvas whose single file node points at a step markdown file carrying valid
-`zettelFlowSettings` frontmatter (the same contract as the onboarding example flow).
+note types — plus a **composed showcase** flow — instead of building a canvas from scratch. Each
+starter is a complete ZettelFlow flow: a canvas whose single file node points at a step markdown
+file carrying valid `zettelFlowSettings` frontmatter (the same contract as the onboarding example
+flow).
 
 ## Installing
 
@@ -23,6 +24,35 @@ notice reports how many flows were installed and how many were skipped.
 
 Each flow targets `_ZettelFlow/examples/notes`; step files live under
 `_ZettelFlow/examples/steps` and the canvases sit in `_ZettelFlow/examples`.
+
+## Literature → Permanent (composed showcase)
+
+A fifth starter, **Literature → Permanent**, shows the engine's power by **composing the cognitive
+actions** (#153–#156) into one flow — it is assembled from the existing actions, not hard-coded, so
+every step is an independent, removable entry in the step's `actions` list. In order:
+
+1. **Input** — `title`, `source`, `summary` prompts (it starts life as a literature note).
+2. **Extract concepts** — `extract-claims` (🔍) surfaces the claims + sources the note declares.
+3. **Find related** — `find-related` (🔗) ranks notes worth linking (top 10).
+4. **Suggest connections** — `suggest-link` (🔗) surfaces the strongest link suggestions (top 5).
+5. **Identify contradictions** — `find-contradiction` (🧠) lists notes that contradict it.
+6. **Maturity signal** — `calculate-maturity` (🧠) scores how developed the note is.
+7. **Promote to Permanent** — a static, no-UI step writes `state: permanent`.
+
+**Human review** is the wizard's own preview: the wizard walks the canvas and previews the note
+before creating it, so you approve the result — no separate confirmation step is needed.
+
+**Fully offline by default.** The composed flow uses only deterministic, offline actions, so it
+works out of the box for everyone. If you [enable AI](ai-provider-setup.md), you can add the opt-in
+🤖 actions (e.g. summarize, generate questions) as extra removable steps.
+
+Notes worth knowing:
+
+- The cognitive actions read the note's position in your knowledge graph, so on a **brand-new,
+  not-yet-indexed note** they safely surface empty results until the note has connections — the
+  flow is an editable showcase of the composition.
+- The promotion writes the default lifecycle property `state`. If you renamed
+  `lifecycle.stateProperty`, edit the installed example step to match.
 
 ## Idempotent — never overwrites
 

--- a/src/application/notes/starterFlowsService.ts
+++ b/src/application/notes/starterFlowsService.ts
@@ -13,7 +13,7 @@ import type { StepPhase } from "zettelkasten/phases";
  * logic can be unit-tested with a mock vault (see {@link StarterFlowVault}).
  */
 
-export type StarterFlowType = "fleeting" | "literature" | "permanent" | "moc";
+export type StarterFlowType = "fleeting" | "literature" | "permanent" | "moc" | "literatureToPermanent";
 
 export type StarterFlowInstallResult = {
     installed: StarterFlowType[];
@@ -56,6 +56,10 @@ export const STARTER_FLOW_PATHS: Record<StarterFlowType, { canvas: string; step:
         canvas: `${EXAMPLE_FOLDER}/Structure map.canvas`,
         step: `${EXAMPLE_STEPS_FOLDER}/Structure.md`,
     },
+    literatureToPermanent: {
+        canvas: `${EXAMPLE_FOLDER}/Literature to Permanent.canvas`,
+        step: `${EXAMPLE_STEPS_FOLDER}/LiteratureToPermanent.md`,
+    },
 };
 
 interface PromptSpec {
@@ -68,11 +72,71 @@ interface PromptSpec {
 }
 
 /**
- * Builds a step markdown file with `zettelFlowSettings` frontmatter following the
- * exact shape used by the onboarding example flow. The single step is always the
- * flow root and targets the shared examples notes folder.
+ * A single `zettelFlowSettings.actions` entry — either an interactive/static `prompt`
+ * or a `hasUI:false` cognitive action (#153–#156) composed into a flow (#157).
  */
-function buildStepTemplate(label: string, prompts: PromptSpec[], body: string, phase: StepPhase): string {
+type ActionEntry =
+    | {
+        kind: "prompt";
+        id: string;
+        key: string;
+        zone: "context" | "frontmatter";
+        hasUI: boolean;
+        description?: string;
+        label?: string;
+        placeholder?: string;
+        staticBehaviour?: boolean;
+        staticValue?: string;
+    }
+    | {
+        kind: "cognitive";
+        /** Registered action type/id, e.g. `find-related`. */
+        type: string;
+        id: string;
+        key: string;
+        zone: "context" | "frontmatter";
+        limit?: number;
+    };
+
+/** Emit the YAML lines for one action entry (shared by the prompt and composed builders). */
+function emitActionEntry(entry: ActionEntry): string[] {
+    if (entry.kind === "prompt") {
+        const lines = ["    - type: prompt", `      id: ${entry.id}`];
+        if (entry.description !== undefined) lines.push(`      description: ${entry.description}`);
+        lines.push(`      hasUI: ${entry.hasUI}`);
+        lines.push(`      key: ${entry.key}`);
+        lines.push(`      zone: ${entry.zone}`);
+        if (entry.label !== undefined) lines.push(`      label: ${entry.label}`);
+        if (entry.placeholder !== undefined) lines.push(`      placeholder: ${entry.placeholder}`);
+        lines.push(`      staticBehaviour: ${entry.staticBehaviour ?? false}`);
+        if (entry.staticBehaviour && entry.staticValue !== undefined) {
+            lines.push(`      staticValue: ${entry.staticValue}`);
+        }
+        return lines;
+    }
+    const lines = [
+        `    - type: ${entry.type}`,
+        `      id: ${entry.id}`,
+        "      hasUI: false",
+        `      key: ${entry.key}`,
+        `      zone: ${entry.zone}`,
+    ];
+    if (entry.limit !== undefined) lines.push(`      limit: ${entry.limit}`);
+    return lines;
+}
+
+/**
+ * Builds a step markdown file with `zettelFlowSettings` frontmatter from an ordered list of
+ * {@link ActionEntry}s. The single step is always the flow root and targets the shared examples
+ * notes folder. The prompt-only {@link buildStepTemplate} delegates here so the four shipped flows
+ * stay byte-for-byte identical (#157, D6); the composed #157 flow passes cognitive entries too.
+ */
+function buildComposedStepTemplate(
+    label: string,
+    phase: StepPhase,
+    entries: ActionEntry[],
+    body: string
+): string {
     const lines: string[] = [];
     lines.push("---");
     lines.push("zettelFlowSettings:");
@@ -81,17 +145,7 @@ function buildStepTemplate(label: string, prompts: PromptSpec[], body: string, p
     // Default knowledge-transformation phase for the starter flow (#149) — cosmetic metadata.
     lines.push(`  phase: ${phase}`);
     lines.push("  actions:");
-    for (const prompt of prompts) {
-        lines.push("    - type: prompt");
-        lines.push(`      id: ${prompt.id}`);
-        lines.push(`      description: ${prompt.description}`);
-        lines.push("      hasUI: true");
-        lines.push(`      key: ${prompt.key}`);
-        lines.push(`      zone: ${prompt.zone}`);
-        lines.push(`      label: ${prompt.label}`);
-        lines.push(`      placeholder: ${prompt.placeholder}`);
-        lines.push("      staticBehaviour: false");
-    }
+    for (const entry of entries) lines.push(...emitActionEntry(entry));
     lines.push(`  targetFolder: ${EXAMPLE_NOTES_FOLDER}`);
     lines.push("  childrenHeader: ''");
     lines.push("  optional: false");
@@ -99,6 +153,22 @@ function buildStepTemplate(label: string, prompts: PromptSpec[], body: string, p
     lines.push("");
     lines.push(body);
     return lines.join("\n");
+}
+
+/** Prompt-only builder (the four shipped flows). Maps each prompt to an entry and delegates. */
+function buildStepTemplate(label: string, prompts: PromptSpec[], body: string, phase: StepPhase): string {
+    const entries: ActionEntry[] = prompts.map((prompt) => ({
+        kind: "prompt",
+        id: prompt.id,
+        key: prompt.key,
+        zone: prompt.zone,
+        hasUI: true,
+        description: prompt.description,
+        label: prompt.label,
+        placeholder: prompt.placeholder,
+        staticBehaviour: false,
+    }));
+    return buildComposedStepTemplate(label, phase, entries, body);
 }
 
 /** File-type canvas nodes read their config from the step frontmatter — no zettelflowConfig here. */
@@ -240,6 +310,60 @@ const STEP_TEMPLATES: Record<StarterFlowType, string> = {
         "# {{title}}\n\n{{about}}\n\n## Notes in this map\n\n",
         "CONNECT"
     ),
+    literatureToPermanent: buildComposedStepTemplate(
+        "Literature → Permanent",
+        "DEVELOP",
+        [
+            {
+                kind: "prompt",
+                id: "zf-l2p-title",
+                key: "title",
+                zone: "context",
+                hasUI: true,
+                description: "Title",
+                label: "Title",
+                placeholder: "Name this literature note...",
+                staticBehaviour: false,
+            },
+            {
+                kind: "prompt",
+                id: "zf-l2p-source",
+                key: "source",
+                zone: "frontmatter",
+                hasUI: true,
+                description: "Source",
+                label: "Source",
+                placeholder: "Book, article, video...",
+                staticBehaviour: false,
+            },
+            {
+                kind: "prompt",
+                id: "zf-l2p-summary",
+                key: "summary",
+                zone: "context",
+                hasUI: true,
+                description: "Your summary",
+                label: "Your summary",
+                placeholder: "Summarise it in your own words...",
+                staticBehaviour: false,
+            },
+            { kind: "cognitive", type: "extract-claims", id: "zf-l2p-extract", key: "claims", zone: "frontmatter" },
+            { kind: "cognitive", type: "find-related", id: "zf-l2p-related", key: "related", zone: "frontmatter", limit: 10 },
+            { kind: "cognitive", type: "suggest-link", id: "zf-l2p-suggest", key: "suggestedLinks", zone: "frontmatter", limit: 5 },
+            { kind: "cognitive", type: "find-contradiction", id: "zf-l2p-contradiction", key: "contradictions", zone: "frontmatter" },
+            { kind: "cognitive", type: "calculate-maturity", id: "zf-l2p-maturity", key: "maturity", zone: "frontmatter" },
+            {
+                kind: "prompt",
+                id: "zf-l2p-promote",
+                key: "state",
+                zone: "frontmatter",
+                hasUI: false,
+                staticBehaviour: true,
+                staticValue: "permanent",
+            },
+        ],
+        "# {{title}}\n\n**Source:** {{source}}\n\n{{summary}}\n\n## Related\n\n{{related}}\n\n## Suggested connections\n\n{{suggestedLinks}}\n\n## Contradictions\n\n{{contradictions}}\n"
+    ),
 };
 
 const CANVAS_CONTENTS: Record<StarterFlowType, string> = {
@@ -247,6 +371,7 @@ const CANVAS_CONTENTS: Record<StarterFlowType, string> = {
     literature: buildCanvas("zf-literature-001", STARTER_FLOW_PATHS.literature.step),
     permanent: buildCanvas("zf-permanent-001", STARTER_FLOW_PATHS.permanent.step),
     moc: buildCanvas("zf-moc-001", STARTER_FLOW_PATHS.moc.step),
+    literatureToPermanent: buildCanvas("zf-l2p-001", STARTER_FLOW_PATHS.literatureToPermanent.step),
 };
 
 async function ensureFolder(vault: StarterFlowVault, path: string): Promise<void> {

--- a/src/architecture/ai/OpenAiCompatibleProvider.ts
+++ b/src/architecture/ai/OpenAiCompatibleProvider.ts
@@ -10,7 +10,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
     return Promise.race([
         promise,
         new Promise<T>((_resolve, reject) =>
-            setTimeout(() => reject(new Error(`AI request timed out after ${ms}ms`)), ms)
+            window.setTimeout(() => reject(new Error(`AI request timed out after ${ms}ms`)), ms)
         ),
     ]);
 }

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -400,6 +400,8 @@ export default {
     starter_flows_permanent_description: 'Distil one atomic idea and connect it to what you already know.',
     starter_flows_moc_name: 'Structure note (map of content)',
     starter_flows_moc_description: 'Create an index note that links related notes together.',
+    starter_flows_literature_to_permanent_name: 'Literature → Permanent',
+    starter_flows_literature_to_permanent_description: 'A composed showcase: capture a source, then extract claims, find related notes, suggest connections, spot contradictions and promote to a permanent note.',
     starter_flows_install_button: 'Install selected',
     starter_flows_none_selected: 'Select at least one flow to install.',
     starter_flows_summary_notice: '{0} flows installed, {1} skipped (already present).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -400,6 +400,8 @@ export default {
     starter_flows_permanent_description: 'Destila una idea atómica y conéctala con lo que ya sabes.',
     starter_flows_moc_name: 'Nota de estructura (mapa de contenido)',
     starter_flows_moc_description: 'Crea una nota índice que enlaza notas relacionadas entre sí.',
+    starter_flows_literature_to_permanent_name: 'Literatura → Permanente',
+    starter_flows_literature_to_permanent_description: 'Un ejemplo compuesto: captura una fuente y luego extrae afirmaciones, busca notas relacionadas, sugiere conexiones, detecta contradicciones y promuévela a nota permanente.',
     starter_flows_install_button: 'Instalar seleccionados',
     starter_flows_none_selected: 'Selecciona al menos un flujo para instalar.',
     starter_flows_summary_notice: '{0} flujos instalados, {1} omitidos (ya existían).',

--- a/src/zettelkasten/modals/StarterFlowsModal.ts
+++ b/src/zettelkasten/modals/StarterFlowsModal.ts
@@ -33,6 +33,11 @@ const FLOW_ROWS: ReadonlyArray<{
         name: "starter_flows_moc_name",
         description: "starter_flows_moc_description",
     },
+    {
+        type: "literatureToPermanent",
+        name: "starter_flows_literature_to_permanent_name",
+        description: "starter_flows_literature_to_permanent_description",
+    },
 ];
 
 /**

--- a/test/application/notes/__snapshots__/starterFlowsService.test.ts.snap
+++ b/test/application/notes/__snapshots__/starterFlowsService.test.ts.snap
@@ -1,0 +1,179 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6) emits unchanged step content for fleeting/literature/permanent/moc: fleeting 1`] = `
+"---
+zettelFlowSettings:
+  root: true
+  label: Fleeting note
+  phase: CAPTURE
+  actions:
+    - type: prompt
+      id: zf-fleeting-title
+      description: Capture your thought
+      hasUI: true
+      key: title
+      zone: context
+      label: Capture your thought
+      placeholder: What is on your mind?...
+      staticBehaviour: false
+  targetFolder: _ZettelFlow/examples/notes
+  childrenHeader: ''
+  optional: false
+---
+
+# {{title}}
+"
+`;
+
+exports[`installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6) emits unchanged step content for fleeting/literature/permanent/moc: literature 1`] = `
+"---
+zettelFlowSettings:
+  root: true
+  label: Literature note
+  phase: PROCESS
+  actions:
+    - type: prompt
+      id: zf-lit-title
+      description: Title
+      hasUI: true
+      key: title
+      zone: context
+      label: Title
+      placeholder: Give this literature note a name...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-lit-source
+      description: Source
+      hasUI: true
+      key: source
+      zone: frontmatter
+      label: Source
+      placeholder: Book, article, video...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-lit-author
+      description: Author
+      hasUI: true
+      key: author
+      zone: frontmatter
+      label: Author
+      placeholder: Who created it?...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-lit-page
+      description: Page or location
+      hasUI: true
+      key: page
+      zone: frontmatter
+      label: Page or location
+      placeholder: e.g. p. 42...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-lit-summary
+      description: Your summary
+      hasUI: true
+      key: summary
+      zone: context
+      label: Your summary
+      placeholder: Summarise it in your own words...
+      staticBehaviour: false
+  targetFolder: _ZettelFlow/examples/notes
+  childrenHeader: ''
+  optional: false
+---
+
+# {{title}}
+
+**Source:** {{source}} — {{author}} (p. {{page}})
+
+{{summary}}
+"
+`;
+
+exports[`installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6) emits unchanged step content for fleeting/literature/permanent/moc: moc 1`] = `
+"---
+zettelFlowSettings:
+  root: true
+  label: Structure note
+  phase: CONNECT
+  actions:
+    - type: prompt
+      id: zf-moc-title
+      description: Map title
+      hasUI: true
+      key: title
+      zone: context
+      label: Map title
+      placeholder: Name this map of content...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-moc-about
+      description: What does this map organise?
+      hasUI: true
+      key: about
+      zone: context
+      label: What does this map organise?
+      placeholder: Describe the theme this map gathers...
+      staticBehaviour: false
+  targetFolder: _ZettelFlow/examples/notes
+  childrenHeader: ''
+  optional: false
+---
+
+# {{title}}
+
+{{about}}
+
+## Notes in this map
+
+"
+`;
+
+exports[`installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6) emits unchanged step content for fleeting/literature/permanent/moc: permanent 1`] = `
+"---
+zettelFlowSettings:
+  root: true
+  label: Permanent note
+  phase: DEVELOP
+  actions:
+    - type: prompt
+      id: zf-perm-title
+      description: Title
+      hasUI: true
+      key: title
+      zone: context
+      label: Title
+      placeholder: Name the idea...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-perm-idea
+      description: The atomic idea
+      hasUI: true
+      key: idea
+      zone: context
+      label: The atomic idea
+      placeholder: State one idea, in your own words...
+      staticBehaviour: false
+    - type: prompt
+      id: zf-perm-connect
+      description: How does this connect to what you already know?
+      hasUI: true
+      key: connect
+      zone: context
+      label: How does this connect to what you already know?
+      placeholder: Link it to existing notes...
+      staticBehaviour: false
+  targetFolder: _ZettelFlow/examples/notes
+  childrenHeader: ''
+  optional: false
+---
+
+# {{title}}
+
+{{idea}}
+
+## Connections
+
+{{connect}}
+"
+`;

--- a/test/application/notes/starterFlowsService.test.ts
+++ b/test/application/notes/starterFlowsService.test.ts
@@ -209,6 +209,16 @@ describe("installStarterFlows — AC-6 partial mix", () => {
     });
 });
 
+describe("installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6)", () => {
+    it("emits unchanged step content for fleeting/literature/permanent/moc", async () => {
+        const { vault } = makeVault();
+        await installStarterFlows(vault, ALL_TYPES);
+        for (const type of ALL_TYPES) {
+            expect(createdContent(vault, STARTER_FLOW_PATHS[type].step)).toMatchSnapshot(type);
+        }
+    });
+});
+
 describe("installStarterFlows — #149 default knowledge phases", () => {
     it("stamps each starter step with its default phase token", async () => {
         const { vault } = makeVault();

--- a/test/application/notes/starterFlowsService.test.ts
+++ b/test/application/notes/starterFlowsService.test.ts
@@ -209,6 +209,74 @@ describe("installStarterFlows — AC-6 partial mix", () => {
     });
 });
 
+/** Parse the `zettelFlowSettings.actions` list from an emitted step markdown. */
+function parseActionsBlock(content: string): Record<string, string>[] {
+    const lines = content.split("\n");
+    const start = lines.findIndex((l) => l.trim() === "actions:");
+    const entries: Record<string, string>[] = [];
+    let current: Record<string, string> | null = null;
+    for (let i = start + 1; i < lines.length; i++) {
+        const line = lines[i];
+        const head = line.match(/^ {4}- ([\w-]+): (.*)$/);
+        const field = line.match(/^ {6}([\w-]+): (.*)$/);
+        if (head) {
+            current = { [head[1]]: head[2] };
+            entries.push(current);
+        } else if (field && current) {
+            current[field[1]] = field[2];
+        } else if (/^ {0,2}\S/.test(line)) {
+            break; // dedented back to a top-level zettelFlowSettings key
+        }
+    }
+    return entries;
+}
+
+describe("literatureToPermanent composed flow (#157, AC-1/AC-2)", () => {
+    it("composes the nine cognitive/prompt entries in order (AC-1)", async () => {
+        const { vault } = makeVault();
+        await installStarterFlows(vault, ["literatureToPermanent"]);
+        const content = createdContent(vault, STARTER_FLOW_PATHS.literatureToPermanent.step);
+        const actions = parseActionsBlock(content);
+
+        expect(actions.map((a) => a.type)).toEqual([
+            "prompt", "prompt", "prompt",
+            "extract-claims", "find-related", "suggest-link", "find-contradiction", "calculate-maturity",
+            "prompt",
+        ]);
+        expect(actions.map((a) => a.key)).toEqual([
+            "title", "source", "summary",
+            "claims", "related", "suggestedLinks", "contradictions", "maturity",
+            "state",
+        ]);
+        expect(actions[4].limit).toBe("10"); // find-related
+        expect(actions[5].limit).toBe("5"); // suggest-link
+    });
+
+    it("promotes to permanent via a static, no-UI prompt entry (AC-1)", async () => {
+        const { vault } = makeVault();
+        await installStarterFlows(vault, ["literatureToPermanent"]);
+        const promote = parseActionsBlock(
+            createdContent(vault, STARTER_FLOW_PATHS.literatureToPermanent.step)
+        ).at(-1)!;
+        expect(promote.type).toBe("prompt");
+        expect(promote.key).toBe("state");
+        expect(promote.zone).toBe("frontmatter");
+        expect(promote.hasUI).toBe("false");
+        expect(promote.staticBehaviour).toBe("true");
+        expect(promote.staticValue).toBe("permanent");
+    });
+
+    it("makes every step an independent, removable top-level entry (AC-2)", async () => {
+        const { vault } = makeVault();
+        await installStarterFlows(vault, ["literatureToPermanent"]);
+        const content = createdContent(vault, STARTER_FLOW_PATHS.literatureToPermanent.step);
+        // Nine distinct "- type:" list items, each with its own key.
+        expect(content.match(/^ {4}- type:/gm)).toHaveLength(9);
+        expect(new Set(parseActionsBlock(content).map((a) => a.key)).size).toBe(9);
+        expect(content).toContain("root: true");
+    });
+});
+
 describe("installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6)", () => {
     it("emits unchanged step content for fleeting/literature/permanent/moc", async () => {
         const { vault } = makeVault();
@@ -229,6 +297,7 @@ describe("installStarterFlows — #149 default knowledge phases", () => {
             literature: "PROCESS",
             permanent: "DEVELOP",
             moc: "CONNECT",
+            literatureToPermanent: "DEVELOP",
         };
         for (const type of ALL_TYPES) {
             const content = createdContent(vault, STARTER_FLOW_PATHS[type].step);

--- a/test/application/notes/starterFlowsService.test.ts
+++ b/test/application/notes/starterFlowsService.test.ts
@@ -277,6 +277,37 @@ describe("literatureToPermanent composed flow (#157, AC-1/AC-2)", () => {
     });
 });
 
+describe("installStarterFlows — #157 create-only idempotency for the composed flow (AC-3)", () => {
+    it("fresh-installs one canvas + one step and logs once", async () => {
+        const infoSpy = jest.spyOn(log, "info");
+        const { vault } = makeVault();
+
+        const result = await installStarterFlows(vault, ["literatureToPermanent"]);
+
+        expect(result.installed).toEqual(["literatureToPermanent"]);
+        expect(vault.create).toHaveBeenCalledTimes(2);
+        const paths = createdPaths(vault);
+        expect(paths).toContain(STARTER_FLOW_PATHS.literatureToPermanent.canvas);
+        expect(paths).toContain(STARTER_FLOW_PATHS.literatureToPermanent.step);
+        expect(infoSpy).toHaveBeenCalledTimes(1);
+        infoSpy.mockRestore();
+    });
+
+    it("skips the composed flow when both files already exist, writing nothing", async () => {
+        const { vault } = makeVault([
+            STARTER_FLOW_PATHS.literatureToPermanent.canvas,
+            STARTER_FLOW_PATHS.literatureToPermanent.step,
+        ]);
+
+        const result = await installStarterFlows(vault, ["literatureToPermanent"]);
+
+        expect(result.skipped).toContain("literatureToPermanent");
+        expect(result.installed).not.toContain("literatureToPermanent");
+        expect(vault.create).not.toHaveBeenCalled();
+        expect(vault.createFolder).not.toHaveBeenCalled();
+    });
+});
+
 describe("installStarterFlows — #157 byte-for-byte guard for the four shipped flows (D6)", () => {
     it("emits unchanged step content for fleeting/literature/permanent/moc", async () => {
         const { vault } = makeVault();

--- a/test/config/starterFlowsLocale.test.ts
+++ b/test/config/starterFlowsLocale.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "starter_flows_literature_to_permanent_name",
+    "starter_flows_literature_to_permanent_description",
+];
+
+describe("literature-to-permanent starter flow i18n parity (#157, AC-6)", () => {
+    it("defines the new flow's modal keys in both en and es, non-empty", () => {
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

The capstone of the Workflow Engine layer: a fifth **installable starter flow, "Literature → Permanent"**, that shows the engine's power by **composing the cognitive actions** (#153–#156) into one runnable, fully-editable flow — assembled from the existing actions, not hard-coded.

The composed root step's `actions` (each an independent, removable entry):
1–3. **Input** — `title`, `source`, `summary` prompts (a literature note)
4. **Extract concepts** — `extract-claims` (🔍)
5. **Find related** — `find-related` (🔗, top 10)
6. **Suggest connections** — `suggest-link` (🔗, top 5)
7. **Identify contradictions** — `find-contradiction` (🧠)
8. **Maturity signal** — `calculate-maturity` (🧠)
9. **Promote to Permanent** — a static, no-UI prompt writing `state: permanent`

**Human review** is the wizard's native preview. **Fully offline by default** — no AI steps bundled (AI is opt-in; docs note how to add them). WAIT/events and multi-note atomic fan-out are out of scope.

## Technical notes

- Extended the pure starter-flow builder: a new `ActionEntry` union + shared `emitActionEntry` + `buildComposedStepTemplate`; `buildStepTemplate` now delegates — the **four shipped flows stay byte-for-byte identical** (guarded by a new snapshot test, and verified line-for-line by the reviewer).
- New `StarterFlowType = "literatureToPermanent"`, wired into `installStarterFlows`/paths/canvas + the modal (5th row) + i18n (en+es).
- Also clears a leftover #156 `lint:obsidian` warning (`window.setTimeout`).

## Test plan

- [x] `npm run verify` green (typecheck + oxlint + lint:obsidian **0** + **640 jest tests**, 4 snapshots)
- [x] AC-1: emitted step composes the 9 entries in order with the right keys/limits + `state: permanent` staticValue
- [x] AC-2: 9 independent removable top-level entries
- [x] AC-3: create-only idempotency + one `log.info` per created flow
- [x] AC-6: i18n parity (new locale test); 4 existing flows byte-for-byte unchanged (snapshot)
- [x] `obsidian-plugin-reviewer` verdict: **RAISE** (byte-identity verified, no blocking/score issues)

Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)