### PR TITLE
feat(state): idea maturity → next-move suggestion (#158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   the canvas so a flow reads as an arc of thinking.
 - **🧠 Knowledge actions** — actions that *reason about* your slip-box, not just write to a note:
   detect an **orphan**, **calculate maturity** (0–100 from state, links, sources and age), **find
-  contradictions**, and **find unanswered questions** — deterministic, offline, over the knowledge
-  model. They feed the knowledge-health layer.
+  contradictions**, **find unanswered questions**, and **suggest the next move** (a concrete
+  to-do: add a source, connect it, add an example, develop it) — deterministic, offline, over the
+  knowledge model. They feed the knowledge-health layer.
 - **🔗 Relation actions** — actions that turn connection-making into a workflow step: **find
   related** and **suggest link** rank notes worth linking by shared graph context (co-citation +
   coupling), and **create semantic relation** writes a typed edge (supports, contradicts, …) to a
@@ -112,7 +113,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | Feature | Description |
 |---|---|
 | **Canvas-based flows** | Use Obsidian's native canvas as the workflow engine — no custom DSL to learn. |
-| **26 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question — 🔗 relation actions — find related, suggest link, create semantic relation — 🔍 research actions — extract claims, compare claims, find sources, attach source — and 🤖 optional AI actions (off by default) — summarize, classify, generate questions. |
+| **27 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question, suggest next move — 🔗 relation actions — find related, suggest link, create semantic relation — 🔍 research actions — extract claims, compare claims, find sources, attach source — and 🤖 optional AI actions (off by default) — summarize, classify, generate questions. |
 | **Conditional edges** | Label a canvas arrow `if: frontmatter.type === "meeting"` to branch the workflow at runtime. |
 | **Dynamic templates** | Use `{{title}}`, `{{date}}`, `{{frontmatter.key}}`, `{{canvas.name}}` in step body templates. |
 | **Live body preview** | See the rendered note body while editing a step's template (desktop). |

--- a/docs/actions/SuggestNextMove.md
+++ b/docs/actions/SuggestNextMove.md
@@ -1,0 +1,37 @@
+# Suggest next move action
+
+🧠 A **Knowledge** action (#158). Proposes the most useful **next moves** to develop the target note,
+from its position in the [knowledge model](../architecture/knowledge-model.md) — turning the maturity
+signals (#153) into a concrete to-do. **Relation- and signal-based, no text or AI inference.**
+Deterministic and offline.
+
+## The moves
+
+Returned in a fixed priority order, only those whose precondition holds:
+
+| Move | When it fires |
+|---|---|
+| **Add a source** | the note makes a claim but cites no source |
+| **Connect it to a related note** | the note has no outgoing links |
+| **Add an example** | the note is connected but declares no `example` relation (#147) |
+| **Develop it toward the next state** | the note is in an early lifecycle state (not yet permanent/evergreen) |
+
+A note that triggers none of these is **well developed** — the action writes an affirming message
+instead of a to-do.
+
+## Options
+
+- **Result property** — where the suggested moves are written (default `nextMoves`).
+- **Write to** — `Frontmatter` or `Context` (also exposed as `{{property}}`).
+- **Target note (optional)** — the note to assess; empty ⇒ the note being built.
+
+## Result
+
+An array of short, sentence-case suggestions (or the "well developed" affirmation), plus a `Notice`.
+It composes naturally after the maturity score: [calculate maturity](CalculateMaturity.md) says *how*
+mature, this says *what to do next*. If the index isn't ready or the note isn't indexed, the action
+safely no-ops.
+
+## Capabilities
+
+File-system read + the disclosed result-property write. **No network, no AI.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - 2.24 Summarize: actions/Summarize.md
       - 2.25 Classify: actions/Classify.md
       - 2.26 Generate questions: actions/GenerateQuestions.md
+      - 2.27 Suggest next move: actions/SuggestNextMove.md
   - 3. Vault Hooks:
       - 3.1 Property Hooks:
           - 3.1.1 Overview: vault-hooks/property-hooks/overview.md

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,6 +15,7 @@ export { DetectOrphanAction } from './detectOrphan/DetectOrphanAction';
 export { CalculateMaturityAction } from './calculateMaturity/CalculateMaturityAction';
 export { FindContradictionAction } from './findContradiction/FindContradictionAction';
 export { FindUnansweredQuestionAction } from './findUnansweredQuestion/FindUnansweredQuestionAction';
+export { SuggestNextMoveAction } from './suggestNextMove/SuggestNextMoveAction';
 export { FindRelatedAction } from './findRelated/FindRelatedAction';
 export { SuggestLinkAction } from './suggestLink/SuggestLinkAction';
 export { CreateSemanticRelationAction } from './createSemanticRelation/CreateSemanticRelationAction';

--- a/src/actions/suggestNextMove/SuggestNextMoveAction.tsx
+++ b/src/actions/suggestNextMove/SuggestNextMoveAction.tsx
@@ -1,0 +1,71 @@
+import { Action, CustomZettelAction, ExecuteInfo } from "architecture/api";
+import { log } from "architecture";
+import { t } from "architecture/lang";
+import { Notice } from "obsidian";
+import { KnowledgeActionElement } from "zettelkasten";
+import { NextMoveToken, suggestNextMoves } from "./nextMoveLogic";
+import {
+    makeKnowledgeSettings,
+    readyModel,
+    resolveTargetPath,
+    writeKnowledgeResult,
+} from "../knowledge/knowledgeActionShared";
+
+type LocaleKey = Parameters<typeof t>[0];
+
+/** Each token maps to a sentence-case, localized "do this next" string at the edge (#158, D-d). */
+const MOVE_LABELS: Record<NextMoveToken, LocaleKey> = {
+    "add-source": "knowledge_next_move_add_source",
+    "connect": "knowledge_next_move_connect",
+    "add-example": "knowledge_next_move_add_example",
+    "advance-state": "knowledge_next_move_advance_state",
+};
+
+const { settings, settingsReader } = makeKnowledgeSettings(
+    "knowledge_action_next_move_label",
+    "knowledge_action_next_move_desc"
+);
+
+/** 🧠 Proposes the most useful next moves to develop the note (#158). Deterministic/offline. */
+export class SuggestNextMoveAction extends CustomZettelAction {
+    private static ICON = "compass";
+    id = "suggest-next-move";
+    category = "knowledge" as const;
+    defaultAction: Action = { type: this.id, hasUI: false, id: this.id, key: "nextMoves", zone: "frontmatter" };
+    settings = settings;
+    settingsReader = settingsReader;
+    link = "https://rafaelgb.github.io/Obsidian-ZettelFlow/actions/SuggestNextMove";
+    purpose = "Suggest the most useful next action to develop this note.";
+
+    async execute(info: ExecuteInfo) {
+        const el = info.element as unknown as KnowledgeActionElement;
+        const model = readyModel();
+        if (!model) {
+            log.debug("[suggest-next-move] knowledge index not ready — skipping");
+            return;
+        }
+        const path = resolveTargetPath(info, el);
+        if (!path) {
+            log.debug("[suggest-next-move] no target note — skipping");
+            return;
+        }
+        const moves = suggestNextMoves(model, path);
+        const value = moves.length > 0
+            ? moves.map((move) => t(MOVE_LABELS[move]))
+            : [t("knowledge_next_move_complete")];
+        writeKnowledgeResult(info, el, value);
+        new Notice(
+            moves.length > 0
+                ? t("knowledge_next_move_notice", String(moves.length))
+                : t("knowledge_next_move_complete")
+        );
+    }
+
+    getIcon(): string {
+        return SuggestNextMoveAction.ICON;
+    }
+
+    getLabel(): string {
+        return t("knowledge_action_next_move_label");
+    }
+}

--- a/src/actions/suggestNextMove/nextMoveLogic.ts
+++ b/src/actions/suggestNextMove/nextMoveLogic.ts
@@ -1,0 +1,45 @@
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import { STATE_FACTOR } from "actions/calculateMaturity/maturityLogic";
+
+/** The fixed, ordered vocabulary of concrete next moves an idea can be nudged toward (#158). */
+export type NextMoveToken = "add-source" | "connect" | "add-example" | "advance-state";
+
+export const NEXT_MOVE_TOKENS: readonly NextMoveToken[] = [
+    "add-source",
+    "connect",
+    "add-example",
+    "advance-state",
+];
+
+/** A state factor at/above this is "developed enough" — no advance-state nudge (matches #153 STATE_FACTOR). */
+const DEVELOPED_STATE_FACTOR = 0.8;
+
+/**
+ * Pure next-move suggestion (#158, FR-2/FR-3/FR-4). From an idea's model signals, returns the
+ * ordered subset of {@link NEXT_MOVE_TOKENS} whose precondition holds:
+ * - `add-source` — makes a claim but has no source;
+ * - `connect` — has no outgoing links;
+ * - `add-example` — is connected (degree > 0) but declares no outgoing `example` relation (#147);
+ * - `advance-state` — sits in an early lifecycle state (factor < 0.8, excluding `archived`).
+ *
+ * A fully-developed idea returns `[]` ("complete"); any non-complete idea returns ≥1 token (AC-2).
+ * Reads only the {@link KnowledgeModel}; deterministic, read-only, never throws. An absent/unindexed
+ * target yields `[]`. Obsidian-free (imports the #153 `STATE_FACTOR`, not the knowledge barrel).
+ */
+export function suggestNextMoves(model: KnowledgeModel, path: string): NextMoveToken[] {
+    const idea = model.get(path);
+    if (!idea) return [];
+
+    const moves: NextMoveToken[] = [];
+    const signals = idea.maturitySignals;
+
+    if (idea.claims.length > 0 && !signals.hasSources) moves.push("add-source");
+    if (signals.outDegree === 0) moves.push("connect");
+    if (signals.degree > 0 && !idea.relations.some((relation) => relation.type === "example")) {
+        moves.push("add-example");
+    }
+    const factor = STATE_FACTOR[idea.state] ?? 0;
+    if (factor < DEVELOPED_STATE_FACTOR && idea.state !== "archived") moves.push("advance-state");
+
+    return moves;
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -578,6 +578,15 @@ export default {
     knowledge_action_target_desc: 'Note to analyze; leave empty to use the note being built.',
     knowledge_find_contradiction_notice: 'Found {0} contradicting note(s).',
     knowledge_find_unanswered_question_notice: 'Found {0} unanswered question(s).',
+    // Next-move suggestion (#158)
+    knowledge_action_next_move_label: 'Suggest next move',
+    knowledge_action_next_move_desc: 'Suggest the most useful next action to develop this note.',
+    knowledge_next_move_add_source: 'Add a source',
+    knowledge_next_move_connect: 'Connect it to a related note',
+    knowledge_next_move_add_example: 'Add an example',
+    knowledge_next_move_advance_state: 'Develop it toward the next state',
+    knowledge_next_move_complete: 'Well developed — no action needed.',
+    knowledge_next_move_notice: 'Suggested {0} next move(s).',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -578,6 +578,15 @@ export default {
     knowledge_action_target_desc: 'Nota a analizar; déjalo vacío para usar la nota que se está creando.',
     knowledge_find_contradiction_notice: 'Se han encontrado {0} nota(s) contradictoria(s).',
     knowledge_find_unanswered_question_notice: 'Se han encontrado {0} pregunta(s) sin responder.',
+    // Sugerencia de siguiente movimiento (#158)
+    knowledge_action_next_move_label: 'Sugerir siguiente movimiento',
+    knowledge_action_next_move_desc: 'Sugiere la acción más útil para desarrollar esta nota.',
+    knowledge_next_move_add_source: 'Añade una fuente',
+    knowledge_next_move_connect: 'Conéctala con una nota relacionada',
+    knowledge_next_move_add_example: 'Añade un ejemplo',
+    knowledge_next_move_advance_state: 'Desarróllala hacia el siguiente estado',
+    knowledge_next_move_complete: 'Bien desarrollada — no requiere acción.',
+    knowledge_next_move_notice: 'Se han sugerido {0} movimiento(s).',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
 	CssClassesAction, DynamicSelectorAction, NumberAction, PromptAction, ScriptAction, SelectorAction,
 	TagsAction, TaskManagementAction, ZettelIdAction,
 	DetectOrphanAction, CalculateMaturityAction, FindContradictionAction, FindUnansweredQuestionAction,
+	SuggestNextMoveAction,
 	FindRelatedAction, SuggestLinkAction, CreateSemanticRelationAction,
 	ExtractClaimsAction, CompareClaimsAction, FindSourcesAction, AttachSourceAction,
 	SummarizeAction, ClassifyAction, GenerateQuestionsAction
@@ -108,6 +109,7 @@ export default class ZettelFlow extends Plugin {
 		actionsStore.registerAction(new CalculateMaturityAction());
 		actionsStore.registerAction(new FindContradictionAction());
 		actionsStore.registerAction(new FindUnansweredQuestionAction());
+		actionsStore.registerAction(new SuggestNextMoveAction());
 		actionsStore.registerAction(new FindRelatedAction());
 		actionsStore.registerAction(new SuggestLinkAction());
 		actionsStore.registerAction(new CreateSemanticRelationAction());

--- a/test/actions/knowledge/knowledgeActionsRegistration.test.ts
+++ b/test/actions/knowledge/knowledgeActionsRegistration.test.ts
@@ -11,6 +11,7 @@ const ACTION_FILES = [
     "src/actions/calculateMaturity/CalculateMaturityAction.tsx",
     "src/actions/findContradiction/FindContradictionAction.tsx",
     "src/actions/findUnansweredQuestion/FindUnansweredQuestionAction.tsx",
+    "src/actions/suggestNextMove/SuggestNextMoveAction.tsx",
 ];
 
 const LOGIC_FILES = [
@@ -18,6 +19,7 @@ const LOGIC_FILES = [
     "src/actions/calculateMaturity/maturityLogic.ts",
     "src/actions/findContradiction/findContradictionLogic.ts",
     "src/actions/findUnansweredQuestion/findUnansweredQuestionLogic.ts",
+    "src/actions/suggestNextMove/nextMoveLogic.ts",
 ];
 
 const ALL_KNOWLEDGE_SOURCES = [
@@ -31,6 +33,7 @@ const REGISTERED_CLASSES = [
     "CalculateMaturityAction",
     "FindContradictionAction",
     "FindUnansweredQuestionAction",
+    "SuggestNextMoveAction",
 ];
 
 describe("knowledge action guardrails (#153, AC-2/AC-3/AC-4)", () => {

--- a/test/actions/knowledge/nextMoveLogic.test.ts
+++ b/test/actions/knowledge/nextMoveLogic.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "@jest/globals";
+import { suggestNextMoves, NEXT_MOVE_TOKENS } from "actions/suggestNextMove/nextMoveLogic";
+import { idea, buildModel } from "./support/knowledgeFixture";
+
+describe("suggestNextMoves (#158, FR-2/FR-3/FR-4, AC-1, AC-2)", () => {
+    it("returns every token, in the fixed order, when all preconditions hold", () => {
+        // a.md: fleeting, no outgoing (connect), an incoming link (degree>0, no example → add-example),
+        // a claim without a source (add-source), early state (advance-state).
+        const model = buildModel([
+            idea("a.md", "fleeting", [], { claims: [{ text: "an idea" }] }),
+            idea("b.md", "permanent", [{ to: "a.md" }]),
+        ]);
+        expect(suggestNextMoves(model, "a.md")).toEqual([...NEXT_MOVE_TOKENS]);
+    });
+
+    it("suggests add-source for a claim with no source", () => {
+        const model = buildModel([
+            idea("s.md", "permanent", [{ to: "x.md", type: "example" }], {
+                claims: [{ text: "c" }],
+                hasSources: false,
+            }),
+        ]);
+        expect(suggestNextMoves(model, "s.md")).toContain("add-source");
+    });
+
+    it("suggests connect only when there are no outgoing links", () => {
+        const connected = buildModel([idea("c.md", "permanent", [{ to: "x.md", type: "example" }], { hasSources: true })]);
+        expect(suggestNextMoves(connected, "c.md")).not.toContain("connect");
+        const isolated = buildModel([idea("i.md", "permanent", [], { hasSources: true })]);
+        expect(suggestNextMoves(isolated, "i.md")).toContain("connect");
+    });
+
+    it("suggests add-example only when connected but lacking an example relation", () => {
+        const withExample = buildModel([idea("e.md", "permanent", [{ to: "x.md", type: "example" }], { hasSources: true })]);
+        expect(suggestNextMoves(withExample, "e.md")).not.toContain("add-example");
+        const noExample = buildModel([
+            idea("n.md", "permanent", [{ to: "x.md" }], { hasSources: true }),
+        ]);
+        expect(suggestNextMoves(noExample, "n.md")).toContain("add-example");
+    });
+
+    it("suggests advance-state for early/unknown states but not permanent/evergreen/archived", () => {
+        const complete = (state: string) =>
+            buildModel([idea("p.md", state, [{ to: "x.md", type: "example" }], { hasSources: true })]);
+        expect(suggestNextMoves(complete("fleeting"), "p.md")).toContain("advance-state");
+        expect(suggestNextMoves(complete("made-up-state"), "p.md")).toContain("advance-state");
+        expect(suggestNextMoves(complete("permanent"), "p.md")).not.toContain("advance-state");
+        expect(suggestNextMoves(complete("evergreen"), "p.md")).not.toContain("advance-state");
+        expect(suggestNextMoves(complete("archived"), "p.md")).not.toContain("advance-state");
+    });
+
+    it("returns [] for a fully-developed (complete) idea", () => {
+        const model = buildModel([
+            idea("done.md", "permanent", [{ to: "x.md", type: "example" }, { to: "y.md" }], {
+                hasSources: true,
+                claims: [{ text: "c", sources: [{ ref: "src", kind: "text" }] }],
+            }),
+        ]);
+        expect(suggestNextMoves(model, "done.md")).toEqual([]);
+    });
+
+    it("yields at least one token for any non-complete idea", () => {
+        const model = buildModel([idea("f.md", "fleeting", [])]);
+        expect(suggestNextMoves(model, "f.md").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns [] for an unknown target and is read-only + deterministic", () => {
+        const model = buildModel([idea("a.md", "fleeting", [])]);
+        expect(suggestNextMoves(model, "missing.md")).toEqual([]);
+        const before = model.all().length;
+        expect(suggestNextMoves(model, "a.md")).toEqual(suggestNextMoves(model, "a.md"));
+        expect(model.all().length).toBe(before);
+    });
+});

--- a/test/actions/knowledge/support/knowledgeFixture.ts
+++ b/test/actions/knowledge/support/knowledgeFixture.ts
@@ -1,18 +1,19 @@
 import { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
-import type { Idea } from "architecture/knowledge/model/Idea";
+import type { Idea, Source } from "architecture/knowledge/model/Idea";
 
 /**
- * Shared fixture for the #153 knowledge-action logic tests. Mirrors the `idea()` helper in
+ * Shared fixture for the #153/#158 knowledge-action logic tests. Mirrors the `idea()` helper in
  * `test/architecture/knowledge/query/queries.test.ts`; `build()` recomputes in/out degree, so the
- * seeded degree is irrelevant — only the graph shape, state, sources and `created` matter.
+ * seeded degree is irrelevant — only the graph shape, state, sources, claims and `created` matter.
  */
 export function idea(
     path: string,
     state: string,
     relations: { to: string; type?: string }[] = [],
-    opts: { hasSources?: boolean; created?: number } = {}
+    opts: { hasSources?: boolean; created?: number; claims?: { text: string; sources?: Source[] }[] } = {}
 ): Idea {
     const rels = relations.map((r) => ({ type: r.type ?? "link", from: path, to: r.to }));
+    const claims = (opts.claims ?? []).map((c) => ({ text: c.text, sources: c.sources ?? [] }));
     return {
         path,
         title: path,
@@ -20,7 +21,7 @@ export function idea(
         modified: 0,
         state,
         relations: rels,
-        claims: [],
+        claims,
         maturitySignals: {
             inDegree: 0,
             outDegree: rels.length,

--- a/test/config/knowledgeActionsLocale.test.ts
+++ b/test/config/knowledgeActionsLocale.test.ts
@@ -21,11 +21,20 @@ const KEYS = [
     "knowledge_action_target_desc",
     "knowledge_find_contradiction_notice",
     "knowledge_find_unanswered_question_notice",
+    // Next-move suggestion (#158)
+    "knowledge_action_next_move_label",
+    "knowledge_action_next_move_desc",
+    "knowledge_next_move_add_source",
+    "knowledge_next_move_connect",
+    "knowledge_next_move_add_example",
+    "knowledge_next_move_advance_state",
+    "knowledge_next_move_complete",
+    "knowledge_next_move_notice",
 ];
 
-describe("knowledge action i18n parity (#153, AC-8)", () => {
-    it("defines all 18 keys in both en and es, non-empty", () => {
-        expect(KEYS.length).toBe(18);
+describe("knowledge action i18n parity (#153/#158, AC-8)", () => {
+    it("defines all 26 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(26);
         const enMap = en as Record<string, string>;
         const esMap = es as Record<string, string>;
         for (const key of KEYS) {


### PR DESCRIPTION
## Summary

Opens the **Knowledge State** layer (🩺 Health). The maturity *score* already exists (#153, `calculate-maturity`); this adds the missing half — a concrete **next move**. A pure `suggestNextMoves(model, path)` returns the ordered subset of moves whose precondition holds over the model:

- **add-source** — makes a claim but cites no source
- **connect** — no outgoing links
- **add-example** — connected but no `example` relation (#147)
- **advance-state** — early lifecycle state (factor < 0.8, excl. `archived`)

"Complete" ⇒ `[]` (a well-developed note gets an affirming message). Surfaced via a new `hasUI:false` **`suggest-next-move`** knowledge action → **27 built-in actions**.

## Design decisions (see the issue's comment)

- **`computeMaturity`/`STATE_FACTOR` FROZEN** (imported, not changed — no rescore, #153 tests stay green).
- Pure fn returns **locale-free tokens** (what the unit test asserts); the action maps them → sentence-case en+es strings written to the note.
- One thin action mirroring #153; **no new view** (slip-box-health integration deferred). Revisions & question-based suggestions out of scope.

## Test plan

- [x] `npm run verify` green (typecheck + oxlint + lint:obsidian **0** + **648 jest tests**)
- [x] AC-1: pure, deterministic, read-only, unknown⇒[] (`nextMoveLogic.test.ts`)
- [x] AC-2: one case per token, order stability, **not-complete ⇒ ≥1**, complete ⇒ []
- [x] Category + registration guardrail grown; i18n parity (26 knowledge keys, en+es)
- [x] `obsidian-plugin-reviewer` verdict: **RAISE** (freeze confirmed, no blocking/score issues)

The one recurring nit — hardcoded-English `purpose` across all 27 actions — is tracked as a codebase-wide follow-up: #187.

Closes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)