### PR TITLE
feat(state): knowledge balance composition metrics (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
 - **🔑 Zettel ID action** — stamp every note with a stable unique identifier (sortable
   timestamp or Luhmann-style **Folgezettel** branching like `21 → 21a → 21a1`).
 - **🩺 Slip-box health dashboard** — a sidebar that surfaces **orphan** and **dead-end** notes,
-  plus a **Knowledge Debt score** (0–100) with a severity bar and a per-category drill-down
-  (unreferenced · dangling · unsourced · open questions), each item one click from a fix — so
-  knowledge-debt never piles up unseen.
+  a **Knowledge Debt score** (0–100) with a severity bar and a per-category drill-down
+  (unreferenced · dangling · unsourced · open questions) each one click from a fix, and a
+  **Knowledge balance** read-out — what your slip-box is made of (references · questions · examples ·
+  conclusions · concepts) with balance nudges — so knowledge-debt never piles up unseen.
 - **🚀 Starter flows** — one-click, ready-made flows for the four classic note types
   (fleeting, literature, permanent, structure/MOC), plus a **Literature → Permanent** composed
   showcase that chains the cognitive actions (extract claims → find related → suggest connections →
@@ -124,7 +125,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Live body preview** | See the rendered note body while editing a step's template (desktop). |
 | **Companion pane** | Live note preview + connection suggestions while the wizard runs — link before you file. |
 | **Zettel ID action** | Stable unique IDs per note: sortable timestamp or Folgezettel branching (`21 → 21a → 21a1`). |
-| **Slip-box health** | Sidebar dashboard surfacing orphan (no outgoing links) and dead-end (no backlinks) notes, plus a **Knowledge Debt score** (unreferenced · dangling · unsourced · open questions) with a drill-down and one-click fixes. |
+| **Slip-box health** | Sidebar dashboard surfacing orphan (no outgoing links) and dead-end (no backlinks) notes, a **Knowledge Debt score** (unreferenced · dangling · unsourced · open questions) with a drill-down and one-click fixes, and a **Knowledge balance** read-out (references · questions · examples · conclusions · concepts) with balance nudges. |
 | **Second-brain review** | A command that generates a weekly review note — ideas created, orphans, forgotten ideas, important-but-unreviewed — each with a next action. |
 | **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes, plus a **Literature → Permanent** composed showcase that chains the cognitive actions. |
 | **Map-of-content builder** | Gather notes by tag/folder into a MOC; re-runs update a managed region and keep your prose. |

--- a/docs/development/slipbox-health-dashboard.md
+++ b/docs/development/slipbox-health-dashboard.md
@@ -64,6 +64,27 @@ row is **one click from a fix** — it opens the offending note. The debt model
 reads the in-memory **Knowledge Model**, so it only sees *resolved* links — **broken-link** and
 **duplicate** debt are deliberately deferred (the model does not ingest unresolved links).
 
+## Knowledge balance (#161)
+
+Below the debt section the pane shows **Knowledge balance** — what your slip-box is *made of*. Every
+note is classified into exactly one composition bucket (**evidence-first** cascade) and shown as a
+count + percent:
+
+| Bucket | A note lands here when… |
+|---|---|
+| **References** | it carries a source (`hasSources`) — checked first, so a sourced note is a reference regardless of what else it does |
+| **Questions** | else it has an outgoing `question` relation |
+| **Examples** | else it has an outgoing `example` relation |
+| **Conclusions** | else it has an outgoing `supports` or `implements` relation |
+| **Concepts** | otherwise (the default) |
+
+Because buckets are mutually exclusive the percentages partition the vault (they sum to ~100%, give
+or take integer rounding). When the vault has at least `MIN_NOTES_FOR_SUGGESTIONS = 5` notes, a
+balance nudge fires for any under-represented bucket (exact, un-rounded ratio): references < 15 %,
+examples < 10 %, questions < 5 %. A balanced slip-box shows a single "well-balanced" line. The model
+(`src/architecture/knowledge/balance/knowledgeBalance.ts`) is pure, Obsidian-free and unit-tested;
+classification is from model signals only (no note-body NLP).
+
 ## Architecture
 
 ```

--- a/src/architecture/components/core/slipboxHealth/SlipboxHealthView.ts
+++ b/src/architecture/components/core/slipboxHealth/SlipboxHealthView.ts
@@ -10,6 +10,12 @@ import {
     DebtCategoryKey,
     KnowledgeDebt,
 } from "architecture/knowledge/debt/knowledgeDebt";
+import {
+    computeKnowledgeBalance,
+    CompositionBucket,
+    BalanceSuggestion,
+    KnowledgeBalance,
+} from "architecture/knowledge/balance/knowledgeBalance";
 import { classifyHealth, HealthNote, HealthResult } from "./classifyHealth";
 
 const DEBOUNCE_MS = 400;
@@ -30,6 +36,20 @@ const DEBT_DESCS: Record<DebtCategoryKey, LocaleKey> = {
     "open-question": "knowledge_debt_open_question_desc",
 };
 
+/** Composition-bucket labels + balance-suggestion lines (#161). */
+const BALANCE_LABELS: Record<CompositionBucket, LocaleKey> = {
+    reference: "knowledge_balance_reference_label",
+    question: "knowledge_balance_question_label",
+    example: "knowledge_balance_example_label",
+    conclusion: "knowledge_balance_conclusion_label",
+    concept: "knowledge_balance_concept_label",
+};
+const BALANCE_SUGGESTIONS: Record<BalanceSuggestion, LocaleKey> = {
+    "add-sources": "knowledge_balance_suggest_add_sources",
+    "add-examples": "knowledge_balance_suggest_add_examples",
+    "ask-questions": "knowledge_balance_suggest_ask_questions",
+};
+
 type ViewState = "indexing" | "ready" | "empty" | "error";
 
 export class SlipboxHealthView extends ItemView {
@@ -38,6 +58,7 @@ export class SlipboxHealthView extends ItemView {
     private state: ViewState = "indexing";
     private result: HealthResult | null = null;
     private debt: KnowledgeDebt | null = null;
+    private balance: KnowledgeBalance | null = null;
     private debounceTimer: number | undefined;
 
     constructor(leaf: WorkspaceLeaf) {
@@ -94,14 +115,22 @@ export class SlipboxHealthView extends ItemView {
                 : "ready";
 
             const index = KnowledgeIndex.getInstance();
-            this.debt = index.status === "ready" ? computeKnowledgeDebt(index.getModel()) : null;
+            if (index.status === "ready") {
+                const model = index.getModel();
+                this.debt = computeKnowledgeDebt(model);
+                this.balance = computeKnowledgeBalance(model);
+            } else {
+                this.debt = null;
+                this.balance = null;
+            }
 
             log.debug(
                 `[SlipboxHealth] scan done in ${this.result.durationMs}ms — ` +
                 `scanned=${this.result.totalScanned}, ` +
                 `orphans=${this.result.orphans.length}, ` +
                 `dead-ends=${this.result.deadEnds.length}, ` +
-                `debt=${this.debt ? this.debt.score : "n/a"}`
+                `debt=${this.debt ? this.debt.score : "n/a"}, ` +
+                `balance=${this.balance ? this.balance.total : "n/a"}`
             );
         } catch (err) {
             this.state = "error";
@@ -138,11 +167,34 @@ export class SlipboxHealthView extends ItemView {
             case "empty":
                 container.createDiv({ cls: c("slipbox-health-status"), text: t("slipbox_health_all_connected") });
                 this.renderDebtSection(container);
+                this.renderBalanceSection(container);
                 break;
             case "ready":
                 this.renderResults(container);
                 this.renderDebtSection(container);
+                this.renderBalanceSection(container);
                 break;
+        }
+    }
+
+    private renderBalanceSection(container: HTMLElement): void {
+        if (!this.balance || this.balance.total === 0) return;
+        const section = container.createDiv({ cls: c("knowledge-balance") });
+        section.createEl("h5", { text: t("knowledge_balance_heading"), cls: c("knowledge-balance-heading") });
+
+        const list = section.createDiv({ cls: c("knowledge-balance-list") });
+        for (const bucket of this.balance.buckets) {
+            const row = list.createDiv({ cls: c("knowledge-balance-row") });
+            row.createSpan({ text: t(BALANCE_LABELS[bucket.key]), cls: c("knowledge-balance-label") });
+            row.createSpan({ text: `${bucket.count} (${bucket.percent}%)`, cls: c("knowledge-balance-value") });
+        }
+
+        if (this.balance.suggestions.length === 0) {
+            section.createDiv({ cls: c("knowledge-balance-note"), text: t("knowledge_balance_balanced") });
+            return;
+        }
+        for (const suggestion of this.balance.suggestions) {
+            section.createDiv({ cls: c("knowledge-balance-suggestion"), text: t(BALANCE_SUGGESTIONS[suggestion]) });
         }
     }
 

--- a/src/architecture/knowledge/balance/knowledgeBalance.ts
+++ b/src/architecture/knowledge/balance/knowledgeBalance.ts
@@ -1,0 +1,87 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+import type { Idea } from "../model/Idea";
+
+/** What a note is *made of* — a mutually-exclusive composition role (#161). */
+export type CompositionBucket = "reference" | "question" | "example" | "conclusion" | "concept";
+
+/** A balance-improving nudge when an expected bucket is under-represented. */
+export type BalanceSuggestion = "add-sources" | "add-examples" | "ask-questions";
+
+export interface BucketMetric {
+    key: CompositionBucket;
+    count: number;
+    /** count / total as a rounded whole percent (0 when the vault is empty). */
+    percent: number;
+}
+
+export interface KnowledgeBalance {
+    total: number;
+    buckets: BucketMetric[];
+    suggestions: BalanceSuggestion[];
+}
+
+/** Fixed display/return order. */
+export const COMPOSITION_BUCKETS: readonly CompositionBucket[] = [
+    "reference",
+    "question",
+    "example",
+    "conclusion",
+    "concept",
+];
+
+/** Under a fresh vault the composition is meaningless — don't nag. */
+export const MIN_NOTES_FOR_SUGGESTIONS = 5;
+const REFERENCE_FLOOR = 15;
+const EXAMPLE_FLOOR = 10;
+const QUESTION_FLOOR = 5;
+
+/**
+ * Classify a note into exactly one composition bucket, **evidence-first** (#161): a note carrying a
+ * source is a `reference` regardless of what else it does; otherwise its dominant outgoing semantic
+ * relation decides (`question` → `example` → `supports`/`implements` = `conclusion`); else `concept`.
+ */
+export function classifyBucket(idea: Idea): CompositionBucket {
+    if (idea.maturitySignals.hasSources) return "reference";
+    const has = (type: string): boolean => idea.relations.some((relation) => relation.type === type);
+    if (has("question")) return "question";
+    if (has("example")) return "example";
+    if (has("supports") || has("implements")) return "conclusion";
+    return "concept";
+}
+
+/**
+ * Pure composition aggregate (#161). Partitions every note into one {@link CompositionBucket} and
+ * returns per-bucket `{ count, percent }` (percent rounded, summing to ~100) + the total, plus
+ * balance suggestions when an expected bucket is under its floor (only for vaults ≥
+ * {@link MIN_NOTES_FOR_SUGGESTIONS}, using the exact un-rounded ratio). Reads only the model;
+ * deterministic, read-only, never throws; empty model ⇒ total 0 / all 0% / no suggestions.
+ * Obsidian-free.
+ */
+export function computeKnowledgeBalance(model: KnowledgeModel): KnowledgeBalance {
+    const all = model.all();
+    const total = all.length;
+    const counts: Record<CompositionBucket, number> = {
+        reference: 0,
+        question: 0,
+        example: 0,
+        conclusion: 0,
+        concept: 0,
+    };
+    for (const idea of all) counts[classifyBucket(idea)]++;
+
+    const buckets: BucketMetric[] = COMPOSITION_BUCKETS.map((key) => ({
+        key,
+        count: counts[key],
+        percent: total > 0 ? Math.round((100 * counts[key]) / total) : 0,
+    }));
+
+    const suggestions: BalanceSuggestion[] = [];
+    if (total >= MIN_NOTES_FOR_SUGGESTIONS) {
+        const pct = (key: CompositionBucket): number => (100 * counts[key]) / total;
+        if (pct("reference") < REFERENCE_FLOOR) suggestions.push("add-sources");
+        if (pct("example") < EXAMPLE_FLOOR) suggestions.push("add-examples");
+        if (pct("question") < QUESTION_FLOOR) suggestions.push("ask-questions");
+    }
+
+    return { total, buckets, suggestions };
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -613,6 +613,17 @@ export default {
     knowledge_debt_unsourced_desc: 'These notes make a claim with no source.',
     knowledge_debt_open_question_label: 'Open questions',
     knowledge_debt_open_question_desc: 'These notes raise a question nothing answers yet.',
+    // Knowledge balance (#161)
+    knowledge_balance_heading: 'Knowledge balance',
+    knowledge_balance_reference_label: 'References',
+    knowledge_balance_question_label: 'Questions',
+    knowledge_balance_example_label: 'Examples',
+    knowledge_balance_conclusion_label: 'Conclusions',
+    knowledge_balance_concept_label: 'Concepts',
+    knowledge_balance_suggest_add_sources: 'Few references — add primary sources to some notes.',
+    knowledge_balance_suggest_add_examples: 'Few examples — ground some ideas with a concrete example.',
+    knowledge_balance_suggest_ask_questions: 'Few open questions — let some notes raise a question.',
+    knowledge_balance_balanced: 'Your slip-box is well-balanced.',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -613,6 +613,17 @@ export default {
     knowledge_debt_unsourced_desc: 'Estas notas afirman algo sin fuente.',
     knowledge_debt_open_question_label: 'Preguntas abiertas',
     knowledge_debt_open_question_desc: 'Estas notas plantean una pregunta que nada responde aún.',
+    // Balance de conocimiento (#161)
+    knowledge_balance_heading: 'Balance de conocimiento',
+    knowledge_balance_reference_label: 'Referencias',
+    knowledge_balance_question_label: 'Preguntas',
+    knowledge_balance_example_label: 'Ejemplos',
+    knowledge_balance_conclusion_label: 'Conclusiones',
+    knowledge_balance_concept_label: 'Conceptos',
+    knowledge_balance_suggest_add_sources: 'Pocas referencias — añade fuentes primarias a algunas notas.',
+    knowledge_balance_suggest_add_examples: 'Pocos ejemplos — aterriza algunas ideas con un ejemplo concreto.',
+    knowledge_balance_suggest_ask_questions: 'Pocas preguntas abiertas — deja que algunas notas planteen una pregunta.',
+    knowledge_balance_balanced: 'Tu slip-box está bien equilibrado.',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/styles/components/knowledgeBalance.scss
+++ b/src/styles/components/knowledgeBalance.scss
@@ -1,0 +1,46 @@
+.zettelkasten-flow__knowledge-balance {
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--background-modifier-border);
+}
+
+.zettelkasten-flow__knowledge-balance-heading {
+    margin: 0 0 0.4rem;
+    font-size: var(--font-ui-small);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__knowledge-balance-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    margin-bottom: 0.5rem;
+}
+
+.zettelkasten-flow__knowledge-balance-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: var(--font-ui-smaller);
+}
+
+.zettelkasten-flow__knowledge-balance-label {
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__knowledge-balance-value {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.zettelkasten-flow__knowledge-balance-note {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+}
+
+.zettelkasten-flow__knowledge-balance-suggestion {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-accent);
+    margin-top: 0.15rem;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -38,6 +38,7 @@
 @use 'components/companionPane.scss';
 @use 'components/slipboxHealth.scss';
 @use 'components/knowledgeDebt.scss';
+@use 'components/knowledgeBalance.scss';
 @use 'components/settingsToolkit.scss';
 @use 'components/resurface.scss';
 @use 'components/mocBuilder.scss';

--- a/test/architecture/knowledge/balance/knowledgeBalance.test.ts
+++ b/test/architecture/knowledge/balance/knowledgeBalance.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    computeKnowledgeBalance,
+    CompositionBucket,
+    COMPOSITION_BUCKETS,
+} from "architecture/knowledge/balance/knowledgeBalance";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// 10 notes across all five buckets; ref2 has BOTH a source and a question edge (evidence-first).
+const model = buildModel([
+    idea("ref1.md", "permanent", [], { hasSources: true }),
+    idea("ref2.md", "permanent", [{ to: "t", type: "question" }], { hasSources: true }),
+    idea("q.md", "permanent", [{ to: "t", type: "question" }]),
+    idea("ex.md", "permanent", [{ to: "t", type: "example" }]),
+    idea("sup.md", "permanent", [{ to: "t", type: "supports" }]),
+    idea("impl.md", "permanent", [{ to: "t", type: "implements" }]),
+    idea("c1.md", "permanent", []),
+    idea("c2.md", "permanent", [{ to: "t", type: "link" }]),
+    idea("c3.md", "permanent", []),
+    idea("c4.md", "permanent", []),
+]);
+
+const bucket = (key: CompositionBucket) =>
+    computeKnowledgeBalance(model).buckets.find((b) => b.key === key)!;
+
+describe("computeKnowledgeBalance (#161, AC-1, AC-2)", () => {
+    it("partitions notes into evidence-first buckets with counts + percents", () => {
+        expect(bucket("reference")).toEqual({ key: "reference", count: 2, percent: 20 });
+        expect(bucket("question")).toEqual({ key: "question", count: 1, percent: 10 });
+        expect(bucket("example")).toEqual({ key: "example", count: 1, percent: 10 });
+        expect(bucket("conclusion")).toEqual({ key: "conclusion", count: 2, percent: 20 });
+        expect(bucket("concept")).toEqual({ key: "concept", count: 4, percent: 40 });
+    });
+
+    it("returns buckets in the fixed order, summing counts to the total", () => {
+        const balance = computeKnowledgeBalance(model);
+        expect(balance.buckets.map((b) => b.key)).toEqual([...COMPOSITION_BUCKETS]);
+        expect(balance.buckets.reduce((s, b) => s + b.count, 0)).toBe(balance.total);
+        expect(balance.total).toBe(10);
+    });
+
+    it("emits no suggestions for a balanced vault (AC-2)", () => {
+        expect(computeKnowledgeBalance(model).suggestions).toEqual([]);
+    });
+
+    it("suggests add-sources when references are missing (AC-2)", () => {
+        const noRefs = buildModel([
+            idea("ex1.md", "permanent", [{ to: "t", type: "example" }]),
+            idea("ex2.md", "permanent", [{ to: "t", type: "example" }]),
+            idea("q1.md", "permanent", [{ to: "t", type: "question" }]),
+            idea("cc1.md", "permanent", []),
+            idea("cc2.md", "permanent", []),
+            idea("cc3.md", "permanent", []),
+            idea("cc4.md", "permanent", []),
+            idea("cc5.md", "permanent", []),
+            idea("cc6.md", "permanent", []),
+            idea("cc7.md", "permanent", []),
+        ]);
+        expect(computeKnowledgeBalance(noRefs).suggestions).toEqual(["add-sources"]);
+    });
+
+    it("does not nag a tiny vault below the minimum", () => {
+        const tiny = buildModel([
+            idea("a.md", "permanent", []),
+            idea("b.md", "permanent", []),
+            idea("c.md", "permanent", []),
+        ]);
+        expect(computeKnowledgeBalance(tiny).suggestions).toEqual([]);
+    });
+
+    it("is deterministic and returns an all-zero balance for an empty model", () => {
+        expect(computeKnowledgeBalance(model)).toEqual(computeKnowledgeBalance(model));
+        const empty = computeKnowledgeBalance(buildModel([]));
+        expect(empty.total).toBe(0);
+        expect(empty.buckets.every((b) => b.count === 0 && b.percent === 0)).toBe(true);
+        expect(empty.suggestions).toEqual([]);
+    });
+});

--- a/test/architecture/knowledge/pure-is-obsidian-free.test.ts
+++ b/test/architecture/knowledge/pure-is-obsidian-free.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 
 // src/architecture/knowledge, reached from test/architecture/knowledge/
 const KNOWLEDGE_ROOT = join(__dirname, "..", "..", "..", "src", "architecture", "knowledge");
-const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review"];
+const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance"];
 
 function collectTsFiles(dir: string): string[] {
     const out: string[] = [];

--- a/test/config/knowledgeBalanceLocale.test.ts
+++ b/test/config/knowledgeBalanceLocale.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "knowledge_balance_heading",
+    "knowledge_balance_reference_label",
+    "knowledge_balance_question_label",
+    "knowledge_balance_example_label",
+    "knowledge_balance_conclusion_label",
+    "knowledge_balance_concept_label",
+    "knowledge_balance_suggest_add_sources",
+    "knowledge_balance_suggest_add_examples",
+    "knowledge_balance_suggest_ask_questions",
+    "knowledge_balance_balanced",
+];
+
+describe("knowledge balance i18n parity (#161)", () => {
+    it("defines all 10 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(10);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

The fourth and final issue of the **Knowledge State** layer (🩺 Health): **composition metrics** — what your slip-box is *made of*. A pure `computeKnowledgeBalance(model)` partitions every note into exactly one of five evidence-first buckets — **references · questions · examples · conclusions · concepts** — returning per-bucket `{ count, percent }` + balance-suggestion tokens, surfaced as a new labeled section in the existing slip-box health pane (below the #159 debt section).

## Design decisions (see the issue comment)

- **Mutually exclusive, evidence-first classification:** reference (`hasSources`) → question → example → conclusion (`supports`/`implements`) → concept. Percentages partition the vault.
- **Suggestions** (exact ratio, only when ≥5 notes): references <15% → add-sources, examples <10% → add-examples, questions <5% → ask-questions.
- Surface = a section in the existing health pane (no new view); a labeled percentage list (no proportional bar → zero inline-style risk).

## Test plan

- [x] `npm run verify` green (typecheck + oxlint + lint:obsidian **0** + **672 jest tests**)
- [x] AC-1: 10-note fixture spanning all 5 buckets incl. the evidence-first tie-break (source + question edge ⇒ reference); exact counts/percents; empty⇒0; determinism
- [x] AC-2: zero-references ⇒ add-sources, balanced ⇒ [], <5 notes ⇒ []
- [x] i18n parity (10 keys en+es); pure module off `obsidian`/the barrel (PURE_DIRS guard)
- [x] `obsidian-plugin-reviewer`: **RAISE** — fully additive, no regression to the #159 debt/orphan sections, no score issues

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)