### PR TITLE
feat(discovery): living knowledge map — auto MOC & hub detection (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
 - **🔭 Morning discovery** — up to **three surprising connections**: pairs of notes that share
   concepts but aren't linked yet, one click from relating them. Graph-structural, offline — the
   value of a slip-box is in the links you *didn't* already know about.
+- **🗺️ Living knowledge map** — detects your **hubs** and the notes that orbit each one, and
+  regenerates as the vault changes so it never goes stale. Read-only, offline — the shape of your
+  knowledge at a glance.
 - **✂️ Atomicity split assist** — turn a multi-topic note into linked atomic notes in one
   command, leaving the source as a hub.
 - **🌱 Note lifecycle states** — give every note a **state** (🌱 fleeting → 📝 literature →
@@ -135,6 +138,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Second-brain review** | A command that generates a weekly review note — ideas created, orphans, forgotten ideas, important-but-unreviewed — each with a next action. |
 | **Thinking heatmap** | A GitHub-style calendar of ideas *developed* (state advanced, source/connection added) over the last year, fed by a private on-by-default local journal (day → count only). |
 | **Morning discovery** | Up to three unexpected connections — unlinked note pairs that share concepts — each one click from being related. Graph-structural, offline. |
+| **Living knowledge map** | A read-only sidebar that detects your hubs and the notes clustering around them, regenerating as the vault changes. |
 | **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes, plus a **Literature → Permanent** composed showcase that chains the cognitive actions. |
 | **Map-of-content builder** | Gather notes by tag/folder into a MOC; re-runs update a managed region and keep your prose. |
 | **Connection resurfacing** | Ranked older/related notes for the active note, with a daily-spark serendipity surface. |

--- a/docs/development/living-knowledge-map.md
+++ b/docs/development/living-knowledge-map.md
@@ -1,0 +1,41 @@
+# Living knowledge map
+
+The **living knowledge map** shows the *shape* of your slip-box: it detects your **hubs** — the notes
+everything clusters around — and the notes that orbit each one. Unlike a hand-made map of content, it
+**regenerates as the vault changes**, so it never goes stale.
+
+## Opening it
+
+Run **"Show knowledge map"** from the command palette, or click **Open** next to *Knowledge map* in
+**Settings → ZettelFlow → Zettelkasten toolkit**. The pane updates automatically (debounced) whenever
+notes or links change.
+
+## How the map is built
+
+The engine is **pure, graph-structural, read-only, and offline**:
+
+- **Hubs** are the well-connected notes — degree ≥ 5 (the existing `hubs` query).
+- **Every other note** is assigned to the hub it is most connected to — connection strength first
+  (a two-way link beats a one-way one), then the hub's own degree, then path, all deterministic.
+- Notes connected to no hub land in an **Unclustered** section.
+
+Each cluster shows its hub, its member count, and the member notes; clicking any name opens the note.
+It **writes nothing** — this is a *view* of the structure, distinct from the
+[MOC builder](moc-builder.md) command, which generates MOC notes.
+
+## Out of scope (for now)
+
+Flat hub-clusters only — deep multi-level / community clustering, a configurable hub threshold, a
+graph-canvas rendering, and a "build a MOC note from this cluster" action are possible follow-ups.
+
+## Architecture
+
+```
+buildKnowledgeMap(model, { hubThreshold })   (pure, Obsidian-free, unit-tested)
+  → { clusters: [{ hub, degree, members }], unclustered }
+
+KnowledgeMapView (ItemView) + KnowledgeMapComponent (show-knowledge-map command, no hotkey)
+  reads the KnowledgeIndex model → buildKnowledgeMap
+  debounced metadataCache "resolved" + vault rename/delete listeners → recompute (auto-update)
+  rows open notes via workspace.openLinkText
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,5 +78,6 @@ nav:
       - 7.14 Second-brain review: development/second-brain-review.md
       - 7.15 Thinking heatmap: development/thinking-heatmap.md
       - 7.16 Morning discovery: development/morning-discovery.md
+      - 7.17 Living knowledge map: development/living-knowledge-map.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/architecture/components/core/knowledgeMap/KnowledgeMapView.ts
+++ b/src/architecture/components/core/knowledgeMap/KnowledgeMapView.ts
@@ -1,0 +1,139 @@
+import { ItemView, WorkspaceLeaf } from "obsidian";
+import { c, log } from "architecture";
+import { t } from "architecture/lang";
+import { KnowledgeIndex } from "architecture/knowledge";
+import { buildKnowledgeMap, Cluster, KnowledgeMap } from "architecture/knowledge/map/knowledgeMap";
+
+const DEBOUNCE_MS = 400;
+
+type ViewState = "indexing" | "ready" | "empty" | "error";
+
+function basename(path: string): string {
+    const file = path.split("/").pop() ?? path;
+    return file.replace(/\.md$/i, "");
+}
+
+/**
+ * A **living knowledge map** (#164): detects your hubs and shows the notes that orbit each one, and
+ * auto-updates as the vault changes via debounced listeners (mirroring the slip-box health pane).
+ * Read-only — rows just open notes. `createEl`/`c()` only; no innerHTML/inline styles.
+ */
+export class KnowledgeMapView extends ItemView {
+    static readonly NAME = "zettelflow-knowledge-map";
+
+    private state: ViewState = "indexing";
+    private map: KnowledgeMap | null = null;
+    private debounceTimer: number | undefined;
+
+    constructor(leaf: WorkspaceLeaf) {
+        super(leaf);
+    }
+
+    getViewType(): string {
+        return KnowledgeMapView.NAME;
+    }
+
+    getDisplayText(): string {
+        return t("knowledge_map_view_title");
+    }
+
+    getIcon(): string {
+        return "network";
+    }
+
+    async onOpen(): Promise<void> {
+        this.registerVaultListeners();
+        this.recompute();
+    }
+
+    async onClose(): Promise<void> {
+        window.clearTimeout(this.debounceTimer);
+        this.contentEl.empty();
+    }
+
+    private registerVaultListeners(): void {
+        const debounced = () => {
+            window.clearTimeout(this.debounceTimer);
+            this.debounceTimer = window.setTimeout(() => this.recompute(), DEBOUNCE_MS);
+        };
+        this.registerEvent(this.app.metadataCache.on("resolved", debounced));
+        this.registerEvent(this.app.vault.on("rename", debounced));
+        this.registerEvent(this.app.vault.on("delete", debounced));
+    }
+
+    private recompute(): void {
+        try {
+            const index = KnowledgeIndex.getInstance();
+            if (index.status !== "ready") {
+                this.state = "indexing";
+                this.render();
+                return;
+            }
+            const start = Date.now();
+            this.map = buildKnowledgeMap(index.getModel());
+            this.state = this.map.clusters.length === 0 && this.map.unclustered.length === 0 ? "empty" : "ready";
+            log.debug(`[KnowledgeMap] built ${this.map.clusters.length} clusters in ${Date.now() - start}ms`);
+        } catch (error) {
+            this.state = "error";
+            log.error(`[KnowledgeMap] build failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        }
+        this.render();
+    }
+
+    private render(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        const container = contentEl.createDiv({ cls: c("knowledge-map") });
+
+        const header = container.createDiv({ cls: c("knowledge-map-header") });
+        header.createEl("h4", { text: t("knowledge_map_view_title"), cls: c("knowledge-map-title") });
+        const refresh = header.createEl("button", {
+            text: t("knowledge_map_refresh_button"),
+            cls: c("knowledge-map-refresh"),
+            attr: { "aria-label": t("knowledge_map_refresh_button") },
+        });
+        this.registerDomEvent(refresh, "click", () => this.recompute());
+
+        if (this.state === "indexing") {
+            container.createDiv({ cls: c("knowledge-map-status"), text: t("knowledge_map_indexing") });
+            return;
+        }
+        if (this.state === "error") {
+            container.createDiv({ cls: c("knowledge-map-status"), text: t("knowledge_map_error") });
+            return;
+        }
+        if (this.state === "empty" || !this.map) {
+            container.createDiv({ cls: c("knowledge-map-status"), text: t("knowledge_map_empty") });
+            return;
+        }
+
+        for (const cluster of this.map.clusters) this.renderCluster(container, cluster);
+        if (this.map.unclustered.length > 0) {
+            const section = container.createDiv({ cls: c("knowledge-map-cluster") });
+            section.createEl("h5", { text: t("knowledge_map_unclustered_heading"), cls: c("knowledge-map-hub") });
+            const list = section.createDiv({ cls: c("knowledge-map-members") });
+            for (const path of this.map.unclustered) this.renderRow(list, path);
+        }
+    }
+
+    private renderCluster(container: HTMLElement, cluster: Cluster): void {
+        const section = container.createDiv({ cls: c("knowledge-map-cluster") });
+        const head = section.createEl("h5", { cls: c("knowledge-map-hub") });
+        const name = head.createSpan({ text: basename(cluster.hub), cls: c("knowledge-map-hub-name") });
+        name.setAttribute("title", cluster.hub);
+        this.registerDomEvent(name, "click", () => void this.app.workspace.openLinkText(cluster.hub, "", false));
+        head.createSpan({
+            text: ` · ${t("knowledge_map_member_count", String(cluster.members.length))}`,
+            cls: c("knowledge-map-count"),
+        });
+        const list = section.createDiv({ cls: c("knowledge-map-members") });
+        for (const path of cluster.members) this.renderRow(list, path);
+    }
+
+    private renderRow(list: HTMLElement, path: string): void {
+        const row = list.createDiv({ cls: c("knowledge-map-member") });
+        const name = row.createSpan({ text: basename(path), cls: c("knowledge-map-member-name") });
+        name.setAttribute("title", path);
+        this.registerDomEvent(name, "click", () => void this.app.workspace.openLinkText(path, "", false));
+    }
+}

--- a/src/architecture/components/core/knowledgeMap/KnowledgeMapView.ts
+++ b/src/architecture/components/core/knowledgeMap/KnowledgeMapView.ts
@@ -92,7 +92,9 @@ export class KnowledgeMapView extends ItemView {
             cls: c("knowledge-map-refresh"),
             attr: { "aria-label": t("knowledge_map_refresh_button") },
         });
-        this.registerDomEvent(refresh, "click", () => this.recompute());
+        // Plain listener on a per-render element: it's GC'd with the node on the next empty()
+        // (registerDomEvent would retain each detached node until onClose across recomputes).
+        refresh.addEventListener("click", () => this.recompute());
 
         if (this.state === "indexing") {
             container.createDiv({ cls: c("knowledge-map-status"), text: t("knowledge_map_indexing") });
@@ -121,7 +123,7 @@ export class KnowledgeMapView extends ItemView {
         const head = section.createEl("h5", { cls: c("knowledge-map-hub") });
         const name = head.createSpan({ text: basename(cluster.hub), cls: c("knowledge-map-hub-name") });
         name.setAttribute("title", cluster.hub);
-        this.registerDomEvent(name, "click", () => void this.app.workspace.openLinkText(cluster.hub, "", false));
+        name.addEventListener("click", () => void this.app.workspace.openLinkText(cluster.hub, "", false));
         head.createSpan({
             text: ` · ${t("knowledge_map_member_count", String(cluster.members.length))}`,
             cls: c("knowledge-map-count"),
@@ -134,6 +136,6 @@ export class KnowledgeMapView extends ItemView {
         const row = list.createDiv({ cls: c("knowledge-map-member") });
         const name = row.createSpan({ text: basename(path), cls: c("knowledge-map-member-name") });
         name.setAttribute("title", path);
-        this.registerDomEvent(name, "click", () => void this.app.workspace.openLinkText(path, "", false));
+        name.addEventListener("click", () => void this.app.workspace.openLinkText(path, "", false));
     }
 }

--- a/src/architecture/knowledge/map/knowledgeMap.ts
+++ b/src/architecture/knowledge/map/knowledgeMap.ts
@@ -1,0 +1,75 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+import { hubs } from "../query/queries";
+
+/** A hub and the non-hub notes that orbit it (#164). */
+export interface Cluster {
+    hub: string;
+    degree: number;
+    members: string[];
+}
+
+export interface KnowledgeMap {
+    clusters: Cluster[];
+    unclustered: string[];
+}
+
+export interface BuildKnowledgeMapOptions {
+    hubThreshold?: number;
+}
+
+const DEFAULT_HUB_THRESHOLD = 5;
+const byPath = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+/**
+ * Pure "living knowledge map" builder (#164). Detects hubs (reusing `hubs`, degree ≥ threshold) and
+ * assigns every non-hub note to its **strongest adjacent hub** — connection strength (2 = bidirectional
+ * link, 1 = one-way) first, then hub degree, then hub path — leaving notes adjacent to no hub in
+ * `unclustered`. Hubs are cluster centers, never members. Clusters ordered by degree desc then hub
+ * path; members and `unclustered` sorted by path. Deterministic, read-only, never throws; empty model
+ * ⇒ empty map. Obsidian-free.
+ */
+export function buildKnowledgeMap(model: KnowledgeModel, opts: BuildKnowledgeMapOptions = {}): KnowledgeMap {
+    const threshold = opts.hubThreshold ?? DEFAULT_HUB_THRESHOLD;
+    const hubIdeas = hubs(model, threshold);
+    const hubPaths = new Set(hubIdeas.map((hub) => hub.path));
+    const members = new Map<string, string[]>();
+    for (const hub of hubIdeas) members.set(hub.path, []);
+
+    const unclustered: string[] = [];
+
+    for (const idea of model.all()) {
+        if (hubPaths.has(idea.path)) continue; // hubs are centers, never members
+        const out = new Set(model.outNeighbors(idea.path));
+        const incoming = new Set(model.inNeighbors(idea.path));
+
+        let best: { hub: string; strength: number; degree: number } | undefined;
+        for (const hub of hubIdeas) {
+            const strength = (out.has(hub.path) ? 1 : 0) + (incoming.has(hub.path) ? 1 : 0);
+            if (strength === 0) continue;
+            const degree = hub.maturitySignals.degree;
+            const better =
+                !best ||
+                strength > best.strength ||
+                (strength === best.strength && degree > best.degree) ||
+                (strength === best.strength && degree === best.degree && hub.path < best.hub);
+            if (better) best = { hub: hub.path, strength, degree };
+        }
+
+        if (best) {
+            const list = members.get(best.hub);
+            if (list) list.push(idea.path);
+        } else {
+            unclustered.push(idea.path);
+        }
+    }
+
+    const clusters: Cluster[] = hubIdeas.map((hub) => ({
+        hub: hub.path,
+        degree: hub.maturitySignals.degree,
+        members: (members.get(hub.path) ?? []).sort(byPath),
+    }));
+    clusters.sort((a, b) => b.degree - a.degree || byPath(a.hub, b.hub));
+    unclustered.sort(byPath);
+
+    return { clusters, unclustered };
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -656,6 +656,17 @@ export default {
     discoveries_accept_error_notice: 'Could not link the notes.',
     settings_toolkit_discoveries_name: 'Discoveries',
     settings_toolkit_discoveries_desc: 'Surface up to three unexpected connections worth making.',
+    // Living knowledge map (#164)
+    knowledge_map_view_title: 'Knowledge map',
+    command_show_knowledge_map: 'Show knowledge map',
+    knowledge_map_indexing: 'Building the index…',
+    knowledge_map_empty: 'No hubs yet — keep connecting your notes.',
+    knowledge_map_error: 'Could not build the knowledge map.',
+    knowledge_map_refresh_button: 'Refresh',
+    knowledge_map_unclustered_heading: 'Unclustered',
+    knowledge_map_member_count: '{0} notes',
+    settings_toolkit_map_name: 'Knowledge map',
+    settings_toolkit_map_desc: 'A living map of your hubs and the notes that orbit them.',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -656,6 +656,17 @@ export default {
     discoveries_accept_error_notice: 'No se han podido enlazar las notas.',
     settings_toolkit_discoveries_name: 'Descubrimientos',
     settings_toolkit_discoveries_desc: 'Muestra hasta tres conexiones inesperadas que vale la pena hacer.',
+    // Mapa de conocimiento vivo (#164)
+    knowledge_map_view_title: 'Mapa de conocimiento',
+    command_show_knowledge_map: 'Mostrar mapa de conocimiento',
+    knowledge_map_indexing: 'Construyendo el índice…',
+    knowledge_map_empty: 'Aún no hay hubs — sigue conectando tus notas.',
+    knowledge_map_error: 'No se ha podido construir el mapa de conocimiento.',
+    knowledge_map_refresh_button: 'Actualizar',
+    knowledge_map_unclustered_heading: 'Sin agrupar',
+    knowledge_map_member_count: '{0} notas',
+    settings_toolkit_map_name: 'Mapa de conocimiento',
+    settings_toolkit_map_desc: 'Un mapa vivo de tus hubs y las notas que orbitan a su alrededor.',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -26,6 +26,7 @@ import { aiSettingsGroup } from "./handlers/aiSettingsGroup";
 import { journalSettingsGroup } from "./handlers/journalSettingsGroup";
 import { ThinkingHeatmapView } from "architecture/components/core/thinkingHeatmap/ThinkingHeatmapView";
 import { DiscoveriesView } from "architecture/components/core/discoveries/DiscoveriesView";
+import { KnowledgeMapView } from "architecture/components/core/knowledgeMap/KnowledgeMapView";
 import { createExampleFlow } from "application/notes/onboardingService";
 import { SlipboxHealthView } from "architecture/components/core/slipboxHealth/SlipboxHealthView";
 import { ResurfaceView } from "architecture/components/core/resurface/ResurfaceView";
@@ -49,6 +50,7 @@ const TOOLKIT_DOCS = {
     atomicity: `${DOCS_BASE}development/atomicity-split/`,
     heatmap: `${DOCS_BASE}development/thinking-heatmap/`,
     discoveries: `${DOCS_BASE}development/morning-discovery/`,
+    map: `${DOCS_BASE}development/living-knowledge-map/`,
 } as const;
 
 export class ZettelFlowSettingsTab extends PluginSettingTab {
@@ -517,6 +519,21 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                                     )
                             );
                             addDocsButton(setting, TOOLKIT_DOCS.discoveries);
+                        },
+                    },
+                    {
+                        name: t("settings_toolkit_map_name"),
+                        desc: t("settings_toolkit_map_desc"),
+                        render: (setting) => {
+                            setting.addButton((btn) =>
+                                btn
+                                    .setButtonText(t("settings_toolkit_open_button"))
+                                    .setCta()
+                                    .onClick(() =>
+                                        void activateSidebarView(plugin.app, KnowledgeMapView.NAME)
+                                    )
+                            );
+                            addDocsButton(setting, TOOLKIT_DOCS.map);
                         },
                     },
                     {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { SlipboxHealthView } from 'architecture/components/core/slipboxHealth/Sl
 import { ResurfaceView } from 'architecture/components/core/resurface/ResurfaceView';
 import { ThinkingHeatmapView } from 'architecture/components/core/thinkingHeatmap/ThinkingHeatmapView';
 import { DiscoveriesView } from 'architecture/components/core/discoveries/DiscoveriesView';
+import { KnowledgeMapView } from 'architecture/components/core/knowledgeMap/KnowledgeMapView';
 import { allCanvasExtensions, canvas, CanvasExtension, CanvasPatcher } from 'architecture/plugin/canvas';
 import { WorkflowEventEngine } from 'architecture/plugin/events/WorkflowEventEngine';
 import { DevelopmentJournal } from 'architecture/plugin/journal/DevelopmentJournal';
@@ -91,6 +92,7 @@ export default class ZettelFlow extends Plugin {
 		this.registerView(ResurfaceView.NAME, (leaf) => new ResurfaceView(leaf));
 		this.registerView(ThinkingHeatmapView.NAME, (leaf) => new ThinkingHeatmapView(leaf));
 		this.registerView(DiscoveriesView.NAME, (leaf) => new DiscoveriesView(leaf));
+		this.registerView(KnowledgeMapView.NAME, (leaf) => new KnowledgeMapView(leaf));
 		try {
 			this.registerExtensions(CodeView.EXTENSIONS, CodeView.NAME);
 		} catch (e) {

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -16,6 +16,7 @@ import { ResurfaceComponent } from "../zcomponents/ResurfaceComponent";
 import { GenerateWeeklyReviewComponent } from "../zcomponents/GenerateWeeklyReviewComponent";
 import { ThinkingHeatmapComponent } from "../zcomponents/ThinkingHeatmapComponent";
 import { DiscoveriesComponent } from "../zcomponents/DiscoveriesComponent";
+import { KnowledgeMapComponent } from "../zcomponents/KnowledgeMapComponent";
 import { StarterFlowsComponent } from "../zcomponents/StarterFlowsComponent";
 import { MocBuilderComponent } from "../zcomponents/MocBuilderComponent";
 import { AtomicitySplitComponent } from "../zcomponents/AtomicitySplitComponent";
@@ -39,6 +40,7 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.registerComponent(new GenerateWeeklyReviewComponent(plugin));
     ZComponentsManager.registerComponent(new ThinkingHeatmapComponent(plugin));
     ZComponentsManager.registerComponent(new DiscoveriesComponent(plugin));
+    ZComponentsManager.registerComponent(new KnowledgeMapComponent(plugin));
     ZComponentsManager.registerComponent(new StarterFlowsComponent(plugin));
     ZComponentsManager.registerComponent(new MocBuilderComponent(plugin));
     ZComponentsManager.registerComponent(new AtomicitySplitComponent(plugin));

--- a/src/starters/zcomponents/KnowledgeMapComponent.ts
+++ b/src/starters/zcomponents/KnowledgeMapComponent.ts
@@ -1,0 +1,23 @@
+import { PluginComponent } from "architecture";
+import ZettelFlow from "main";
+import { t } from "architecture/lang";
+import { activateSidebarView } from "architecture/plugin";
+import { KnowledgeMapView } from "architecture/components/core/knowledgeMap/KnowledgeMapView";
+
+/** Registers the `show-knowledge-map` command (#164), opening the living knowledge-map view. No hotkey. */
+export class KnowledgeMapComponent extends PluginComponent {
+    constructor(plugin: ZettelFlow) {
+        super(plugin);
+        this.plugin = plugin;
+    }
+
+    private plugin: ZettelFlow;
+
+    onLoad(): void {
+        this.plugin.addCommand({
+            id: "show-knowledge-map",
+            name: t("command_show_knowledge_map"),
+            callback: () => void activateSidebarView(this.plugin.app, KnowledgeMapView.NAME),
+        });
+    }
+}

--- a/src/styles/components/knowledgeMap.scss
+++ b/src/styles/components/knowledgeMap.scss
@@ -1,0 +1,77 @@
+.zettelkasten-flow__knowledge-map {
+    padding: 0.5rem;
+}
+
+.zettelkasten-flow__knowledge-map-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.zettelkasten-flow__knowledge-map-title {
+    margin: 0;
+    font-size: var(--font-ui-medium);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__knowledge-map-refresh {
+    font-size: var(--font-ui-smaller);
+}
+
+.zettelkasten-flow__knowledge-map-status {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    padding: 0.5rem 0;
+}
+
+.zettelkasten-flow__knowledge-map-cluster {
+    margin-bottom: 0.75rem;
+}
+
+.zettelkasten-flow__knowledge-map-hub {
+    margin: 0 0 0.25rem;
+    font-size: var(--font-ui-small);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__knowledge-map-hub-name {
+    cursor: pointer;
+    color: var(--text-accent);
+    font-weight: var(--font-semibold);
+}
+
+.zettelkasten-flow__knowledge-map-hub-name:hover {
+    text-decoration: underline;
+}
+
+.zettelkasten-flow__knowledge-map-count {
+    color: var(--text-muted);
+    font-weight: var(--font-normal);
+}
+
+.zettelkasten-flow__knowledge-map-members {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding-left: 0.75rem;
+    border-left: 2px solid var(--background-modifier-border);
+}
+
+.zettelkasten-flow__knowledge-map-member {
+    padding: 0.1rem 0;
+}
+
+.zettelkasten-flow__knowledge-map-member-name {
+    cursor: pointer;
+    color: var(--text-accent);
+    font-size: var(--font-ui-smaller);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.zettelkasten-flow__knowledge-map-member-name:hover {
+    text-decoration: underline;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -41,6 +41,7 @@
 @use 'components/knowledgeBalance.scss';
 @use 'components/thinkingHeatmap.scss';
 @use 'components/discoveries.scss';
+@use 'components/knowledgeMap.scss';
 @use 'components/settingsToolkit.scss';
 @use 'components/resurface.scss';
 @use 'components/mocBuilder.scss';

--- a/test/architecture/knowledge/map/knowledgeMap.test.ts
+++ b/test/architecture/knowledge/map/knowledgeMap.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "@jest/globals";
+import { buildKnowledgeMap } from "architecture/knowledge/map/knowledgeMap";
+import { hubs } from "architecture/knowledge/query/queries";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// Threshold 4. Degrees: h1=7, h2=6, h3=4 (member-less, hub-only edges). shDeg(2)/shStr(3)/m*(1)/u(0) non-hubs.
+// shDeg → h1 & h2 one-way ⇒ degree tie-break → h1. shStr ↔ h2 (strength 2) beats one-way h1. u isolated.
+const model = buildModel([
+    idea("h1.md", "permanent", [{ to: "h3.md" }]),
+    idea("h2.md", "permanent", [{ to: "shStr.md" }, { to: "h3.md" }]),
+    idea("h3.md", "permanent", [{ to: "h1.md" }, { to: "h2.md" }]),
+    idea("m1.md", "permanent", [{ to: "h1.md" }]),
+    idea("m2.md", "permanent", [{ to: "h1.md" }]),
+    idea("m3.md", "permanent", [{ to: "h2.md" }]),
+    idea("m4.md", "permanent", [{ to: "h1.md" }]),
+    idea("shDeg.md", "permanent", [{ to: "h1.md" }, { to: "h2.md" }]),
+    idea("shStr.md", "permanent", [{ to: "h1.md" }, { to: "h2.md" }]),
+    idea("u.md", "permanent", []),
+]);
+
+describe("buildKnowledgeMap (#164, AC-1)", () => {
+    it("detects hubs and clusters non-hub notes by strongest adjacent hub", () => {
+        expect(buildKnowledgeMap(model, { hubThreshold: 4 })).toEqual({
+            clusters: [
+                { hub: "h1.md", degree: 7, members: ["m1.md", "m2.md", "m4.md", "shDeg.md"] },
+                { hub: "h2.md", degree: 6, members: ["m3.md", "shStr.md"] },
+                { hub: "h3.md", degree: 4, members: [] },
+            ],
+            unclustered: ["u.md"],
+        });
+    });
+
+    it("uses exactly the hubs() query for detection", () => {
+        const map = buildKnowledgeMap(model, { hubThreshold: 4 });
+        expect(new Set(map.clusters.map((c) => c.hub))).toEqual(new Set(hubs(model, 4).map((h) => h.path)));
+    });
+
+    it("is deterministic, read-only, and empty for an empty model", () => {
+        expect(buildKnowledgeMap(model, { hubThreshold: 4 })).toEqual(buildKnowledgeMap(model, { hubThreshold: 4 }));
+        expect(model.size()).toBe(10);
+        expect(buildKnowledgeMap(buildModel([]))).toEqual({ clusters: [], unclustered: [] });
+    });
+});

--- a/test/architecture/knowledge/pure-is-obsidian-free.test.ts
+++ b/test/architecture/knowledge/pure-is-obsidian-free.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 
 // src/architecture/knowledge, reached from test/architecture/knowledge/
 const KNOWLEDGE_ROOT = join(__dirname, "..", "..", "..", "src", "architecture", "knowledge");
-const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery"];
+const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map"];
 
 function collectTsFiles(dir: string): string[] {
     const out: string[] = [];

--- a/test/config/knowledgeMapLocale.test.ts
+++ b/test/config/knowledgeMapLocale.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "knowledge_map_view_title",
+    "command_show_knowledge_map",
+    "knowledge_map_indexing",
+    "knowledge_map_empty",
+    "knowledge_map_error",
+    "knowledge_map_refresh_button",
+    "knowledge_map_unclustered_heading",
+    "knowledge_map_member_count",
+    "settings_toolkit_map_name",
+    "settings_toolkit_map_desc",
+];
+
+describe("knowledge map i18n parity (#164)", () => {
+    it("defines all 10 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(10);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

A **living knowledge map** that detects your hubs and the notes orbiting each one, regenerating as the vault changes — reframing the manual MOC as a *living* map.

- Pure `buildKnowledgeMap(model, { hubThreshold=5 })` → `{ clusters, unclustered }`, reusing the existing `hubs` query + a strongest-adjacent-hub clustering rule (strength → hub degree → path). Deterministic, read-only, off the barrel.
- Read-only `KnowledgeMapView` + `show-knowledge-map` command, auto-updating via debounced `metadataCache "resolved"` + `vault rename/delete` listeners (AC-2). Rows open notes only — **no vault write** (capability None).

## Design decisions (see the issue comment)

- Flat hub-clusters (hierarchy deferred) · new read-only view (not the MOC modal) · strictly read-only for v1 (a "build MOC note" action deferred) · hub threshold fixed at 5.

## Test plan

- [x] `npm run verify` green (typecheck + oxlint + lint:obsidian **0** + **695 jest tests**)
- [x] AC-1: exact hub detection (= `hubs()`) + cluster membership + strength/degree tie-breaks + unclustered + ordering + empty + determinism, on a computed fixture
- [x] AC-2: debounced vault listeners → recompute (mirrors SlipboxHealthView)
- [x] pure module off `obsidian`/the barrel (PURE_DIRS); i18n parity (10 keys en+es)
- [x] `obsidian-plugin-reviewer`: **RAISE** — read-only confirmed, no score issues; applied the lifecycle nit (addEventListener on per-render rows)

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)