### PR TITLE
feat(discovery): traverse the graph — reasoning paths & concept navigation (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
 - **🗺️ Living knowledge map** — detects your **hubs** and the notes that orbit each one, and
   regenerates as the vault changes so it never goes stale. Read-only, offline — the shape of your
   knowledge at a glance.
+- **🕸️ Concept navigation** — walk your vault like a wiki you wrote: focus a note, see its typed
+  neighbours (in **and** out), click one to re-focus — Learning → Memory → Spacing effect → Anki,
+  no folders. Ships with headless **reasoning paths** that read the graph as an argument
+  (supports → expands → example → implements). Read-only, offline.
 - **✂️ Atomicity split assist** — turn a multi-topic note into linked atomic notes in one
   command, leaving the source as a hub.
 - **🌱 Note lifecycle states** — give every note a **state** (🌱 fleeting → 📝 literature →
@@ -141,6 +145,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Thinking heatmap** | A GitHub-style calendar of ideas *developed* (state advanced, source/connection added) over the last year, fed by a private on-by-default local journal (day → count only). |
 | **Morning discovery** | Up to three unexpected connections — unlinked note pairs that share concepts — each one click from being related. Graph-structural, offline. |
 | **Living knowledge map** | A read-only sidebar that detects your hubs and the notes clustering around them, regenerating as the vault changes. |
+| **Concept navigation** | Walk your vault by typed relation (in + out) — focus a note, click a neighbour to re-focus, no folders — plus argument-forward reasoning paths over the same graph. Read-only, offline. |
 | **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes, plus a **Literature → Permanent** composed showcase that chains the cognitive actions. |
 | **Map-of-content builder** | Gather notes by tag/folder into a MOC; re-runs update a managed region and keep your prose. |
 | **Connection resurfacing** | Ranked older/related notes for the active note, with a daily-spark serendipity surface. |

--- a/docs/development/concept-navigation.md
+++ b/docs/development/concept-navigation.md
@@ -1,0 +1,61 @@
+# Concept navigation
+
+**Concept navigation** lets you *walk* your vault the way you walk Wikipedia — but it's a wiki you
+wrote. Pick a focus note and it shows the notes it connects to by **typed relation**, in **both
+directions**; click any one to **re-focus** on it. Learning → Memory → Spacing effect → Anki, without
+ever opening a folder.
+
+It's the first tool of the 🕸️ **Graph** pillar, and it ships with a second, headless traversal —
+**reasoning paths** — that reads the same typed-relations graph as an argument.
+
+## Opening it
+
+Run **"Show concept navigation"** from the command palette, or click **Open** next to *Concept
+navigation* in **Settings → ZettelFlow → Zettelkasten toolkit**. The pane updates automatically
+(debounced) whenever notes or links change.
+
+## Navigating
+
+- **Entry point.** With nothing focused, the pane seeds from the **active note** if it's indexed,
+  otherwise it lists your **hubs** (the `hubs` query, degree ≥ 5) as starting points.
+- **Focus.** The focused note's neighbours are grouped under **Leads to** (its outgoing typed
+  relations) and **Referenced by** (the notes that point at it), each split by relation type
+  (`supports`, `contradicts`, `expands`, `question`, `example`, `implements`, `link`).
+- **Walk.** Click a neighbour to re-focus the pane on it — the hub→neighbour loop. Click the focus
+  name to open the note in the editor; **Hubs** returns to the entry list.
+
+The grouping engine `conceptNeighbors` is **pure, read-only, offline** and uses the **whole**
+relation vocabulary — every typed neighbour is walkable, unlike reasoning paths below. It **writes
+nothing**.
+
+## Reasoning paths
+
+`reasoningPaths(model, start, { maxDepth })` follows only the **argument-forward** relations —
+`supports → expands → example → implements`, in that precedence — to return the **maximal argument
+chains** leaving a note (an idea supported, expanded, exemplified, then implemented). It is
+cycle-safe (never revisits a note on a path), depth-bounded (default 5 steps), deterministic, and
+Obsidian-free. Counter-argument (`contradicts`), open `question`, `inspired-by` and plain `link`
+edges are deliberately excluded so a path reads as a single line of reasoning — challenging an idea
+is the job of [find contradiction](../actions/FindContradiction.md) and the
+[thinking simulator](../actions/ThinkingSimulator.md). This function is a tested, documented
+foundation; a dedicated argument-path view is a likely follow-up.
+
+## Out of scope (for now)
+
+Read-only navigation only — no graph-canvas rendering, no path pinning/bookmarking, no configurable
+hub threshold or forward-relation set, and no argument-path rendering surface yet.
+
+## Architecture
+
+```
+reasoningPaths(model, start, { maxDepth })        (pure, Obsidian-free, unit-tested)
+  → [{ start, steps: [{ type, to }] }]            maximal, cycle-safe, forward-only
+
+conceptNeighbors(model, path)                     (pure, Obsidian-free, unit-tested)
+  → { focus, groups: [{ type, direction, targets }] }   out-before-in, vocabulary order
+
+ConceptNavView (ItemView) + ConceptNavComponent (show-concept-nav command, no hotkey)
+  reads the KnowledgeIndex model → conceptNeighbors(focus)
+  entry = active indexed note else hubs()
+  clicking a neighbour re-focuses; debounced metadataCache/vault listeners → recompute
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,5 +80,6 @@ nav:
       - 7.15 Thinking heatmap: development/thinking-heatmap.md
       - 7.16 Morning discovery: development/morning-discovery.md
       - 7.17 Living knowledge map: development/living-knowledge-map.md
+      - 7.18 Concept navigation: development/concept-navigation.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/architecture/components/core/conceptNav/ConceptNavView.ts
+++ b/src/architecture/components/core/conceptNav/ConceptNavView.ts
@@ -27,6 +27,8 @@ export class ConceptNavView extends ItemView {
     private state: ViewState = "indexing";
     private model: KnowledgeModel | null = null;
     private focus: string | null = null;
+    /** Set when the user deliberately returns to the hub list — suppresses active-note re-seeding. */
+    private userChoseHubs = false;
     private neighbors: ConceptNeighbors | null = null;
     private entryHubs: string[] = [];
     private debounceTimer: number | undefined;
@@ -78,9 +80,10 @@ export class ConceptNavView extends ItemView {
             }
             const start = Date.now();
             this.model = index.getModel();
-            // Drop a focus whose note is gone; otherwise seed from the active note when unfocused.
+            // Drop a focus whose note is gone; otherwise seed from the active note when unfocused,
+            // unless the user deliberately went back to the hub list (then keep them there).
             if (this.focus && !this.model.get(this.focus)) this.focus = null;
-            if (!this.focus) {
+            if (!this.focus && !this.userChoseHubs) {
                 const active = this.app.workspace.getActiveFile();
                 if (active && this.model.get(active.path)) this.focus = active.path;
             }
@@ -107,6 +110,7 @@ export class ConceptNavView extends ItemView {
     /** Re-focus the pane on a note (the hub→neighbour walk) without re-reading the index. */
     private focusOn(path: string): void {
         this.focus = path;
+        this.userChoseHubs = false;
         if (this.model) {
             this.deriveState();
             this.render();
@@ -161,12 +165,13 @@ export class ConceptNavView extends ItemView {
         name.setAttribute("title", neighbors.focus);
         name.addEventListener("click", () => void this.app.workspace.openLinkText(neighbors.focus, "", false));
         const back = focusRow.createEl("button", {
-            text: t("concept_nav_entry_heading"),
+            text: t("concept_nav_back_button"),
             cls: c("concept-nav-back"),
-            attr: { "aria-label": t("concept_nav_entry_heading") },
+            attr: { "aria-label": t("concept_nav_back_button") },
         });
         back.addEventListener("click", () => {
             this.focus = null;
+            this.userChoseHubs = true;
             this.deriveState();
             this.render();
         });

--- a/src/architecture/components/core/conceptNav/ConceptNavView.ts
+++ b/src/architecture/components/core/conceptNav/ConceptNavView.ts
@@ -184,7 +184,7 @@ export class ConceptNavView extends ItemView {
                 lastDirection = group.direction;
             }
             const section = container.createDiv({ cls: c("concept-nav-group") });
-            section.createEl("span", { text: group.type, cls: c("concept-nav-type") });
+            section.createSpan({ text: group.type, cls: c("concept-nav-type") });
             const list = section.createDiv({ cls: c("concept-nav-list") });
             for (const target of group.targets) this.renderNavRow(list, target);
         }

--- a/src/architecture/components/core/conceptNav/ConceptNavView.ts
+++ b/src/architecture/components/core/conceptNav/ConceptNavView.ts
@@ -1,0 +1,199 @@
+import { ItemView, WorkspaceLeaf } from "obsidian";
+import { c, log } from "architecture";
+import { t } from "architecture/lang";
+import { KnowledgeIndex } from "architecture/knowledge";
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import { ConceptNeighbors, conceptNeighbors } from "architecture/knowledge/traverse/conceptNeighbors";
+import { hubs } from "architecture/knowledge/query/queries";
+
+const DEBOUNCE_MS = 400;
+
+type ViewState = "indexing" | "entry" | "focused" | "empty" | "error";
+
+function basename(path: string): string {
+    const file = path.split("/").pop() ?? path;
+    return file.replace(/\.md$/i, "");
+}
+
+/**
+ * **Concept navigation** (#166): walk the vault like a wiki you wrote. A focus note shows its typed
+ * neighbours (outgoing and incoming); clicking one **re-focuses** the pane on it. With no focus it
+ * seeds from the active indexed note, else the vault's hubs. Auto-updates via debounced listeners
+ * (mirroring the knowledge-map pane). Read-only — `createEl`/`c()` only; no innerHTML/inline styles.
+ */
+export class ConceptNavView extends ItemView {
+    static readonly NAME = "zettelflow-concept-nav";
+
+    private state: ViewState = "indexing";
+    private model: KnowledgeModel | null = null;
+    private focus: string | null = null;
+    private neighbors: ConceptNeighbors | null = null;
+    private entryHubs: string[] = [];
+    private debounceTimer: number | undefined;
+
+    constructor(leaf: WorkspaceLeaf) {
+        super(leaf);
+    }
+
+    getViewType(): string {
+        return ConceptNavView.NAME;
+    }
+
+    getDisplayText(): string {
+        return t("concept_nav_view_title");
+    }
+
+    getIcon(): string {
+        return "waypoints";
+    }
+
+    async onOpen(): Promise<void> {
+        this.registerVaultListeners();
+        this.recompute();
+    }
+
+    async onClose(): Promise<void> {
+        window.clearTimeout(this.debounceTimer);
+        this.contentEl.empty();
+    }
+
+    private registerVaultListeners(): void {
+        const debounced = () => {
+            window.clearTimeout(this.debounceTimer);
+            this.debounceTimer = window.setTimeout(() => this.recompute(), DEBOUNCE_MS);
+        };
+        this.registerEvent(this.app.metadataCache.on("resolved", debounced));
+        this.registerEvent(this.app.vault.on("rename", debounced));
+        this.registerEvent(this.app.vault.on("delete", debounced));
+    }
+
+    private recompute(): void {
+        try {
+            const index = KnowledgeIndex.getInstance();
+            if (index.status !== "ready") {
+                this.state = "indexing";
+                this.model = null;
+                this.render();
+                return;
+            }
+            const start = Date.now();
+            this.model = index.getModel();
+            // Drop a focus whose note is gone; otherwise seed from the active note when unfocused.
+            if (this.focus && !this.model.get(this.focus)) this.focus = null;
+            if (!this.focus) {
+                const active = this.app.workspace.getActiveFile();
+                if (active && this.model.get(active.path)) this.focus = active.path;
+            }
+            this.deriveState();
+            log.debug(`[ConceptNav] recomputed (focus=${this.focus ?? "none"}) in ${Date.now() - start}ms`);
+        } catch (error) {
+            this.state = "error";
+            log.error(`[ConceptNav] recompute failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        }
+        this.render();
+    }
+
+    private deriveState(): void {
+        if (!this.model) return;
+        if (this.focus) {
+            this.neighbors = conceptNeighbors(this.model, this.focus);
+            this.state = "focused";
+        } else {
+            this.entryHubs = hubs(this.model).map((hub) => hub.path).sort();
+            this.state = this.entryHubs.length === 0 ? "empty" : "entry";
+        }
+    }
+
+    /** Re-focus the pane on a note (the hub→neighbour walk) without re-reading the index. */
+    private focusOn(path: string): void {
+        this.focus = path;
+        if (this.model) {
+            this.deriveState();
+            this.render();
+        }
+    }
+
+    private render(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        const container = contentEl.createDiv({ cls: c("concept-nav") });
+
+        const header = container.createDiv({ cls: c("concept-nav-header") });
+        header.createEl("h4", { text: t("concept_nav_view_title"), cls: c("concept-nav-title") });
+        const refresh = header.createEl("button", {
+            text: t("concept_nav_refresh_button"),
+            cls: c("concept-nav-refresh"),
+            attr: { "aria-label": t("concept_nav_refresh_button") },
+        });
+        refresh.addEventListener("click", () => this.recompute());
+
+        if (this.state === "indexing") {
+            container.createDiv({ cls: c("concept-nav-status"), text: t("concept_nav_indexing") });
+            return;
+        }
+        if (this.state === "error") {
+            container.createDiv({ cls: c("concept-nav-status"), text: t("concept_nav_error") });
+            return;
+        }
+        if (this.state === "empty") {
+            container.createDiv({ cls: c("concept-nav-status"), text: t("concept_nav_empty") });
+            return;
+        }
+        if (this.state === "entry") {
+            this.renderEntry(container);
+            return;
+        }
+        this.renderFocused(container);
+    }
+
+    private renderEntry(container: HTMLElement): void {
+        container.createEl("h5", { text: t("concept_nav_entry_heading"), cls: c("concept-nav-heading") });
+        const list = container.createDiv({ cls: c("concept-nav-list") });
+        for (const path of this.entryHubs) this.renderNavRow(list, path);
+    }
+
+    private renderFocused(container: HTMLElement): void {
+        const neighbors = this.neighbors;
+        if (!neighbors) return;
+
+        const focusRow = container.createDiv({ cls: c("concept-nav-focus") });
+        const name = focusRow.createSpan({ text: basename(neighbors.focus), cls: c("concept-nav-focus-name") });
+        name.setAttribute("title", neighbors.focus);
+        name.addEventListener("click", () => void this.app.workspace.openLinkText(neighbors.focus, "", false));
+        const back = focusRow.createEl("button", {
+            text: t("concept_nav_entry_heading"),
+            cls: c("concept-nav-back"),
+            attr: { "aria-label": t("concept_nav_entry_heading") },
+        });
+        back.addEventListener("click", () => {
+            this.focus = null;
+            this.deriveState();
+            this.render();
+        });
+
+        if (neighbors.groups.length === 0) {
+            container.createDiv({ cls: c("concept-nav-status"), text: t("concept_nav_empty") });
+            return;
+        }
+
+        let lastDirection: "out" | "in" | null = null;
+        for (const group of neighbors.groups) {
+            if (group.direction !== lastDirection) {
+                const heading = group.direction === "out" ? t("concept_nav_out_heading") : t("concept_nav_in_heading");
+                container.createEl("h5", { text: heading, cls: c("concept-nav-heading") });
+                lastDirection = group.direction;
+            }
+            const section = container.createDiv({ cls: c("concept-nav-group") });
+            section.createEl("span", { text: group.type, cls: c("concept-nav-type") });
+            const list = section.createDiv({ cls: c("concept-nav-list") });
+            for (const target of group.targets) this.renderNavRow(list, target);
+        }
+    }
+
+    private renderNavRow(list: HTMLElement, path: string): void {
+        const row = list.createDiv({ cls: c("concept-nav-row") });
+        const name = row.createSpan({ text: basename(path), cls: c("concept-nav-row-name") });
+        name.setAttribute("title", path);
+        name.addEventListener("click", () => this.focusOn(path));
+    }
+}

--- a/src/architecture/knowledge/traverse/conceptNeighbors.ts
+++ b/src/architecture/knowledge/traverse/conceptNeighbors.ts
@@ -1,0 +1,65 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+import { ALL_RELATION_TYPES } from "../relations/vocabulary";
+import { incomingRelations } from "../query/queries";
+
+/** One direction/type bucket of a focus note's neighbours (targets sorted by path). */
+export interface NeighborGroup {
+    type: string;
+    direction: "out" | "in";
+    targets: string[];
+}
+
+/** The full typed neighbourhood of a focus note — the data the concept-navigation view renders. */
+export interface ConceptNeighbors {
+    focus: string;
+    groups: NeighborGroup[];
+}
+
+/** Present types ordered by the #147 vocabulary; unknown types come after, alphabetically. */
+function orderedTypes(present: Iterable<string>): string[] {
+    const set = new Set(present);
+    const known = ALL_RELATION_TYPES.filter((type) => set.has(type));
+    const unknown = [...set].filter((type) => !ALL_RELATION_TYPES.includes(type)).sort();
+    return [...known, ...unknown];
+}
+
+function groupsFor(
+    direction: "out" | "in",
+    byType: Map<string, Set<string>>
+): NeighborGroup[] {
+    return orderedTypes(byType.keys()).map((type) => ({
+        type,
+        direction,
+        targets: [...byType.get(type)!].sort(),
+    }));
+}
+
+/**
+ * Pure concept-navigation data (#166, FR-6). Groups a focus note's **outgoing and incoming** typed
+ * relations (the whole #147 vocabulary — `contradicts`/`question`/`link` are all walkable, unlike
+ * the argument-only {@link reasoningPaths}) so the view can walk the vault like a wiki you wrote.
+ *
+ * Groups are ordered out-before-in, then by vocabulary order, with targets sorted by path. An
+ * unknown/unindexed focus yields `{ focus, groups: [] }`. Reads only the {@link KnowledgeModel};
+ * deterministic, read-only, never throws. Obsidian-free.
+ */
+export function conceptNeighbors(model: KnowledgeModel, path: string): ConceptNeighbors {
+    const idea = model.get(path);
+    if (!idea) return { focus: path, groups: [] };
+
+    const outByType = new Map<string, Set<string>>();
+    for (const relation of idea.relations) {
+        const set = outByType.get(relation.type) ?? new Set<string>();
+        set.add(relation.to);
+        outByType.set(relation.type, set);
+    }
+
+    const inByType = new Map<string, Set<string>>();
+    for (const relation of incomingRelations(model, path)) {
+        const set = inByType.get(relation.type) ?? new Set<string>();
+        set.add(relation.from);
+        inByType.set(relation.type, set);
+    }
+
+    return { focus: path, groups: [...groupsFor("out", outByType), ...groupsFor("in", inByType)] };
+}

--- a/src/architecture/knowledge/traverse/reasoningPaths.ts
+++ b/src/architecture/knowledge/traverse/reasoningPaths.ts
@@ -1,0 +1,108 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+
+/**
+ * The constructive **argument-forward** relation vocabulary (#166), in traversal precedence order:
+ * an idea is *supported*, then *expanded*, then *exemplified*, then *implemented* — the arc of an
+ * argument. Counter-argument (`contradicts`), open `question`, `inspired-by` and the plain `link`
+ * fallback are deliberately excluded so a reasoning path reads as a single line of reasoning.
+ */
+export const ARGUMENT_FORWARD_RELATION_TYPES = ["supports", "expands", "example", "implements"] as const;
+
+export type ArgumentForwardType = (typeof ARGUMENT_FORWARD_RELATION_TYPES)[number];
+
+/** One taken edge in a reasoning path: the relation type followed and the note it reached. */
+export interface PathStep {
+    type: string;
+    to: string;
+}
+
+/** A maximal argument chain from `start`, as the ordered forward edges taken. */
+export interface Path {
+    start: string;
+    steps: PathStep[];
+}
+
+export interface ReasoningPathsOptions {
+    /** Maximum number of steps in a returned chain (default 5). */
+    maxDepth?: number;
+}
+
+const DEFAULT_MAX_DEPTH = 5;
+
+/** The forward edges leaving `path`, grouped by {@link ARGUMENT_FORWARD_RELATION_TYPES} precedence. */
+function forwardEdges(model: KnowledgeModel, path: string): PathStep[] {
+    const idea = model.get(path);
+    if (!idea) return [];
+    const edges: PathStep[] = [];
+    for (const type of ARGUMENT_FORWARD_RELATION_TYPES) {
+        for (const relation of idea.relations) {
+            if (relation.type === type) edges.push({ type, to: relation.to });
+        }
+    }
+    return edges;
+}
+
+/**
+ * Pure reasoning-path traversal (#166, FR-2..FR-5). From `start`, follows the argument-forward
+ * relations depth-first (in precedence order) and returns every **maximal** chain — a chain ends
+ * when its last note has no unvisited forward edge, or when `maxDepth` steps are reached. A note is
+ * never revisited within a path (cycle-safe). An unknown/unindexed start, or a start with no forward
+ * edge, yields `[]`.
+ *
+ * Deterministic: paths are deduped and sorted by their step sequence (relation precedence, then the
+ * reached note paths). Reads only the {@link KnowledgeModel}; read-only, never throws. Obsidian-free.
+ */
+export function reasoningPaths(
+    model: KnowledgeModel,
+    start: string,
+    opts: ReasoningPathsOptions = {}
+): Path[] {
+    if (!model.get(start)) return [];
+    const maxDepth = opts.maxDepth ?? DEFAULT_MAX_DEPTH;
+
+    const paths: Path[] = [];
+    const steps: PathStep[] = [];
+    const visited = new Set<string>([start]);
+
+    const walk = (node: string): void => {
+        const edges = forwardEdges(model, node).filter((edge) => !visited.has(edge.to));
+        if (edges.length === 0 || steps.length >= maxDepth) {
+            if (steps.length > 0) paths.push({ start, steps: [...steps] });
+            return;
+        }
+        for (const edge of edges) {
+            visited.add(edge.to);
+            steps.push(edge);
+            walk(edge.to);
+            steps.pop();
+            visited.delete(edge.to);
+        }
+    };
+    walk(start);
+
+    return dedupeAndSort(paths);
+}
+
+const precedenceOf = (type: string): number => ARGUMENT_FORWARD_RELATION_TYPES.indexOf(type as ArgumentForwardType);
+
+function comparePaths(a: Path, b: Path): number {
+    const shared = Math.min(a.steps.length, b.steps.length);
+    for (let i = 0; i < shared; i++) {
+        const byType = precedenceOf(a.steps[i].type) - precedenceOf(b.steps[i].type);
+        if (byType !== 0) return byType;
+        if (a.steps[i].to !== b.steps[i].to) return a.steps[i].to < b.steps[i].to ? -1 : 1;
+    }
+    return a.steps.length - b.steps.length;
+}
+
+function dedupeAndSort(paths: Path[]): Path[] {
+    const seen = new Set<string>();
+    const unique: Path[] = [];
+    for (const path of paths) {
+        const key = path.steps.map((step) => `${step.type}>${step.to}`).join("|");
+        if (seen.has(key)) continue;
+        seen.add(key);
+        unique.push(path);
+    }
+    return unique.sort(comparePaths);
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -690,6 +690,7 @@ export default {
     concept_nav_entry_heading: 'Hubs',
     concept_nav_out_heading: 'Leads to',
     concept_nav_in_heading: 'Referenced by',
+    concept_nav_back_button: 'Back to hubs',
     settings_toolkit_concept_nav_name: 'Concept navigation',
     settings_toolkit_concept_nav_desc: 'Walk your notes by concept, like a Wikipedia you wrote.',
     // Relation actions (#154)

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -680,6 +680,18 @@ export default {
     knowledge_map_member_count: '{0} notes',
     settings_toolkit_map_name: 'Knowledge map',
     settings_toolkit_map_desc: 'A living map of your hubs and the notes that orbit them.',
+    // Concept navigation (#166)
+    concept_nav_view_title: 'Concept navigation',
+    command_show_concept_nav: 'Show concept navigation',
+    concept_nav_indexing: 'Building the index…',
+    concept_nav_empty: 'No concepts to navigate yet — keep connecting your notes.',
+    concept_nav_error: 'Could not load concept navigation.',
+    concept_nav_refresh_button: 'Refresh',
+    concept_nav_entry_heading: 'Hubs',
+    concept_nav_out_heading: 'Leads to',
+    concept_nav_in_heading: 'Referenced by',
+    settings_toolkit_concept_nav_name: 'Concept navigation',
+    settings_toolkit_concept_nav_desc: 'Walk your notes by concept, like a Wikipedia you wrote.',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -690,6 +690,7 @@ export default {
     concept_nav_entry_heading: 'Hubs',
     concept_nav_out_heading: 'Lleva a',
     concept_nav_in_heading: 'Referenciada por',
+    concept_nav_back_button: 'Volver a hubs',
     settings_toolkit_concept_nav_name: 'Navegación por conceptos',
     settings_toolkit_concept_nav_desc: 'Recorre tus notas por conceptos, como una Wikipedia que escribiste tú.',
     // Acciones de relaciones (#154)

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -680,6 +680,18 @@ export default {
     knowledge_map_member_count: '{0} notas',
     settings_toolkit_map_name: 'Mapa de conocimiento',
     settings_toolkit_map_desc: 'Un mapa vivo de tus hubs y las notas que orbitan a su alrededor.',
+    // Navegación por conceptos (#166)
+    concept_nav_view_title: 'Navegación por conceptos',
+    command_show_concept_nav: 'Mostrar navegación por conceptos',
+    concept_nav_indexing: 'Construyendo el índice…',
+    concept_nav_empty: 'Aún no hay conceptos que navegar — sigue conectando tus notas.',
+    concept_nav_error: 'No se ha podido cargar la navegación por conceptos.',
+    concept_nav_refresh_button: 'Actualizar',
+    concept_nav_entry_heading: 'Hubs',
+    concept_nav_out_heading: 'Lleva a',
+    concept_nav_in_heading: 'Referenciada por',
+    settings_toolkit_concept_nav_name: 'Navegación por conceptos',
+    settings_toolkit_concept_nav_desc: 'Recorre tus notas por conceptos, como una Wikipedia que escribiste tú.',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -27,6 +27,7 @@ import { journalSettingsGroup } from "./handlers/journalSettingsGroup";
 import { ThinkingHeatmapView } from "architecture/components/core/thinkingHeatmap/ThinkingHeatmapView";
 import { DiscoveriesView } from "architecture/components/core/discoveries/DiscoveriesView";
 import { KnowledgeMapView } from "architecture/components/core/knowledgeMap/KnowledgeMapView";
+import { ConceptNavView } from "architecture/components/core/conceptNav/ConceptNavView";
 import { createExampleFlow } from "application/notes/onboardingService";
 import { SlipboxHealthView } from "architecture/components/core/slipboxHealth/SlipboxHealthView";
 import { ResurfaceView } from "architecture/components/core/resurface/ResurfaceView";
@@ -51,6 +52,7 @@ const TOOLKIT_DOCS = {
     heatmap: `${DOCS_BASE}development/thinking-heatmap/`,
     discoveries: `${DOCS_BASE}development/morning-discovery/`,
     map: `${DOCS_BASE}development/living-knowledge-map/`,
+    conceptNav: `${DOCS_BASE}development/concept-navigation/`,
 } as const;
 
 export class ZettelFlowSettingsTab extends PluginSettingTab {
@@ -534,6 +536,21 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                                     )
                             );
                             addDocsButton(setting, TOOLKIT_DOCS.map);
+                        },
+                    },
+                    {
+                        name: t("settings_toolkit_concept_nav_name"),
+                        desc: t("settings_toolkit_concept_nav_desc"),
+                        render: (setting) => {
+                            setting.addButton((btn) =>
+                                btn
+                                    .setButtonText(t("settings_toolkit_open_button"))
+                                    .setCta()
+                                    .onClick(() =>
+                                        void activateSidebarView(plugin.app, ConceptNavView.NAME)
+                                    )
+                            );
+                            addDocsButton(setting, TOOLKIT_DOCS.conceptNav);
                         },
                     },
                     {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { ResurfaceView } from 'architecture/components/core/resurface/ResurfaceV
 import { ThinkingHeatmapView } from 'architecture/components/core/thinkingHeatmap/ThinkingHeatmapView';
 import { DiscoveriesView } from 'architecture/components/core/discoveries/DiscoveriesView';
 import { KnowledgeMapView } from 'architecture/components/core/knowledgeMap/KnowledgeMapView';
+import { ConceptNavView } from 'architecture/components/core/conceptNav/ConceptNavView';
 import { allCanvasExtensions, canvas, CanvasExtension, CanvasPatcher } from 'architecture/plugin/canvas';
 import { WorkflowEventEngine } from 'architecture/plugin/events/WorkflowEventEngine';
 import { DevelopmentJournal } from 'architecture/plugin/journal/DevelopmentJournal';
@@ -93,6 +94,7 @@ export default class ZettelFlow extends Plugin {
 		this.registerView(ThinkingHeatmapView.NAME, (leaf) => new ThinkingHeatmapView(leaf));
 		this.registerView(DiscoveriesView.NAME, (leaf) => new DiscoveriesView(leaf));
 		this.registerView(KnowledgeMapView.NAME, (leaf) => new KnowledgeMapView(leaf));
+		this.registerView(ConceptNavView.NAME, (leaf) => new ConceptNavView(leaf));
 		try {
 			this.registerExtensions(CodeView.EXTENSIONS, CodeView.NAME);
 		} catch (e) {

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -17,6 +17,7 @@ import { GenerateWeeklyReviewComponent } from "../zcomponents/GenerateWeeklyRevi
 import { ThinkingHeatmapComponent } from "../zcomponents/ThinkingHeatmapComponent";
 import { DiscoveriesComponent } from "../zcomponents/DiscoveriesComponent";
 import { KnowledgeMapComponent } from "../zcomponents/KnowledgeMapComponent";
+import { ConceptNavComponent } from "../zcomponents/ConceptNavComponent";
 import { StarterFlowsComponent } from "../zcomponents/StarterFlowsComponent";
 import { MocBuilderComponent } from "../zcomponents/MocBuilderComponent";
 import { AtomicitySplitComponent } from "../zcomponents/AtomicitySplitComponent";
@@ -41,6 +42,7 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.registerComponent(new ThinkingHeatmapComponent(plugin));
     ZComponentsManager.registerComponent(new DiscoveriesComponent(plugin));
     ZComponentsManager.registerComponent(new KnowledgeMapComponent(plugin));
+    ZComponentsManager.registerComponent(new ConceptNavComponent(plugin));
     ZComponentsManager.registerComponent(new StarterFlowsComponent(plugin));
     ZComponentsManager.registerComponent(new MocBuilderComponent(plugin));
     ZComponentsManager.registerComponent(new AtomicitySplitComponent(plugin));

--- a/src/starters/zcomponents/ConceptNavComponent.ts
+++ b/src/starters/zcomponents/ConceptNavComponent.ts
@@ -1,0 +1,23 @@
+import { PluginComponent } from "architecture";
+import ZettelFlow from "main";
+import { t } from "architecture/lang";
+import { activateSidebarView } from "architecture/plugin";
+import { ConceptNavView } from "architecture/components/core/conceptNav/ConceptNavView";
+
+/** Registers the `show-concept-nav` command (#166), opening the concept-navigation view. No hotkey. */
+export class ConceptNavComponent extends PluginComponent {
+    constructor(plugin: ZettelFlow) {
+        super(plugin);
+        this.plugin = plugin;
+    }
+
+    private plugin: ZettelFlow;
+
+    onLoad(): void {
+        this.plugin.addCommand({
+            id: "show-concept-nav",
+            name: t("command_show_concept_nav"),
+            callback: () => void activateSidebarView(this.plugin.app, ConceptNavView.NAME),
+        });
+    }
+}

--- a/src/styles/components/conceptNav.scss
+++ b/src/styles/components/conceptNav.scss
@@ -1,0 +1,96 @@
+.zettelkasten-flow__concept-nav {
+    padding: 0.5rem;
+}
+
+.zettelkasten-flow__concept-nav-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.zettelkasten-flow__concept-nav-title {
+    margin: 0;
+    font-size: var(--font-ui-medium);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__concept-nav-refresh,
+.zettelkasten-flow__concept-nav-back {
+    font-size: var(--font-ui-smaller);
+}
+
+.zettelkasten-flow__concept-nav-status {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    padding: 0.5rem 0;
+}
+
+.zettelkasten-flow__concept-nav-focus {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 2px solid var(--background-modifier-border);
+}
+
+.zettelkasten-flow__concept-nav-focus-name {
+    cursor: pointer;
+    color: var(--text-normal);
+    font-weight: var(--font-semibold);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.zettelkasten-flow__concept-nav-focus-name:hover {
+    text-decoration: underline;
+}
+
+.zettelkasten-flow__concept-nav-heading {
+    margin: 0.5rem 0 0.25rem;
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.zettelkasten-flow__concept-nav-group {
+    margin-bottom: 0.5rem;
+}
+
+.zettelkasten-flow__concept-nav-type {
+    display: inline-block;
+    margin-bottom: 0.15rem;
+    font-size: var(--font-ui-smaller);
+    color: var(--text-accent);
+    font-weight: var(--font-semibold);
+}
+
+.zettelkasten-flow__concept-nav-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding-left: 0.75rem;
+    border-left: 2px solid var(--background-modifier-border);
+}
+
+.zettelkasten-flow__concept-nav-row {
+    padding: 0.1rem 0;
+}
+
+.zettelkasten-flow__concept-nav-row-name {
+    cursor: pointer;
+    color: var(--text-accent);
+    font-size: var(--font-ui-smaller);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.zettelkasten-flow__concept-nav-row-name:hover {
+    text-decoration: underline;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -42,6 +42,7 @@
 @use 'components/thinkingHeatmap.scss';
 @use 'components/discoveries.scss';
 @use 'components/knowledgeMap.scss';
+@use 'components/conceptNav.scss';
 @use 'components/settingsToolkit.scss';
 @use 'components/resurface.scss';
 @use 'components/mocBuilder.scss';

--- a/test/architecture/knowledge/pure-is-obsidian-free.test.ts
+++ b/test/architecture/knowledge/pure-is-obsidian-free.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 
 // src/architecture/knowledge, reached from test/architecture/knowledge/
 const KNOWLEDGE_ROOT = join(__dirname, "..", "..", "..", "src", "architecture", "knowledge");
-const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map"];
+const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map", "traverse"];
 
 function collectTsFiles(dir: string): string[] {
     const out: string[] = [];

--- a/test/architecture/knowledge/traverse/conceptNeighbors.test.ts
+++ b/test/architecture/knowledge/traverse/conceptNeighbors.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "@jest/globals";
+import { conceptNeighbors } from "architecture/knowledge/traverse/conceptNeighbors";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// focus.md: outgoing edges of several types (incl. contradicts/link), plus three incoming edges.
+const model = buildModel([
+    idea("focus.md", "permanent", [
+        { to: "o_b.md", type: "supports" },
+        { to: "o_a.md", type: "supports" },
+        { to: "o_e.md", type: "example" },
+        { to: "o_c.md", type: "contradicts" },
+        { to: "o_l.md" }, // link (default type)
+    ]),
+    idea("in1.md", "permanent", [{ to: "focus.md", type: "expands" }]),
+    idea("in2.md", "permanent", [{ to: "focus.md", type: "question" }]),
+    idea("in3.md", "permanent", [{ to: "focus.md", type: "supports" }]),
+]);
+
+describe("conceptNeighbors (#166, FR-6, AC-2 pure part)", () => {
+    it("groups all typed neighbours out-before-in, in vocabulary order, targets path-sorted", () => {
+        expect(conceptNeighbors(model, "focus.md")).toEqual({
+            focus: "focus.md",
+            groups: [
+                { type: "supports", direction: "out", targets: ["o_a.md", "o_b.md"] },
+                { type: "contradicts", direction: "out", targets: ["o_c.md"] },
+                { type: "example", direction: "out", targets: ["o_e.md"] },
+                { type: "link", direction: "out", targets: ["o_l.md"] },
+                { type: "supports", direction: "in", targets: ["in3.md"] },
+                { type: "expands", direction: "in", targets: ["in1.md"] },
+                { type: "question", direction: "in", targets: ["in2.md"] },
+            ],
+        });
+    });
+
+    it("returns empty groups for an unknown/unindexed focus", () => {
+        expect(conceptNeighbors(model, "missing.md")).toEqual({ focus: "missing.md", groups: [] });
+    });
+
+    it("is deterministic and read-only", () => {
+        const before = model.size();
+        expect(conceptNeighbors(model, "focus.md")).toEqual(conceptNeighbors(model, "focus.md"));
+        expect(model.size()).toBe(before);
+    });
+});

--- a/test/architecture/knowledge/traverse/reasoningPaths.test.ts
+++ b/test/architecture/knowledge/traverse/reasoningPaths.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    reasoningPaths,
+    ARGUMENT_FORWARD_RELATION_TYPES,
+} from "architecture/knowledge/traverse/reasoningPaths";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// Main argument graph (forward types: supports > expands > example > implements):
+//   a --supports--> b --expands--> d --example--> e --implements--> f --supports--> a (cycle)
+//   a --expands--> c (leaf)
+//   a --contradicts--> xc · a --question--> xq · a --link--> xl   (all EXCLUDED noise)
+// Cap chain: p1 --s--> p2 --s--> p3 --s--> p4 --s--> p5 --s--> p6 --s--> p7 (7 nodes, >5 steps).
+const model = buildModel([
+    idea("a.md", "permanent", [
+        { to: "b.md", type: "supports" },
+        { to: "c.md", type: "expands" },
+        { to: "xc.md", type: "contradicts" },
+        { to: "xq.md", type: "question" },
+        { to: "xl.md" }, // link (default type) — excluded
+    ]),
+    idea("b.md", "permanent", [{ to: "d.md", type: "expands" }]),
+    idea("c.md", "permanent", []),
+    idea("d.md", "permanent", [{ to: "e.md", type: "example" }]),
+    idea("e.md", "permanent", [{ to: "f.md", type: "implements" }]),
+    idea("f.md", "permanent", [{ to: "a.md", type: "supports" }]),
+    idea("p1.md", "permanent", [{ to: "p2.md", type: "supports" }]),
+    idea("p2.md", "permanent", [{ to: "p3.md", type: "supports" }]),
+    idea("p3.md", "permanent", [{ to: "p4.md", type: "supports" }]),
+    idea("p4.md", "permanent", [{ to: "p5.md", type: "supports" }]),
+    idea("p5.md", "permanent", [{ to: "p6.md", type: "supports" }]),
+    idea("p6.md", "permanent", [{ to: "p7.md", type: "supports" }]),
+]);
+
+describe("reasoningPaths (#166, FR-2..FR-5, AC-1)", () => {
+    it("exposes the argument-forward relation set in precedence order", () => {
+        expect([...ARGUMENT_FORWARD_RELATION_TYPES]).toEqual(["supports", "expands", "example", "implements"]);
+    });
+
+    it("returns the maximal argument chains, branch-precedence ordered, ignoring excluded types and cycles", () => {
+        expect(reasoningPaths(model, "a.md")).toEqual([
+            {
+                start: "a.md",
+                steps: [
+                    { type: "supports", to: "b.md" },
+                    { type: "expands", to: "d.md" },
+                    { type: "example", to: "e.md" },
+                    { type: "implements", to: "f.md" },
+                ],
+            },
+            { start: "a.md", steps: [{ type: "expands", to: "c.md" }] },
+        ]);
+    });
+
+    it("never includes an excluded-type edge (contradicts/question/link) in any step", () => {
+        const steps = reasoningPaths(model, "a.md").flatMap((path) => path.steps);
+        for (const step of steps) {
+            expect(["supports", "expands", "example", "implements"]).toContain(step.type);
+        }
+    });
+
+    it("caps a chain longer than maxDepth (default 5) to 5 steps", () => {
+        expect(reasoningPaths(model, "p1.md")).toEqual([
+            {
+                start: "p1.md",
+                steps: [
+                    { type: "supports", to: "p2.md" },
+                    { type: "supports", to: "p3.md" },
+                    { type: "supports", to: "p4.md" },
+                    { type: "supports", to: "p5.md" },
+                    { type: "supports", to: "p6.md" },
+                ],
+            },
+        ]);
+    });
+
+    it("honours a custom maxDepth", () => {
+        expect(reasoningPaths(model, "p1.md", { maxDepth: 2 })).toEqual([
+            {
+                start: "p1.md",
+                steps: [
+                    { type: "supports", to: "p2.md" },
+                    { type: "supports", to: "p3.md" },
+                ],
+            },
+        ]);
+    });
+
+    it("returns [] for a start with no outgoing forward edge, an unknown start, and an empty model", () => {
+        expect(reasoningPaths(model, "c.md")).toEqual([]);
+        expect(reasoningPaths(model, "missing.md")).toEqual([]);
+        expect(reasoningPaths(buildModel([]), "a.md")).toEqual([]);
+    });
+
+    it("is deterministic and read-only", () => {
+        const before = model.size();
+        expect(reasoningPaths(model, "a.md")).toEqual(reasoningPaths(model, "a.md"));
+        expect(model.size()).toBe(before);
+    });
+});

--- a/test/config/conceptNavLocale.test.ts
+++ b/test/config/conceptNavLocale.test.ts
@@ -12,13 +12,14 @@ const KEYS = [
     "concept_nav_entry_heading",
     "concept_nav_out_heading",
     "concept_nav_in_heading",
+    "concept_nav_back_button",
     "settings_toolkit_concept_nav_name",
     "settings_toolkit_concept_nav_desc",
 ];
 
 describe("concept navigation i18n parity (#166)", () => {
-    it("defines all 11 keys in both en and es, non-empty", () => {
-        expect(KEYS.length).toBe(11);
+    it("defines all 12 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(12);
         const enMap = en as Record<string, string>;
         const esMap = es as Record<string, string>;
         for (const key of KEYS) {

--- a/test/config/conceptNavLocale.test.ts
+++ b/test/config/conceptNavLocale.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "concept_nav_view_title",
+    "command_show_concept_nav",
+    "concept_nav_indexing",
+    "concept_nav_empty",
+    "concept_nav_error",
+    "concept_nav_refresh_button",
+    "concept_nav_entry_heading",
+    "concept_nav_out_heading",
+    "concept_nav_in_heading",
+    "settings_toolkit_concept_nav_name",
+    "settings_toolkit_concept_nav_desc",
+];
+
+describe("concept navigation i18n parity (#166)", () => {
+    it("defines all 11 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(11);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Traverse the graph — reasoning paths & concept navigation (#166)

Opens the 🕸️ **Graph** pillar: two read-only, offline traversals over the #147 typed-relations graph.

### 1. Concept navigation (view)
Walk your vault like a wiki you wrote. Focus a note → its **typed neighbours in both directions**
(*Leads to* / *Referenced by*, grouped by relation type); click any one to **re-focus** on it —
Learning → Memory → Spacing effect → Anki, no folders.
- Pure core `conceptNeighbors(model, path) → { focus, groups: { type, direction, targets }[] }` — full vocabulary, out-before-in → vocab order → path-sorted. Exact-fixture tested.
- `ConceptNavView` mirrors the #164 knowledge-map view (debounced auto-update, `createEl`/`c()`, no innerHTML/inline styles). Entry point = active indexed note else `hubs()`; a sticky **Back to hubs** control; focus name opens the note. Command `show-concept-nav` (no hotkey) + toolkit launcher.

### 2. Reasoning paths (headless core)
`reasoningPaths(model, start, { maxDepth }) → Path[]` — follows only the **argument-forward** relations
(`supports → expands → example → implements`) to return the **maximal argument chains** leaving a note.
Cycle-safe, depth-bounded (default 5), deterministic. `contradicts`/`question`/`inspired-by`/`link`
excluded so a path reads as one line of reasoning. A tested, documented foundation for a future
argument-path view.

### Guardrails / AC
- Both cores are **pure, Obsidian-free, off the barrel**, in the new `traverse/` dir (added to `PURE_DIRS`). AC-1 (reasoning chains) + AC-2 (concept navigation) are exact-fixture `toEqual` suites.
- en/es parity (12 keys), docs `development/concept-navigation.md` + nav, README (🕸️ toolkit bullet + Features row; **no** action-count change — this is a view).
- `npm run verify` green — typecheck + oxlint + **lint:obsidian 0** + **722** jest tests.
- Reviewed by `obsidian-plugin-reviewer`: verdict *raises the score*, no blockers; the one pre-merge fix (sticky "Back to hubs" across vault edits) is applied, plus a clearer back-button label.

Closes #166. Relates to #144.
