### PR TITLE
feat(state): open questions first-class + auto-answer detection (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   neighbours (in **and** out), click one to re-focus — Learning → Memory → Spacing effect → Anki,
   no folders. Ships with headless **reasoning paths** that read the graph as an argument
   (supports → expands → example → implements). Read-only, offline.
+- **❓ Open questions** — every unanswered question in your vault, made first-class: each `question::`
+  with no answer yet, its asker(s), and the note most likely to answer it (ranked by shared graph
+  context). Read-only, offline — a live thread instead of a dead end.
 - **✂️ Atomicity split assist** — turn a multi-topic note into linked atomic notes in one
   command, leaving the source as a hub.
 - **🌱 Note lifecycle states** — give every note a **state** (🌱 fleeting → 📝 literature →
@@ -146,6 +149,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Morning discovery** | Up to three unexpected connections — unlinked note pairs that share concepts — each one click from being related. Graph-structural, offline. |
 | **Living knowledge map** | A read-only sidebar that detects your hubs and the notes clustering around them, regenerating as the vault changes. |
 | **Concept navigation** | Walk your vault by typed relation (in + out) — focus a note, click a neighbour to re-focus, no folders — plus argument-forward reasoning paths over the same graph. Read-only, offline. |
+| **Open questions** | A vault-wide list of every unanswered `question::`, its askers, and candidate answering notes ranked by shared graph context. Read-only, offline. |
 | **Zettelkasten starter flows** | One-click install of ready-made flows for fleeting, literature, permanent and MOC notes, plus a **Literature → Permanent** composed showcase that chains the cognitive actions. |
 | **Map-of-content builder** | Gather notes by tag/folder into a MOC; re-runs update a managed region and keep your prose. |
 | **Connection resurfacing** | Ranked older/related notes for the active note, with a daily-spark serendipity surface. |

--- a/docs/development/open-questions.md
+++ b/docs/development/open-questions.md
@@ -1,0 +1,54 @@
+# Open questions
+
+Questions you raise while writing get buried in note bodies and are never revisited. **Open
+questions** makes them first-class: it lists every **unanswered** question across the whole vault,
+and for each one proposes the note most likely to answer it — so a question is a live thread, not a
+dead end.
+
+## Opening it
+
+Run **"Show open questions"** from the command palette, or click **Open** next to *Open questions* in
+**Settings → ZettelFlow → Zettelkasten toolkit**. The pane updates automatically (debounced) whenever
+notes or links change.
+
+## What counts as an open question
+
+A question is a `question` **semantic relation** (#147): a note that points to a question note via
+`question::`. A question is **open** when its target has **no incoming `supports`** edge — nothing
+answers it yet. This is the vault-wide generalisation of the per-note
+[find unanswered question](../actions/FindUnansweredQuestion.md) action. Questions come **only** from
+the `question` relation — there is no NLP of note prose.
+
+The pure query `openQuestions(model) → { path, askedBy }[]` lists each open question with the notes
+that asked it, sorted deterministically. Read-only and offline.
+
+## Answer detection
+
+For each open question, `proposeAnswers(model, questionPath) → { path, score }[]` ranks candidate
+answering notes by **graph-structural relatedness** — the same #154 metric as
+[suggest link](../actions/SuggestLink.md) (co-citation weighted above bibliographic coupling). It
+reuses that single metric (`rankRelatedScored`), which already excludes the question's askers and any
+directly connected note, and it returns `[]` for a question that is unknown, already answered, or
+shares no graph context. The top five candidates are shown per question.
+
+## Read-only (for now)
+
+The view **proposes** the `candidate --supports--> question` link but does **not** write it — it
+lists and navigates only, so it adds no file-system capability. Create the edge yourself with the
+[create semantic relation](../actions/CreateSemanticRelation.md) action; a one-click "link it"
+affordance is a possible follow-up.
+
+## Architecture
+
+```
+openQuestions(model)                              (pure, Obsidian-free, unit-tested)
+  → [{ path, askedBy }]     every question target with no incoming `supports`
+
+proposeAnswers(model, questionPath, { limit })    (pure, Obsidian-free, unit-tested)
+  → [{ path, score }]       top-N by rankRelatedScored (#154), guards unknown/answered/context-less
+
+OpenQuestionsView (ItemView) + OpenQuestionsComponent (show-open-questions command, no hotkey)
+  reads the KnowledgeIndex model → openQuestions + proposeAnswers per question
+  debounced metadataCache "resolved" + vault rename/delete listeners → recompute
+  rows open notes via workspace.openLinkText; writes nothing
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,5 +81,6 @@ nav:
       - 7.16 Morning discovery: development/morning-discovery.md
       - 7.17 Living knowledge map: development/living-knowledge-map.md
       - 7.18 Concept navigation: development/concept-navigation.md
+      - 7.19 Open questions: development/open-questions.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/actions/relations/relationRankingLogic.ts
+++ b/src/actions/relations/relationRankingLogic.ts
@@ -10,29 +10,35 @@ export interface RankRelatedOptions {
 const CO_CITATION_WEIGHT = 2;
 const COUPLING_WEIGHT = 1;
 
+/** A related note with its shared-context relatedness score (#154/#167). */
+export interface ScoredRelated {
+    path: string;
+    score: number;
+}
+
 /**
- * Pure graph-structural relatedness ranking (#154, D4). Scores every other indexed note against
- * `sourcePath` from shared graph context — **co-citation** (notes that link to *both*) weighted
- * above **bibliographic coupling** (notes that *both* link to) — and returns the candidates' paths
- * ordered by score descending, ties broken by path ascending.
+ * Pure graph-structural relatedness ranking (#154, D4), score-carrying variant (#167). Scores every
+ * other indexed note against `sourcePath` from shared graph context — **co-citation** (notes that
+ * link to *both*) weighted above **bibliographic coupling** (notes that *both* link to) — and returns
+ * the candidates as `{ path, score }` ordered by score descending, ties broken by path ascending.
  *
  * Excludes the source itself, any note already directly connected to it (an edge in either
  * direction), and any candidate whose score is 0 (no shared context). Reads only the #145
  * {@link KnowledgeModel} (`inNeighbors`/`outNeighbors`, which union every edge type — D5);
  * Obsidian-free, deterministic, never throws. An absent/unknown source yields `[]`.
  */
-export function rankRelated(
+export function rankRelatedScored(
     model: KnowledgeModel,
     sourcePath: string,
     opts: RankRelatedOptions = {}
-): string[] {
+): ScoredRelated[] {
     if (!model.get(sourcePath)) return [];
 
     const sourceIn = new Set(model.inNeighbors(sourcePath));
     const sourceOut = new Set(model.outNeighbors(sourcePath));
     const connected = new Set<string>([...sourceIn, ...sourceOut]);
 
-    const scored: { path: string; score: number }[] = [];
+    const scored: ScoredRelated[] = [];
     for (const idea of model.all()) {
         const path = idea.path;
         if (path === sourcePath || connected.has(path)) continue;
@@ -47,8 +53,19 @@ export function rankRelated(
     scored.sort((a, b) => b.score - a.score || compareStrings(a.path, b.path));
 
     const limit = opts.limit;
-    const capped = limit !== undefined && limit > 0 ? scored.slice(0, limit) : scored;
-    return capped.map((entry) => entry.path);
+    return limit !== undefined && limit > 0 ? scored.slice(0, limit) : scored;
+}
+
+/**
+ * The paths-only view of {@link rankRelatedScored} (#154, D4) — the single relatedness metric source.
+ * Same ordering and exclusions; an absent/unknown source yields `[]`.
+ */
+export function rankRelated(
+    model: KnowledgeModel,
+    sourcePath: string,
+    opts: RankRelatedOptions = {}
+): string[] {
+    return rankRelatedScored(model, sourcePath, opts).map((entry) => entry.path);
 }
 
 function countShared(reference: Set<string>, others: string[]): number {

--- a/src/architecture/components/core/openQuestions/OpenQuestionsView.ts
+++ b/src/architecture/components/core/openQuestions/OpenQuestionsView.ts
@@ -1,0 +1,147 @@
+import { ItemView, WorkspaceLeaf } from "obsidian";
+import { c, log } from "architecture";
+import { t } from "architecture/lang";
+import { KnowledgeIndex } from "architecture/knowledge";
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import { OpenQuestion, openQuestions } from "architecture/knowledge/questions/openQuestions";
+import { proposeAnswers } from "architecture/knowledge/questions/proposeAnswers";
+
+const DEBOUNCE_MS = 400;
+
+type ViewState = "indexing" | "ready" | "empty" | "error";
+
+function basename(path: string): string {
+    const file = path.split("/").pop() ?? path;
+    return file.replace(/\.md$/i, "");
+}
+
+/**
+ * **Open questions** (#167): lists every unanswered question across the vault — its asker(s) and the
+ * notes most likely to answer it (the #154 relatedness heuristic). Read-only: rows open notes, the
+ * proposed `supports` link is shown but not written. Auto-updates via debounced listeners (mirroring
+ * the concept-navigation pane). `createEl`/`c()` only; no innerHTML/inline styles.
+ */
+export class OpenQuestionsView extends ItemView {
+    static readonly NAME = "zettelflow-open-questions";
+
+    private state: ViewState = "indexing";
+    private model: KnowledgeModel | null = null;
+    private questions: OpenQuestion[] = [];
+    private debounceTimer: number | undefined;
+
+    constructor(leaf: WorkspaceLeaf) {
+        super(leaf);
+    }
+
+    getViewType(): string {
+        return OpenQuestionsView.NAME;
+    }
+
+    getDisplayText(): string {
+        return t("open_questions_view_title");
+    }
+
+    getIcon(): string {
+        return "circle-help";
+    }
+
+    async onOpen(): Promise<void> {
+        this.registerVaultListeners();
+        this.recompute();
+    }
+
+    async onClose(): Promise<void> {
+        window.clearTimeout(this.debounceTimer);
+        this.contentEl.empty();
+    }
+
+    private registerVaultListeners(): void {
+        const debounced = () => {
+            window.clearTimeout(this.debounceTimer);
+            this.debounceTimer = window.setTimeout(() => this.recompute(), DEBOUNCE_MS);
+        };
+        this.registerEvent(this.app.metadataCache.on("resolved", debounced));
+        this.registerEvent(this.app.vault.on("rename", debounced));
+        this.registerEvent(this.app.vault.on("delete", debounced));
+    }
+
+    private recompute(): void {
+        try {
+            const index = KnowledgeIndex.getInstance();
+            if (index.status !== "ready") {
+                this.state = "indexing";
+                this.model = null;
+                this.render();
+                return;
+            }
+            const start = Date.now();
+            this.model = index.getModel();
+            this.questions = openQuestions(this.model);
+            this.state = this.questions.length === 0 ? "empty" : "ready";
+            log.debug(`[OpenQuestions] ${this.questions.length} open in ${Date.now() - start}ms`);
+        } catch (error) {
+            this.state = "error";
+            log.error(`[OpenQuestions] recompute failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        }
+        this.render();
+    }
+
+    private render(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        const container = contentEl.createDiv({ cls: c("open-questions") });
+
+        const header = container.createDiv({ cls: c("open-questions-header") });
+        header.createEl("h4", { text: t("open_questions_view_title"), cls: c("open-questions-title") });
+        const refresh = header.createEl("button", {
+            text: t("open_questions_refresh_button"),
+            cls: c("open-questions-refresh"),
+            attr: { "aria-label": t("open_questions_refresh_button") },
+        });
+        refresh.addEventListener("click", () => this.recompute());
+
+        if (this.state === "indexing") {
+            container.createDiv({ cls: c("open-questions-status"), text: t("open_questions_indexing") });
+            return;
+        }
+        if (this.state === "error") {
+            container.createDiv({ cls: c("open-questions-status"), text: t("open_questions_error") });
+            return;
+        }
+        if (this.state === "empty") {
+            container.createDiv({ cls: c("open-questions-status"), text: t("open_questions_empty") });
+            return;
+        }
+
+        for (const question of this.questions) this.renderQuestion(container, question);
+    }
+
+    private renderQuestion(container: HTMLElement, question: OpenQuestion): void {
+        const section = container.createDiv({ cls: c("open-questions-item") });
+        const title = section.createEl("h5", { cls: c("open-questions-q") });
+        const name = title.createSpan({ text: basename(question.path), cls: c("open-questions-q-name") });
+        name.setAttribute("title", question.path);
+        name.addEventListener("click", () => void this.app.workspace.openLinkText(question.path, "", false));
+
+        const asked = section.createDiv({ cls: c("open-questions-line") });
+        asked.createSpan({ text: t("open_questions_asked_by"), cls: c("open-questions-label") });
+        const askedList = asked.createDiv({ cls: c("open-questions-refs") });
+        for (const asker of question.askedBy) this.renderRef(askedList, asker);
+
+        const candidates = this.model ? proposeAnswers(this.model, question.path) : [];
+        const answers = section.createDiv({ cls: c("open-questions-line") });
+        answers.createSpan({ text: t("open_questions_proposed_answers"), cls: c("open-questions-label") });
+        if (candidates.length === 0) {
+            answers.createSpan({ text: t("open_questions_no_answer"), cls: c("open-questions-no-answer") });
+            return;
+        }
+        const answerList = answers.createDiv({ cls: c("open-questions-refs") });
+        for (const candidate of candidates) this.renderRef(answerList, candidate.path);
+    }
+
+    private renderRef(list: HTMLElement, path: string): void {
+        const name = list.createSpan({ text: basename(path), cls: c("open-questions-ref") });
+        name.setAttribute("title", path);
+        name.addEventListener("click", () => void this.app.workspace.openLinkText(path, "", false));
+    }
+}

--- a/src/architecture/knowledge/questions/openQuestions.ts
+++ b/src/architecture/knowledge/questions/openQuestions.ts
@@ -1,0 +1,36 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+import { edgesByType, incomingRelations } from "../query/queries";
+
+/** An unanswered question raised somewhere in the vault, with the notes that asked it. */
+export interface OpenQuestion {
+    path: string;
+    askedBy: string[];
+}
+
+function compareStrings(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Pure vault-wide open-questions query (#167, FR-1/FR-2). Generalises #153's per-note
+ * `findUnansweredQuestions`: collects every `question` edge (#147), groups the askers (`from`) by the
+ * question note (`to`), and keeps only questions with **no incoming `supports`** — i.e. nothing
+ * answers them yet. Sorted by question path asc, `askedBy` deduped + sorted asc.
+ *
+ * Reads only the {@link KnowledgeModel}; deterministic, read-only, never throws. Obsidian-free.
+ */
+export function openQuestions(model: KnowledgeModel): OpenQuestion[] {
+    const askersByQuestion = new Map<string, Set<string>>();
+    for (const edge of edgesByType(model, "question")) {
+        const askers = askersByQuestion.get(edge.to) ?? new Set<string>();
+        askers.add(edge.from);
+        askersByQuestion.set(edge.to, askers);
+    }
+
+    const result: OpenQuestion[] = [];
+    for (const [path, askers] of askersByQuestion) {
+        if (incomingRelations(model, path, "supports").length > 0) continue;
+        result.push({ path, askedBy: [...askers].sort(compareStrings) });
+    }
+    return result.sort((a, b) => compareStrings(a.path, b.path));
+}

--- a/src/architecture/knowledge/questions/proposeAnswers.ts
+++ b/src/architecture/knowledge/questions/proposeAnswers.ts
@@ -34,5 +34,6 @@ export function proposeAnswers(
     if (incomingRelations(model, questionPath, "supports").length > 0) return [];
 
     const limit = opts.limit ?? DEFAULT_LIMIT;
-    return rankRelatedScored(model, questionPath, { limit }).map(({ path, score }) => ({ path, score }));
+    // ScoredRelated is structurally an AnswerCandidate; rankRelatedScored returns fresh objects.
+    return rankRelatedScored(model, questionPath, { limit });
 }

--- a/src/architecture/knowledge/questions/proposeAnswers.ts
+++ b/src/architecture/knowledge/questions/proposeAnswers.ts
@@ -1,0 +1,38 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+import { incomingRelations } from "../query/queries";
+import { rankRelatedScored } from "actions/relations/relationRankingLogic";
+
+/** A note proposed as an answer to an open question, with its relatedness score (#167). */
+export interface AnswerCandidate {
+    path: string;
+    score: number;
+}
+
+export interface ProposeAnswersOptions {
+    /** How many candidates to propose (default 5, matching the relation-suggestion default). */
+    limit?: number;
+}
+
+const DEFAULT_LIMIT = 5;
+
+/**
+ * Pure answer-detection heuristic (#167, FR-3/FR-4/FR-5). For an **open** question, proposes the
+ * notes most likely to answer it — the top-N by the #154 relatedness score (`rankRelatedScored`:
+ * co-citation weighted above coupling), which already excludes the question's askers and any directly
+ * connected note. Each candidate is the `candidate --supports--> question` link the view suggests.
+ *
+ * Returns `[]` when the question is unknown/unindexed, already answered (it has an incoming
+ * `supports`), or shares no graph context. Reads only the {@link KnowledgeModel}; deterministic,
+ * read-only, never throws. Obsidian-free — reuses the single relatedness metric, no new score.
+ */
+export function proposeAnswers(
+    model: KnowledgeModel,
+    questionPath: string,
+    opts: ProposeAnswersOptions = {}
+): AnswerCandidate[] {
+    if (!model.get(questionPath)) return [];
+    if (incomingRelations(model, questionPath, "supports").length > 0) return [];
+
+    const limit = opts.limit ?? DEFAULT_LIMIT;
+    return rankRelatedScored(model, questionPath, { limit }).map(({ path, score }) => ({ path, score }));
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -693,6 +693,18 @@ export default {
     concept_nav_back_button: 'Back to hubs',
     settings_toolkit_concept_nav_name: 'Concept navigation',
     settings_toolkit_concept_nav_desc: 'Walk your notes by concept, like a Wikipedia you wrote.',
+    // Open questions (#167)
+    open_questions_view_title: 'Open questions',
+    command_show_open_questions: 'Show open questions',
+    open_questions_indexing: 'Building the index…',
+    open_questions_empty: 'No open questions — every question has an answer, or none are asked yet.',
+    open_questions_error: 'Could not load open questions.',
+    open_questions_refresh_button: 'Refresh',
+    open_questions_asked_by: 'Asked by',
+    open_questions_proposed_answers: 'Might be answered by',
+    open_questions_no_answer: 'No candidate answer found.',
+    settings_toolkit_open_questions_name: 'Open questions',
+    settings_toolkit_open_questions_desc: 'Every unanswered question in your vault, with candidate answers.',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -693,6 +693,18 @@ export default {
     concept_nav_back_button: 'Volver a hubs',
     settings_toolkit_concept_nav_name: 'Navegación por conceptos',
     settings_toolkit_concept_nav_desc: 'Recorre tus notas por conceptos, como una Wikipedia que escribiste tú.',
+    // Preguntas abiertas (#167)
+    open_questions_view_title: 'Preguntas abiertas',
+    command_show_open_questions: 'Mostrar preguntas abiertas',
+    open_questions_indexing: 'Construyendo el índice…',
+    open_questions_empty: 'No hay preguntas abiertas — todas tienen respuesta, o aún no se ha planteado ninguna.',
+    open_questions_error: 'No se han podido cargar las preguntas abiertas.',
+    open_questions_refresh_button: 'Actualizar',
+    open_questions_asked_by: 'Planteada por',
+    open_questions_proposed_answers: 'Podría responderla',
+    open_questions_no_answer: 'No se ha encontrado ninguna respuesta candidata.',
+    settings_toolkit_open_questions_name: 'Preguntas abiertas',
+    settings_toolkit_open_questions_desc: 'Todas las preguntas sin responder de tu bóveda, con respuestas candidatas.',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -28,6 +28,7 @@ import { ThinkingHeatmapView } from "architecture/components/core/thinkingHeatma
 import { DiscoveriesView } from "architecture/components/core/discoveries/DiscoveriesView";
 import { KnowledgeMapView } from "architecture/components/core/knowledgeMap/KnowledgeMapView";
 import { ConceptNavView } from "architecture/components/core/conceptNav/ConceptNavView";
+import { OpenQuestionsView } from "architecture/components/core/openQuestions/OpenQuestionsView";
 import { createExampleFlow } from "application/notes/onboardingService";
 import { SlipboxHealthView } from "architecture/components/core/slipboxHealth/SlipboxHealthView";
 import { ResurfaceView } from "architecture/components/core/resurface/ResurfaceView";
@@ -53,6 +54,7 @@ const TOOLKIT_DOCS = {
     discoveries: `${DOCS_BASE}development/morning-discovery/`,
     map: `${DOCS_BASE}development/living-knowledge-map/`,
     conceptNav: `${DOCS_BASE}development/concept-navigation/`,
+    openQuestions: `${DOCS_BASE}development/open-questions/`,
 } as const;
 
 export class ZettelFlowSettingsTab extends PluginSettingTab {
@@ -551,6 +553,21 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                                     )
                             );
                             addDocsButton(setting, TOOLKIT_DOCS.conceptNav);
+                        },
+                    },
+                    {
+                        name: t("settings_toolkit_open_questions_name"),
+                        desc: t("settings_toolkit_open_questions_desc"),
+                        render: (setting) => {
+                            setting.addButton((btn) =>
+                                btn
+                                    .setButtonText(t("settings_toolkit_open_button"))
+                                    .setCta()
+                                    .onClick(() =>
+                                        void activateSidebarView(plugin.app, OpenQuestionsView.NAME)
+                                    )
+                            );
+                            addDocsButton(setting, TOOLKIT_DOCS.openQuestions);
                         },
                     },
                     {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import { ThinkingHeatmapView } from 'architecture/components/core/thinkingHeatma
 import { DiscoveriesView } from 'architecture/components/core/discoveries/DiscoveriesView';
 import { KnowledgeMapView } from 'architecture/components/core/knowledgeMap/KnowledgeMapView';
 import { ConceptNavView } from 'architecture/components/core/conceptNav/ConceptNavView';
+import { OpenQuestionsView } from 'architecture/components/core/openQuestions/OpenQuestionsView';
 import { allCanvasExtensions, canvas, CanvasExtension, CanvasPatcher } from 'architecture/plugin/canvas';
 import { WorkflowEventEngine } from 'architecture/plugin/events/WorkflowEventEngine';
 import { DevelopmentJournal } from 'architecture/plugin/journal/DevelopmentJournal';
@@ -95,6 +96,7 @@ export default class ZettelFlow extends Plugin {
 		this.registerView(DiscoveriesView.NAME, (leaf) => new DiscoveriesView(leaf));
 		this.registerView(KnowledgeMapView.NAME, (leaf) => new KnowledgeMapView(leaf));
 		this.registerView(ConceptNavView.NAME, (leaf) => new ConceptNavView(leaf));
+		this.registerView(OpenQuestionsView.NAME, (leaf) => new OpenQuestionsView(leaf));
 		try {
 			this.registerExtensions(CodeView.EXTENSIONS, CodeView.NAME);
 		} catch (e) {

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -18,6 +18,7 @@ import { ThinkingHeatmapComponent } from "../zcomponents/ThinkingHeatmapComponen
 import { DiscoveriesComponent } from "../zcomponents/DiscoveriesComponent";
 import { KnowledgeMapComponent } from "../zcomponents/KnowledgeMapComponent";
 import { ConceptNavComponent } from "../zcomponents/ConceptNavComponent";
+import { OpenQuestionsComponent } from "../zcomponents/OpenQuestionsComponent";
 import { StarterFlowsComponent } from "../zcomponents/StarterFlowsComponent";
 import { MocBuilderComponent } from "../zcomponents/MocBuilderComponent";
 import { AtomicitySplitComponent } from "../zcomponents/AtomicitySplitComponent";
@@ -43,6 +44,7 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.registerComponent(new DiscoveriesComponent(plugin));
     ZComponentsManager.registerComponent(new KnowledgeMapComponent(plugin));
     ZComponentsManager.registerComponent(new ConceptNavComponent(plugin));
+    ZComponentsManager.registerComponent(new OpenQuestionsComponent(plugin));
     ZComponentsManager.registerComponent(new StarterFlowsComponent(plugin));
     ZComponentsManager.registerComponent(new MocBuilderComponent(plugin));
     ZComponentsManager.registerComponent(new AtomicitySplitComponent(plugin));

--- a/src/starters/zcomponents/OpenQuestionsComponent.ts
+++ b/src/starters/zcomponents/OpenQuestionsComponent.ts
@@ -1,0 +1,23 @@
+import { PluginComponent } from "architecture";
+import ZettelFlow from "main";
+import { t } from "architecture/lang";
+import { activateSidebarView } from "architecture/plugin";
+import { OpenQuestionsView } from "architecture/components/core/openQuestions/OpenQuestionsView";
+
+/** Registers the `show-open-questions` command (#167), opening the open-questions view. No hotkey. */
+export class OpenQuestionsComponent extends PluginComponent {
+    constructor(plugin: ZettelFlow) {
+        super(plugin);
+        this.plugin = plugin;
+    }
+
+    private plugin: ZettelFlow;
+
+    onLoad(): void {
+        this.plugin.addCommand({
+            id: "show-open-questions",
+            name: t("command_show_open_questions"),
+            callback: () => void activateSidebarView(this.plugin.app, OpenQuestionsView.NAME),
+        });
+    }
+}

--- a/src/styles/components/openQuestions.scss
+++ b/src/styles/components/openQuestions.scss
@@ -1,0 +1,84 @@
+.zettelkasten-flow__open-questions {
+    padding: 0.5rem;
+}
+
+.zettelkasten-flow__open-questions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.zettelkasten-flow__open-questions-title {
+    margin: 0;
+    font-size: var(--font-ui-medium);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__open-questions-refresh {
+    font-size: var(--font-ui-smaller);
+}
+
+.zettelkasten-flow__open-questions-status {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    padding: 0.5rem 0;
+}
+
+.zettelkasten-flow__open-questions-item {
+    margin-bottom: 0.75rem;
+    padding-left: 0.5rem;
+    border-left: 2px solid var(--background-modifier-border);
+}
+
+.zettelkasten-flow__open-questions-q {
+    margin: 0 0 0.25rem;
+    font-size: var(--font-ui-small);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__open-questions-q-name {
+    cursor: pointer;
+    color: var(--text-accent);
+    font-weight: var(--font-semibold);
+}
+
+.zettelkasten-flow__open-questions-q-name:hover {
+    text-decoration: underline;
+}
+
+.zettelkasten-flow__open-questions-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.35rem;
+    margin: 0.1rem 0;
+}
+
+.zettelkasten-flow__open-questions-label {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+}
+
+.zettelkasten-flow__open-questions-refs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.zettelkasten-flow__open-questions-ref {
+    cursor: pointer;
+    color: var(--text-accent);
+    font-size: var(--font-ui-smaller);
+}
+
+.zettelkasten-flow__open-questions-ref:hover {
+    text-decoration: underline;
+}
+
+.zettelkasten-flow__open-questions-no-answer {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-faint);
+    font-style: italic;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -43,6 +43,7 @@
 @use 'components/discoveries.scss';
 @use 'components/knowledgeMap.scss';
 @use 'components/conceptNav.scss';
+@use 'components/openQuestions.scss';
 @use 'components/settingsToolkit.scss';
 @use 'components/resurface.scss';
 @use 'components/mocBuilder.scss';

--- a/test/actions/relations/relationRankingLogic.test.ts
+++ b/test/actions/relations/relationRankingLogic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { rankRelated } from "actions/relations/relationRankingLogic";
+import { rankRelated, rankRelatedScored } from "actions/relations/relationRankingLogic";
 import { idea, buildModel } from "../knowledge/support/knowledgeFixture";
 
 /**
@@ -66,5 +66,29 @@ describe("rankRelated (#154, FR-2, AC-1, D4)", () => {
             idea("t.md", "permanent", []),
         ]);
         expect(rankRelated(tie, "s.md")).toEqual(["a.md", "b.md"]);
+    });
+});
+
+describe("rankRelatedScored (#167 — score-carrying variant)", () => {
+    it("returns {path,score} ordered score-desc then path-asc, with non-increasing score", () => {
+        const scored = rankRelatedScored(model, "source.md");
+        expect(scored).toEqual([
+            { path: "X.md", score: 6 },
+            { path: "Y.md", score: 3 },
+        ]);
+        for (let i = 1; i < scored.length; i++) {
+            expect(scored[i].score).toBeLessThanOrEqual(scored[i - 1].score);
+        }
+    });
+
+    it("honours the limit and returns [] for an unknown source", () => {
+        expect(rankRelatedScored(model, "source.md", { limit: 1 })).toEqual([{ path: "X.md", score: 6 }]);
+        expect(rankRelatedScored(model, "missing.md")).toEqual([]);
+    });
+
+    it("rankRelated is exactly rankRelatedScored's paths (single metric source)", () => {
+        expect(rankRelated(model, "source.md")).toEqual(
+            rankRelatedScored(model, "source.md").map((entry) => entry.path)
+        );
     });
 });

--- a/test/architecture/knowledge/pure-is-obsidian-free.test.ts
+++ b/test/architecture/knowledge/pure-is-obsidian-free.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 
 // src/architecture/knowledge, reached from test/architecture/knowledge/
 const KNOWLEDGE_ROOT = join(__dirname, "..", "..", "..", "src", "architecture", "knowledge");
-const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map", "traverse"];
+const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map", "traverse", "questions"];
 
 function collectTsFiles(dir: string): string[] {
     const out: string[] = [];

--- a/test/architecture/knowledge/questions/openQuestions.test.ts
+++ b/test/architecture/knowledge/questions/openQuestions.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "@jest/globals";
+import { openQuestions } from "architecture/knowledge/questions/openQuestions";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// a --question--> q1 (open, 1 asker) · b,c --question--> q2 (open, 2 askers)
+// d --question--> aq, e --supports--> aq (ANSWERED — excluded) · n --link--> x (no question edge)
+const model = buildModel([
+    idea("a.md", "permanent", [{ to: "q1.md", type: "question" }]),
+    idea("b.md", "permanent", [{ to: "q2.md", type: "question" }]),
+    idea("c.md", "permanent", [{ to: "q2.md", type: "question" }]),
+    idea("d.md", "permanent", [{ to: "aq.md", type: "question" }]),
+    idea("e.md", "permanent", [{ to: "aq.md", type: "supports" }]),
+    idea("n.md", "permanent", [{ to: "x.md" }]),
+]);
+
+describe("openQuestions (#167, FR-1/FR-2, AC-1)", () => {
+    it("lists every unanswered question vault-wide with its askers, sorted", () => {
+        expect(openQuestions(model)).toEqual([
+            { path: "q1.md", askedBy: ["a.md"] },
+            { path: "q2.md", askedBy: ["b.md", "c.md"] },
+        ]);
+    });
+
+    it("excludes a question that already has an incoming supports edge", () => {
+        expect(openQuestions(model).map((q) => q.path)).not.toContain("aq.md");
+    });
+
+    it("returns [] for an empty model", () => {
+        expect(openQuestions(buildModel([]))).toEqual([]);
+    });
+
+    it("is deterministic and read-only", () => {
+        const before = model.size();
+        expect(openQuestions(model)).toEqual(openQuestions(model));
+        expect(model.size()).toBe(before);
+    });
+});

--- a/test/architecture/knowledge/questions/proposeAnswers.test.ts
+++ b/test/architecture/knowledge/questions/proposeAnswers.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "@jest/globals";
+import { proposeAnswers } from "architecture/knowledge/questions/proposeAnswers";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// q.md is an open question. Candidates by shared graph context (rankRelated):
+//   c2 — co-cited with q by P1 & P2 (score 2·2 = 4)
+//   c1 — couples with q via S    (score 1·1 = 1)
+//   ask — asks q (--question-->), an in-neighbour ⇒ excluded from the ranking.
+// aq.md is an ANSWERED question (incoming supports); lonely.md is a context-less question.
+const model = buildModel([
+    idea("q.md", "permanent", [{ to: "S.md" }]),
+    idea("ask.md", "permanent", [{ to: "q.md", type: "question" }]),
+    idea("P1.md", "permanent", [{ to: "q.md" }, { to: "c2.md" }]),
+    idea("P2.md", "permanent", [{ to: "q.md" }, { to: "c2.md" }]),
+    idea("c2.md", "permanent", []),
+    idea("c1.md", "permanent", [{ to: "S.md" }]),
+    idea("S.md", "permanent", []),
+    idea("ans.md", "permanent", [{ to: "aq.md", type: "question" }]),
+    idea("sup.md", "permanent", [{ to: "aq.md", type: "supports" }]),
+    idea("aq.md", "permanent", []),
+    idea("asker2.md", "permanent", [{ to: "lonely.md", type: "question" }]),
+    idea("lonely.md", "permanent", []),
+]);
+
+describe("proposeAnswers (#167, FR-3/FR-4/FR-5, AC-2)", () => {
+    it("ranks candidate answers by relatedness, strongest first, with non-increasing score", () => {
+        expect(proposeAnswers(model, "q.md")).toEqual([
+            { path: "c2.md", score: 4 },
+            { path: "c1.md", score: 1 },
+        ]);
+    });
+
+    it("excludes the asking note (it is directly connected)", () => {
+        expect(proposeAnswers(model, "q.md").map((candidate) => candidate.path)).not.toContain("ask.md");
+    });
+
+    it("honours the limit", () => {
+        expect(proposeAnswers(model, "q.md", { limit: 1 })).toEqual([{ path: "c2.md", score: 4 }]);
+    });
+
+    it("returns [] for an unknown question, an already-answered question, and a context-less question", () => {
+        expect(proposeAnswers(model, "missing.md")).toEqual([]);
+        expect(proposeAnswers(model, "aq.md")).toEqual([]);
+        expect(proposeAnswers(model, "lonely.md")).toEqual([]);
+    });
+
+    it("is read-only", () => {
+        const before = model.size();
+        proposeAnswers(model, "q.md");
+        expect(model.size()).toBe(before);
+    });
+});

--- a/test/config/openQuestionsLocale.test.ts
+++ b/test/config/openQuestionsLocale.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "open_questions_view_title",
+    "command_show_open_questions",
+    "open_questions_indexing",
+    "open_questions_empty",
+    "open_questions_error",
+    "open_questions_refresh_button",
+    "open_questions_asked_by",
+    "open_questions_proposed_answers",
+    "open_questions_no_answer",
+    "settings_toolkit_open_questions_name",
+    "settings_toolkit_open_questions_desc",
+];
+
+describe("open questions i18n parity (#167)", () => {
+    it("defines all 11 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(11);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Open questions first-class + auto-answer detection (#167)

Questions you raise get buried in note bodies. This makes them first-class: a vault-wide list of
every **unanswered** question, with candidate answering notes.

### What ships
- **`openQuestions(model) → { path, askedBy }[]`** (new `architecture/knowledge/questions/`) — every `question`-edge target with **no incoming `supports`**, askers deduped+sorted, path-sorted. Generalises #153's per-note `findUnansweredQuestions` to the whole vault. Exact-fixture tested.
- **`proposeAnswers(model, questionPath, {limit}) → { path, score }[]`** — the answer heuristic: top-N candidates by the **reused #154 relatedness** (co-citation > coupling), which already excludes askers and connected notes. Guards `[]` for unknown / already-answered / context-less questions. Exact-fixture tested.
- **Single metric source** — `relationRankingLogic` now exports `rankRelatedScored` (`{path,score}[]`); `rankRelated` delegates to it (`.map(e=>e.path)`), byte-identical for `FindRelatedAction`/`SuggestLinkAction` (delegation test added).
- **Read-only "Open questions" view** mirroring the #166 pane (debounced auto-update, `createEl`/`c()`, no innerHTML/inline styles) — each question with its askers and its top proposed answers, all navigable. Command `show-open-questions` (no hotkey) + toolkit launcher. **Writes nothing** (proposes the `supports` link, doesn't create it — link-writing deferred).

### Guardrails / AC
- Both cores pure, Obsidian-free, off the barrel, in the new `questions/` dir (added to `PURE_DIRS`). AC-1 (`openQuestions`) + AC-2 (`proposeAnswers`) are exact-fixture `toEqual` suites.
- en/es parity (11 keys), docs `development/open-questions.md` + nav 7.19, README (❓ toolkit bullet + Features row; **no** action-count change — this is a view).
- `npm run verify` green — typecheck + oxlint + **lint:obsidian 0** + **735** jest tests.
- Reviewed by `obsidian-plugin-reviewer`: verdict *raises/holds the score*, no must-fix; the refactor is behaviour-preserving. Optional cleanup (redundant identity map) applied.

Closes #167. Relates to #144.
