### PR TITLE
feat(patterns): Knowledge Patterns — templates gain behavior (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | Feature | Description |
 |---|---|
 | **Canvas-based flows** | Use Obsidian's native canvas as the workflow engine — no custom DSL to learn. |
-| **Knowledge patterns** | Templates that carry behavior — on creation a pattern runs its attached offline knowledge/relation actions. The shipped **Permanent Note** pattern lands notes already related, cross-checked and scored. Additive & backward-compatible; legacy templates are unchanged. |
+| **Knowledge patterns** | Templates that carry behavior — on creation a pattern runs its attached offline knowledge/relation actions through the standard pipeline. The shipped **Permanent Note** pattern wires find related · find contradictions · suggest links · calculate maturity, computed against your existing graph. Additive & backward-compatible; legacy templates are unchanged. |
 | **28 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question, suggest next move, thinking simulator — 🔗 relation actions — find related, suggest link, create semantic relation — 🔍 research actions — extract claims, compare claims, find sources, attach source — and 🤖 optional AI actions (off by default) — summarize, classify, generate questions. |
 | **Conditional edges** | Label a canvas arrow `if: frontmatter.type === "meeting"` to branch the workflow at runtime. |
 | **Dynamic templates** | Use `{{title}}`, `{{date}}`, `{{frontmatter.key}}`, `{{canvas.name}}` in step body templates. |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | Feature | Description |
 |---|---|
 | **Canvas-based flows** | Use Obsidian's native canvas as the workflow engine — no custom DSL to learn. |
+| **Knowledge patterns** | Templates that carry behavior — on creation a pattern runs its attached offline knowledge/relation actions. The shipped **Permanent Note** pattern lands notes already related, cross-checked and scored. Additive & backward-compatible; legacy templates are unchanged. |
 | **28 built-in actions** | Prompt, Number, Checkbox, Calendar, Selector, Dynamic selector, Tags, Backlink, CSS classes, Task management, Script, Zettel ID, 🧠 knowledge actions — detect orphan, calculate maturity, find contradiction, find unanswered question, suggest next move, thinking simulator — 🔗 relation actions — find related, suggest link, create semantic relation — 🔍 research actions — extract claims, compare claims, find sources, attach source — and 🤖 optional AI actions (off by default) — summarize, classify, generate questions. |
 | **Conditional edges** | Label a canvas arrow `if: frontmatter.type === "meeting"` to branch the workflow at runtime. |
 | **Dynamic templates** | Use `{{title}}`, `{{date}}`, `{{frontmatter.key}}`, `{{canvas.name}}` in step body templates. |

--- a/docs/development/knowledge-patterns.md
+++ b/docs/development/knowledge-patterns.md
@@ -1,0 +1,71 @@
+# Knowledge patterns
+
+A template describes a note's **structure** — its fields and body. A **Knowledge Pattern** adds
+**behavior**: an ordered list of actions that run when a note is created from it. *Structure + behavior.*
+
+The shipped **Permanent Note** pattern isn't just Claim / Evidence / Connections / Questions fields —
+on creation it runs **find related · find contradictions · suggest links · calculate maturity**, so a
+new permanent note lands already connected, cross-checked and scored.
+
+## How it works
+
+A step's `zettelFlowSettings` gains one optional, additive key:
+
+```yaml
+zettelFlowSettings:
+  root: true
+  label: Permanent note
+  actions:            # the interactive wizard steps (unchanged)
+    - type: prompt
+      ...
+  onCreation:         # NEW (#170): headless actions run on note creation, in order
+    - type: find-related
+      hasUI: false
+      key: related
+      zone: frontmatter
+      limit: 10
+    - type: find-contradiction
+      hasUI: false
+      key: contradictions
+      zone: frontmatter
+    - type: suggest-link
+      hasUI: false
+      key: suggestedLinks
+      zone: frontmatter
+      limit: 5
+    - type: calculate-maturity
+      hasUI: false
+      key: maturity
+      zone: frontmatter
+```
+
+When the note is built, after its structure is assembled and **before** the file is written, the
+note-builder runs each `onCreation` action in order through the standard `execute()` pipeline, so
+their results land in the note's frontmatter. Each action is best-effort: a failure is logged and
+never aborts the build or the remaining actions. The `onCreation` list is collected from every walked
+step, so a multi-step flow composes its behavior.
+
+## Backward compatibility
+
+`onCreation` is **optional and additive**, exactly like `phase` (#149), `trigger` (#150) and `wait`
+(#151). A legacy template with no `onCreation` key parses and behaves **exactly as before** — a plain
+static template. The step-builder preserves the field opaquely (there is no visual editor yet), so an
+unrelated edit never drops it.
+
+## Scope
+
+This ships **on-creation** behavior only. General "on-event" triggers (run behavior on later edits,
+state changes, etc.) are a deliberate follow-up; launching a whole *flow* on a vault event is already
+the `trigger` field (#150).
+
+## A note on timing
+
+On-creation actions run **before** the new note's own file exists, so the graph-based actions rank it
+against the **already-indexed** vault (they no-op gracefully if the index isn't ready). That is the
+intended "land already connected" behavior — the new note is not yet in the index for its own pass.
+
+## Try it
+
+Install the starter flows (Settings → ZettelFlow → Zettelkasten toolkit → *Starter flows*), then build
+a note from the **Permanent note** flow: its frontmatter will carry `related`, `contradictions`,
+`suggestedLinks` and `maturity`, filled from your existing graph.

--- a/docs/development/knowledge-patterns.md
+++ b/docs/development/knowledge-patterns.md
@@ -4,8 +4,9 @@ A template describes a note's **structure** — its fields and body. A **Knowled
 **behavior**: an ordered list of actions that run when a note is created from it. *Structure + behavior.*
 
 The shipped **Permanent Note** pattern isn't just Claim / Evidence / Connections / Questions fields —
-on creation it runs **find related · find contradictions · suggest links · calculate maturity**, so a
-new permanent note lands already connected, cross-checked and scored.
+on creation it runs **find related · find contradictions · suggest links · calculate maturity** against
+your existing graph, writing each result into the note's frontmatter. (See *A note on timing* below for
+what a brand-new note receives on its very first pass.)
 
 ## How it works
 
@@ -61,11 +62,13 @@ the `trigger` field (#150).
 ## A note on timing
 
 On-creation actions run **before** the new note's own file exists, so the graph-based actions rank it
-against the **already-indexed** vault (they no-op gracefully if the index isn't ready). That is the
-intended "land already connected" behavior — the new note is not yet in the index for its own pass.
+against the **already-indexed** vault, and the new note is not yet a node in that graph. In practice a
+*brand-new* note's first pass often writes empty result properties (`related: []`, etc.) — the values
+fill in once the vault re-indexes and the pattern is run again. Re-running the pattern automatically
+after the note is indexed is a planned follow-up.
 
 ## Try it
 
 Install the starter flows (Settings → ZettelFlow → Zettelkasten toolkit → *Starter flows*), then build
-a note from the **Permanent note** flow: its frontmatter will carry `related`, `contradictions`,
-`suggestedLinks` and `maturity`, filled from your existing graph.
+a note from the **Permanent note** flow: its frontmatter will carry the pattern's result properties
+(`related`, `contradictions`, `suggestedLinks`, `maturity`), computed against your existing graph.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,5 +84,6 @@ nav:
       - 7.19 Open questions: development/open-questions.md
       - 7.20 Evolution timeline: development/evolution-timeline.md
       - 7.21 Evidence map: development/evidence-map.md
+      - 7.22 Knowledge patterns: development/knowledge-patterns.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/application/components/noteBuilder/state/NoteBuilderState.tsx
+++ b/src/application/components/noteBuilder/state/NoteBuilderState.tsx
@@ -11,6 +11,7 @@ import { log } from "architecture";
 import { Action } from "architecture/api";
 import { v4 as uuid4 } from "uuid";
 import { FileService } from "architecture/plugin";
+import { resolveOnCreationActions } from "application/patterns/resolveOnCreationActions";
 
 export const useNoteBuilderStore = create<NoteBuilderState>((set, get) => ({
   creationMode: true,
@@ -88,7 +89,8 @@ export const useNoteBuilderStore = create<NoteBuilderState>((set, get) => ({
         }
         builder.note
           .addPath(node.path, position)
-          .setTargetFolder(node.targetFolder);
+          .setTargetFolder(node.targetFolder)
+          .addOnCreation(resolveOnCreationActions(node));
 
         return {
           builder,

--- a/src/application/notes/NoteBuilder.ts
+++ b/src/application/notes/NoteBuilder.ts
@@ -9,6 +9,7 @@ import { TFile, moment as obsidianMoment } from "obsidian";
 import type MomentFn from "moment";
 import { SelectorMenuModal } from "zettelkasten";
 import { NoteBuilderStateActions } from "application/components/noteBuilder/typing";
+import { runOnCreationActions } from "application/patterns/runOnCreationActions";
 
 // Obsidian bundles moment and re-exports it, but types it as a namespace; cast to the
 // callable moment signature (type-only import of 'moment' is allowed by the guidelines).
@@ -123,7 +124,21 @@ export class NoteBuilder {
     }
     this.applyContextTokens();
     await this.manageElements();
+    await this.runOnCreation();
     this.appendConnectionLinks();
+  }
+
+  /**
+   * Run the Knowledge Pattern on-creation actions (#170) collected from the walked steps, as a block,
+   * after the note's structure is assembled and before the file is written — so their results land in
+   * `content`. Best-effort per action, reusing the standard `execute(info)` pipeline.
+   */
+  private async runOnCreation(): Promise<void> {
+    await runOnCreationActions(
+      this.note.getOnCreation(),
+      { content: this.content, note: this.note, context: this.context },
+      (type) => actionsStore.getAction(type)
+    );
   }
 
   /**

--- a/src/application/notes/model/NoteDTO.ts
+++ b/src/application/notes/model/NoteDTO.ts
@@ -11,6 +11,7 @@ export class NoteDTO {
     private uniquePrefixPattern = "";
     private targetFolder = "";
     private targetFolderLocked = false;
+    private onCreationActions: Action[] = [];
 
     public getFinalPath(): string {
         return this.getTargetFolder()
@@ -137,6 +138,20 @@ export class NoteDTO {
         if (basename && !this.links.includes(basename)) {
             this.links.push(basename);
         }
+        return this;
+    }
+
+    /**
+     * The Knowledge Pattern on-creation actions (#170) collected from every walked step, in walk
+     * order. Session-scoped (not tied to a step position) — the note-builder runs them as a block
+     * once the note's structure is assembled.
+     */
+    public getOnCreation(): Action[] {
+        return this.onCreationActions;
+    }
+
+    public addOnCreation(actions: Action[]): NoteDTO {
+        if (actions.length > 0) this.onCreationActions.push(...actions);
         return this;
     }
 

--- a/src/application/notes/starterFlowsService.ts
+++ b/src/application/notes/starterFlowsService.ts
@@ -135,7 +135,8 @@ function buildComposedStepTemplate(
     label: string,
     phase: StepPhase,
     entries: ActionEntry[],
-    body: string
+    body: string,
+    onCreation?: ActionEntry[]
 ): string {
     const lines: string[] = [];
     lines.push("---");
@@ -146,6 +147,11 @@ function buildComposedStepTemplate(
     lines.push(`  phase: ${phase}`);
     lines.push("  actions:");
     for (const entry of entries) lines.push(...emitActionEntry(entry));
+    // Knowledge Pattern on-creation behavior (#170): headless actions run when a note is created.
+    if (onCreation && onCreation.length > 0) {
+        lines.push("  onCreation:");
+        for (const entry of onCreation) lines.push(...emitActionEntry(entry));
+    }
     lines.push(`  targetFolder: ${EXAMPLE_NOTES_FOLDER}`);
     lines.push("  childrenHeader: ''");
     lines.push("  optional: false");
@@ -156,7 +162,13 @@ function buildComposedStepTemplate(
 }
 
 /** Prompt-only builder (the four shipped flows). Maps each prompt to an entry and delegates. */
-function buildStepTemplate(label: string, prompts: PromptSpec[], body: string, phase: StepPhase): string {
+function buildStepTemplate(
+    label: string,
+    prompts: PromptSpec[],
+    body: string,
+    phase: StepPhase,
+    onCreation?: ActionEntry[]
+): string {
     const entries: ActionEntry[] = prompts.map((prompt) => ({
         kind: "prompt",
         id: prompt.id,
@@ -168,8 +180,20 @@ function buildStepTemplate(label: string, prompts: PromptSpec[], body: string, p
         placeholder: prompt.placeholder,
         staticBehaviour: false,
     }));
-    return buildComposedStepTemplate(label, phase, entries, body);
+    return buildComposedStepTemplate(label, phase, entries, body, onCreation);
 }
+
+/**
+ * The default **Permanent Note pattern** behavior (#170): on creation the note is ranked against the
+ * vault (find related · find contradictions · suggest links) and given an initial maturity score —
+ * so a permanent note lands already connected, cross-checked and scored. All headless (`hasUI:false`).
+ */
+const PERMANENT_ON_CREATION: ActionEntry[] = [
+    { kind: "cognitive", type: "find-related", id: "zf-perm-related", key: "related", zone: "frontmatter", limit: 10 },
+    { kind: "cognitive", type: "find-contradiction", id: "zf-perm-contradiction", key: "contradictions", zone: "frontmatter" },
+    { kind: "cognitive", type: "suggest-link", id: "zf-perm-suggest", key: "suggestedLinks", zone: "frontmatter", limit: 5 },
+    { kind: "cognitive", type: "calculate-maturity", id: "zf-perm-maturity", key: "maturity", zone: "frontmatter" },
+];
 
 /** File-type canvas nodes read their config from the step frontmatter — no zettelflowConfig here. */
 function buildCanvas(nodeId: string, stepPath: string): string {
@@ -285,7 +309,8 @@ const STEP_TEMPLATES: Record<StarterFlowType, string> = {
             },
         ],
         "# {{title}}\n\n{{idea}}\n\n## Connections\n\n{{connect}}\n",
-        "DEVELOP"
+        "DEVELOP",
+        PERMANENT_ON_CREATION
     ),
     moc: buildStepTemplate(
         "Structure note",

--- a/src/application/patterns/resolveOnCreationActions.ts
+++ b/src/application/patterns/resolveOnCreationActions.ts
@@ -1,0 +1,11 @@
+import type { Action } from "architecture/api";
+import type { StepSettings } from "zettelkasten";
+
+/**
+ * The ordered on-creation behavior of a **Knowledge Pattern** (#170) — the `hasUI:false` actions a
+ * template runs when a note is created from it. A legacy template with no `onCreation` field yields
+ * `[]` (a plain static template), so back-compat is guaranteed. Pure: never mutates `settings`.
+ */
+export function resolveOnCreationActions(settings: StepSettings): Action[] {
+    return settings.onCreation ?? [];
+}

--- a/src/application/patterns/runOnCreationActions.ts
+++ b/src/application/patterns/runOnCreationActions.ts
@@ -10,8 +10,9 @@ export type ActionLookup = (type: string) => { execute(info: ExecuteInfo): void 
 /**
  * Run a Knowledge Pattern's on-creation actions (#170) in declared order, reusing the standard
  * `execute(info)` pipeline. Best-effort: each action is wrapped so one failure is logged and never
- * aborts the build or the remaining actions (mirrors `KnowledgeIndex.recordDevelopment`). Unknown
- * action types are skipped.
+ * aborts the build or the remaining actions (mirrors `KnowledgeIndex.recordDevelopment`). An action
+ * the lookup can't resolve is skipped when the lookup returns undefined (e.g. an injected/test store);
+ * the production `ActionsStore` throws instead, which the same per-action catch absorbs.
  */
 export async function runOnCreationActions(
     actions: Action[],

--- a/src/application/patterns/runOnCreationActions.ts
+++ b/src/application/patterns/runOnCreationActions.ts
@@ -1,0 +1,37 @@
+import { log } from "architecture/monitoring/Logger";
+import type { Action, ExecuteInfo } from "architecture/api";
+
+/** The shared execution context an on-creation action needs — the note being built (#170). */
+export type OnCreationContext = Pick<ExecuteInfo, "content" | "note" | "context">;
+
+/** Resolves a registered action implementation for a type (e.g. the `ActionsStore`). */
+export type ActionLookup = (type: string) => { execute(info: ExecuteInfo): void | Promise<void> } | undefined;
+
+/**
+ * Run a Knowledge Pattern's on-creation actions (#170) in declared order, reusing the standard
+ * `execute(info)` pipeline. Best-effort: each action is wrapped so one failure is logged and never
+ * aborts the build or the remaining actions (mirrors `KnowledgeIndex.recordDevelopment`). Unknown
+ * action types are skipped.
+ */
+export async function runOnCreationActions(
+    actions: Action[],
+    ctx: OnCreationContext,
+    getAction: ActionLookup
+): Promise<void> {
+    for (const action of actions) {
+        try {
+            const impl = getAction(action.type);
+            if (!impl) continue;
+            await impl.execute({
+                element: { ...action, result: null } as ExecuteInfo["element"],
+                content: ctx.content,
+                note: ctx.note,
+                context: ctx.context,
+            });
+        } catch (error) {
+            log.error(
+                `[patterns] on-creation action "${action.type}" failed: ${error instanceof Error ? error.message : "unknown error"}`
+            );
+        }
+    }
+}

--- a/src/application/patterns/runOnCreationActions.ts
+++ b/src/application/patterns/runOnCreationActions.ts
@@ -23,7 +23,7 @@ export async function runOnCreationActions(
             const impl = getAction(action.type);
             if (!impl) continue;
             await impl.execute({
-                element: { ...action, result: null } as ExecuteInfo["element"],
+                element: { ...action, result: null },
                 content: ctx.content,
                 note: ctx.note,
                 context: ctx.context,

--- a/src/zettelkasten/mappers/StepBuilderMapper.ts
+++ b/src/zettelkasten/mappers/StepBuilderMapper.ts
@@ -4,7 +4,7 @@ import { v4 as uuid4 } from "uuid";
 
 export class StepBuilderMapper {
     public static StepBuilderInfo2StepSettings(info: StepBuilderInfo): StepSettings {
-        const { label, childrenHeader, targetFolder, root, optional, actions, phase, trigger, wait } = info;
+        const { label, childrenHeader, targetFolder, root, optional, actions, phase, trigger, wait, onCreation } = info;
         const settings: StepSettings = {
             root,
             actions,
@@ -19,11 +19,13 @@ export class StepBuilderMapper {
         if (trigger !== undefined) settings.trigger = trigger;
         // Preserve a WAIT marker — #151.
         if (wait !== undefined) settings.wait = wait;
+        // Preserve Knowledge Pattern on-creation behavior opaquely — #170.
+        if (onCreation !== undefined) settings.onCreation = onCreation;
         return settings;
     }
 
     public static StepBuilderInfo2CommunityStepSettings(info: StepBuilderInfo, origin: Partial<CommunityStepSettings>): CommunityStepSettings {
-        const { label, childrenHeader, targetFolder, root, optional, actions, phase, trigger, wait, title = "", description = "" } = info;
+        const { label, childrenHeader, targetFolder, root, optional, actions, phase, trigger, wait, onCreation, title = "", description = "" } = info;
         const { author = "You", id = uuid4() } = origin;
         const settings: CommunityStepSettings = {
             ...origin,
@@ -42,11 +44,12 @@ export class StepBuilderMapper {
         if (phase !== undefined) settings.phase = phase;
         if (trigger !== undefined) settings.trigger = trigger;
         if (wait !== undefined) settings.wait = wait;
+        if (onCreation !== undefined) settings.onCreation = onCreation;
         return settings;
     }
 
     public static StepSettings2PartialStepBuilderInfo(settings: StepSettings): Partial<Omit<StepBuilderInfo, "containerEl">> {
-        const { root, label, childrenHeader, targetFolder, optional, actions, phase, trigger, wait } = settings;
+        const { root, label, childrenHeader, targetFolder, optional, actions, phase, trigger, wait, onCreation } = settings;
         const info: Partial<Omit<StepBuilderInfo, "containerEl">> = {
             root,
             label,
@@ -58,6 +61,7 @@ export class StepBuilderMapper {
         if (phase !== undefined) info.phase = phase;
         if (trigger !== undefined) info.trigger = trigger;
         if (wait !== undefined) info.wait = wait;
+        if (onCreation !== undefined) info.onCreation = onCreation;
         return info;
     }
 }

--- a/src/zettelkasten/typing.ts
+++ b/src/zettelkasten/typing.ts
@@ -47,6 +47,14 @@ export type StepSettings = {
      * straight through (back-compat). The only new block kind of the visual workflow language.
      */
     wait?: WaitSettings,
+    /**
+     * Optional **Knowledge Pattern** behavior (#170): an ordered list of `hasUI:false` actions the
+     * note-builder runs on note creation, after the note's structure is assembled and before the file
+     * is written — turning a static template into "structure + behavior". Additive & opt-in — absence
+     * means a plain static template (back-compat). Authored in frontmatter/YAML in v1 (no builder UI
+     * yet); the builder preserves it opaquely so an unrelated edit never drops it.
+     */
+    onCreation?: Action[],
 }
 
 export type ZettelFlowElement = {

--- a/test/application/notes/__snapshots__/starterFlowsService.test.ts.snap
+++ b/test/application/notes/__snapshots__/starterFlowsService.test.ts.snap
@@ -163,6 +163,29 @@ zettelFlowSettings:
       label: How does this connect to what you already know?
       placeholder: Link it to existing notes...
       staticBehaviour: false
+  onCreation:
+    - type: find-related
+      id: zf-perm-related
+      hasUI: false
+      key: related
+      zone: frontmatter
+      limit: 10
+    - type: find-contradiction
+      id: zf-perm-contradiction
+      hasUI: false
+      key: contradictions
+      zone: frontmatter
+    - type: suggest-link
+      id: zf-perm-suggest
+      hasUI: false
+      key: suggestedLinks
+      zone: frontmatter
+      limit: 5
+    - type: calculate-maturity
+      id: zf-perm-maturity
+      hasUI: false
+      key: maturity
+      zone: frontmatter
   targetFolder: _ZettelFlow/examples/notes
   childrenHeader: ''
   optional: false

--- a/test/application/notes/model/NoteDTO.test.ts
+++ b/test/application/notes/model/NoteDTO.test.ts
@@ -9,6 +9,16 @@ describe("NoteDTO", () => {
     expect(n.getFinalPath()).toBe("Notes/Inbox/My Note.md");
   });
 
+  it("collects on-creation pattern actions in walk order (#170)", () => {
+    const n = new NoteDTO();
+    expect(n.getOnCreation()).toEqual([]);
+    const a = { type: "find-related", id: "find-related", hasUI: false } as any;
+    const b = { type: "calculate-maturity", id: "calculate-maturity", hasUI: false } as any;
+    const c = { type: "suggest-link", id: "suggest-link", hasUI: false } as any;
+    n.addOnCreation([a, b]).addOnCreation([]).addOnCreation([c]);
+    expect(n.getOnCreation()).toEqual([a, b, c]);
+  });
+
   it("strips a trailing slash from the target folder", () => {
     const n = new NoteDTO();
     n.setTargetFolder("Notes/").setTitle("t");

--- a/test/application/notes/starterFlowsService.test.ts
+++ b/test/application/notes/starterFlowsService.test.ts
@@ -146,6 +146,29 @@ describe("installStarterFlows — AC-3 type-appropriate content", () => {
         expect(content).toContain("connect");
     });
 
+    it("the permanent step ships the default Knowledge Pattern on-creation behavior (#170)", async () => {
+        const { vault } = makeVault();
+        await installStarterFlows(vault, ["permanent"]);
+        const content = createdContent(vault, STARTER_FLOW_PATHS.permanent.step);
+
+        // The interactive actions block is unchanged — still the three prompts, no cognitive double-run.
+        const actions = parseActionsBlock(content);
+        expect(actions.map((a) => a.type)).toEqual(["prompt", "prompt", "prompt"]);
+        expect(actions.map((a) => a.key)).toEqual(["title", "idea", "connect"]);
+
+        // The new on-creation block runs the four headless actions, in order.
+        const onCreation = parseBlock(content, "onCreation:");
+        expect(onCreation.map((a) => a.type)).toEqual([
+            "find-related", "find-contradiction", "suggest-link", "calculate-maturity",
+        ]);
+        expect(onCreation.map((a) => a.key)).toEqual([
+            "related", "contradictions", "suggestedLinks", "maturity",
+        ]);
+        expect(onCreation.every((a) => a.hasUI === "false")).toBe(true);
+        expect(onCreation[0].limit).toBe("10"); // find-related
+        expect(onCreation[2].limit).toBe("5"); // suggest-link
+    });
+
     it("every canvas is valid JSON and never contains zettelflowConfig", async () => {
         const { vault } = makeVault();
         await installStarterFlows(vault, ALL_TYPES);
@@ -211,8 +234,13 @@ describe("installStarterFlows — AC-6 partial mix", () => {
 
 /** Parse the `zettelFlowSettings.actions` list from an emitted step markdown. */
 function parseActionsBlock(content: string): Record<string, string>[] {
+    return parseBlock(content, "actions:");
+}
+
+/** Parse a `zettelFlowSettings.<blockKey>` action list (e.g. `actions:` or `onCreation:`). */
+function parseBlock(content: string, blockKey: string): Record<string, string>[] {
     const lines = content.split("\n");
-    const start = lines.findIndex((l) => l.trim() === "actions:");
+    const start = lines.findIndex((l) => l.trim() === blockKey);
     const entries: Record<string, string>[] = [];
     let current: Record<string, string> | null = null;
     for (let i = start + 1; i < lines.length; i++) {

--- a/test/application/patterns/resolveOnCreationActions.test.ts
+++ b/test/application/patterns/resolveOnCreationActions.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+import { resolveOnCreationActions } from "application/patterns/resolveOnCreationActions";
+import type { StepSettings } from "zettelkasten";
+import type { Action } from "architecture/api";
+
+const action = (id: string): Action => ({ type: id, id, hasUI: false, key: id, zone: "frontmatter" });
+
+function baseSettings(extra: Partial<StepSettings> = {}): StepSettings {
+    return { root: false, actions: [], label: "Step", ...extra };
+}
+
+describe("resolveOnCreationActions (#170, AC-1/AC-2)", () => {
+    it("returns the attached on-creation actions in declared order (AC-1)", () => {
+        const a = action("find-related");
+        const b = action("calculate-maturity");
+        expect(resolveOnCreationActions(baseSettings({ onCreation: [a, b] }))).toEqual([a, b]);
+    });
+
+    it("returns [] for a legacy template with no onCreation, without mutating it (AC-2)", () => {
+        const legacy = baseSettings();
+        const clone = JSON.parse(JSON.stringify(legacy));
+        expect(resolveOnCreationActions(legacy)).toEqual([]);
+        expect(legacy).toEqual(clone);
+        expect("onCreation" in legacy).toBe(false);
+    });
+
+    it("returns [] for an explicitly empty onCreation", () => {
+        expect(resolveOnCreationActions(baseSettings({ onCreation: [] }))).toEqual([]);
+    });
+});

--- a/test/application/patterns/runOnCreationActions.test.ts
+++ b/test/application/patterns/runOnCreationActions.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { runOnCreationActions, OnCreationContext } from "application/patterns/runOnCreationActions";
+import { log } from "architecture/monitoring/Logger";
+import type { Action, ExecuteInfo } from "architecture/api";
+
+const action = (id: string): Action => ({ type: id, id, hasUI: false, key: id, zone: "frontmatter" });
+const ctx = { content: {}, note: {}, context: {} } as unknown as OnCreationContext;
+
+describe("runOnCreationActions (#170, FR-3, AC-1)", () => {
+    beforeEach(() => jest.restoreAllMocks());
+
+    it("runs the actions in declared order", async () => {
+        const calls: string[] = [];
+        const impls: Record<string, { execute: (info: ExecuteInfo) => void }> = {
+            a: { execute: () => void calls.push("a") },
+            b: { execute: () => void calls.push("b") },
+            c: { execute: () => void calls.push("c") },
+        };
+        await runOnCreationActions([action("a"), action("b"), action("c")], ctx, (type) => impls[type]);
+        expect(calls).toEqual(["a", "b", "c"]);
+    });
+
+    it("catches a failing action, logs it, and still runs the rest", async () => {
+        const errorSpy = jest.spyOn(log, "error").mockImplementation(() => undefined);
+        const calls: string[] = [];
+        const impls: Record<string, { execute: (info: ExecuteInfo) => void }> = {
+            a: { execute: () => void calls.push("a") },
+            b: { execute: () => { throw new Error("boom"); } },
+            c: { execute: () => void calls.push("c") },
+        };
+        await runOnCreationActions([action("a"), action("b"), action("c")], ctx, (type) => impls[type]);
+        expect(calls).toEqual(["a", "c"]);
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op for an empty list and skips unknown action types", async () => {
+        const execute = jest.fn();
+        await runOnCreationActions([], ctx, () => ({ execute }));
+        expect(execute).not.toHaveBeenCalled();
+        await runOnCreationActions([action("missing")], ctx, () => undefined);
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("passes each action as element {...action, result:null} plus the shared context", async () => {
+        const received: ExecuteInfo[] = [];
+        const a = action("a");
+        await runOnCreationActions([a], ctx, () => ({ execute: (info) => void received.push(info) }));
+        expect(received[0].element).toEqual({ ...a, result: null });
+        expect(received[0].content).toBe(ctx.content);
+        expect(received[0].note).toBe(ctx.note);
+        expect(received[0].context).toBe(ctx.context);
+    });
+});

--- a/test/zettelkasten/mappers/StepBuilderMapper.test.ts
+++ b/test/zettelkasten/mappers/StepBuilderMapper.test.ts
@@ -100,6 +100,35 @@ describe("StepBuilderMapper — WAIT round-trip (#151, back-compat)", () => {
     });
 });
 
+describe("StepBuilderMapper — onCreation round-trip (#170, back-compat)", () => {
+    const onCreation = [{ type: "find-related", id: "find-related", hasUI: false, key: "related", zone: "frontmatter" }];
+
+    it("omits the onCreation key for a legacy static template", () => {
+        const settings = StepBuilderMapper.StepBuilderInfo2StepSettings(info());
+        expect("onCreation" in settings).toBe(false);
+        const back = StepBuilderMapper.StepSettings2PartialStepBuilderInfo(settings);
+        expect("onCreation" in back).toBe(false);
+    });
+
+    it("preserves the on-creation behavior opaquely both directions (no builder UI, but never dropped)", () => {
+        const settings = StepBuilderMapper.StepBuilderInfo2StepSettings(info({ onCreation }));
+        expect(settings.onCreation).toEqual(onCreation);
+        const back = StepBuilderMapper.StepSettings2PartialStepBuilderInfo(settings);
+        expect(back.onCreation).toEqual(onCreation);
+    });
+
+    it("two steps differing only by onCreation have deep-equal non-onCreation projections", () => {
+        const withBehavior = StepBuilderMapper.StepBuilderInfo2StepSettings(info({ onCreation }));
+        const without = StepBuilderMapper.StepBuilderInfo2StepSettings(info());
+        const strip = (s: StepSettings) => {
+            const { onCreation: oc, ...rest } = s;
+            void oc;
+            return rest;
+        };
+        expect(strip(withBehavior)).toEqual(strip(without));
+    });
+});
+
 describe("mergeStepSettingsIntoFrontmatter — clear-on-save (#149 phase, #151 wait)", () => {
     it("keeps a phase and a wait that the incoming settings carry", () => {
         const merged = mergeStepSettingsIntoFrontmatter(


### PR DESCRIPTION
## Knowledge Patterns — templates gain behavior (#170)

**Knowledge Pattern = structure + behavior.** A template gains an optional, ordered list of
on-creation actions that run when a note is created from it — turning a static template into one that
*does* something. Fully additive and **backward-compatible**.

### What ships
- **Additive `onCreation?: Action[]`** on `StepSettings` (mirrors `phase`/`trigger`/`wait`), preserved opaquely in all three `StepBuilderMapper` methods (omit-when-undefined). Legacy templates parse and behave **exactly as before**.
- **Pure `resolveOnCreationActions(settings)`** (`settings.onCreation ?? []`, no mutation) — the AC-1/AC-2 test surface. **Pure `runOnCreationActions(actions, ctx, getAction)`** — runs each action in declared order through the standard `execute(info)` pipeline, per-action best-effort (a failure is logged, never aborts the build).
- **Note-builder wiring:** `NoteDTO` collects each walked step's `onCreation` in walk order; `NoteBuilder.buildNote()` runs them **after** structure assembly and **before** the file is written, so results land in the note's frontmatter.
- **Default "Permanent Note" pattern** (via the starter-flows channel): on creation it wires find-related · find-contradiction · suggest-link · calculate-maturity (all `hasUI:false`), computed against your existing graph. Its interactive `actions` block is unchanged (no double-run).

### Guardrails / AC
- **AC-2 (back-compat)** is the central invariant, proven by two tests: the pure resolver's no-mutation/deep-equal test and the mapper's "no key added/dropped when absent" round-trip. `mergeStepSettingsIntoFrontmatter` preserves `onCreation` (no `delete`; survives the spread).
- **AC-1**: ordered resolve + ordered `execute` after structure assembly. **AC-3**: shipped Permanent pattern (four headless actions, exact order/keys/limits). Scope = on-creation only (on-event deferred).
- `npm run verify` green — typecheck + oxlint + **lint:obsidian 0** + **770** jest tests. No new i18n string, no UI, no innerHTML/inline styles, no network/AI.
- Reviewed by `obsidian-plugin-reviewer`: **no blocking issues, backward-compat solid, merge-ready.** Applied the honesty fix (softened copy: a brand-new note's first pass ranks against the not-yet-indexed graph, so results fill in on re-index) and filed follow-ups **#200** (re-run the pattern after indexing) and **#201** (silence headless-action Notices in patterns).

Closes #170. Relates to #144.
