### PR TITLE
feat(discovery): derived projects — folder → book/course/article outline (#173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   offline — the state of your mind at a glance.
 - **📝 Note-builder companion pane** — a live preview of the note as you build it, plus
   suggested connections to existing notes so you can link before you file.
+- **📖 Derived projects** — turn a folder of notes into the *structure* of a book / course / article:
+  one command clusters and orders them from the semantic graph into an outline (MOC) that links every
+  source note. It organizes what you already know — graph-derived, offline, no AI.
 - **🔑 Zettel ID action** — stamp every note with a stable unique identifier (sortable
   timestamp or Luhmann-style **Folgezettel** branching like `21 → 21a → 21a1`).
 - **🩺 Slip-box health dashboard** — a sidebar that surfaces **orphan** and **dead-end** notes,
@@ -161,6 +164,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Slip-box health** | Sidebar dashboard surfacing orphan (no outgoing links) and dead-end (no backlinks) notes, a **Knowledge Debt score** (unreferenced · dangling · unsourced · open questions) with a drill-down and one-click fixes, and a **Knowledge balance** read-out (references · questions · examples · conclusions · concepts) with balance nudges. |
 | **Knowledge dashboard** | An ops console for the state of your system — connectivity % · knowledge debt · today (to process, contradictions, connections, open questions) — where every panel proposes a recommended next action. Read-only, offline. |
 | **ZettelFlow Home** | The IDE-style front door: greeting + "thinking for N days", new ideas, main concepts, notes that deserve a review, suggested connections, and the deterministic next recommended session. Read-only, offline. |
+| **Derived projects** | Turn a folder of notes into an ordered book/course/article outline (MOC) — clustered and sequenced from the semantic graph, linking every source note. Graph-derived, offline, no AI. |
 | **Second-brain review** | A command that generates a weekly review note — ideas created, orphans, forgotten ideas, important-but-unreviewed — each with a next action. |
 | **Thinking heatmap** | A GitHub-style calendar of ideas *developed* (state advanced, source/connection added) over the last year, fed by a private on-by-default local journal (day → count only). |
 | **Morning discovery** | Up to three unexpected connections — unlinked note pairs that share concepts — each one click from being related. Graph-structural, offline. |

--- a/docs/development/derived-projects.md
+++ b/docs/development/derived-projects.md
@@ -1,0 +1,57 @@
+# Derived projects
+
+Knowledge stays trapped as notes; turning it into output is fully manual. **Derived projects** turns
+a folder of notes into the **structure** of a book, course, article, talk or newsletter — an ordered
+outline that **links every source note**. It does not write prose for you; it **organizes** what you
+already know, from the semantic graph.
+
+## Using it
+
+Open any note in the folder you want to outline, then run **"Derive project outline"** from the
+command palette. ZettelFlow reads that note's **folder**, clusters its notes from the graph, and
+writes a structure note to `_ZettelFlow/projects/<folder> outline.md`, opening it. Offline, no AI.
+
+*(Selecting an arbitrary set of ~40 notes via a picker is a planned follow-up; v1 uses the active
+note's folder.)*
+
+## How the outline is built
+
+Restricted to the folder's indexed notes:
+
+- **Sections** are clusters, the [knowledge-map](living-knowledge-map.md) way (#164): an **anchor**
+  is a selected note whose *in-selection* degree (neighbours that are also in the selection) is ≥ 2;
+  each anchor heads its own section.
+- **Members** — every non-anchor note joins its **strongest-adjacent anchor** (a bidirectional link
+  beats a one-way one; ties by the anchor's in-selection degree, then path). A note with no adjacent
+  anchor lands in a final **Other notes** section — nothing is dropped.
+- **Order** — within a section the anchor leads, then members by in-selection degree (most connected
+  first) then path; sections are ordered by anchor degree, "Other notes" last.
+- Every indexed selected note appears **exactly once**; a note in the selection that isn't indexed is
+  ignored. The whole thing is pure, deterministic and never throws.
+
+## The exported note
+
+A Map of Content: an H1 title (`<folder> — project outline`), a `##` heading per section, and a
+`- [[note]]` wikilink per source note. It's a normal note — edit, reorder and flesh it out into your
+draft.
+
+## Out of scope (deferred)
+
+- **AI polish** — an optional pass to refine section titles / ordering is a follow-up. The shipped
+  command is fully offline and AI-free (that's AC-2).
+- **Project type** — book / course / article / talk / newsletter is a label only for v1 (the title);
+  per-type structure is a follow-up.
+
+## Architecture
+
+```
+deriveOutline(model, selectedPaths, { hubThreshold, miscTitle })   (pure, Obsidian-free, unit-tested)
+  → { sections: [{ title, notes }] }        selection-restricted clustering, every note linked once
+
+renderOutlineMarkdown(outline, { title })                          (pure, Obsidian-free, unit-tested)
+  → the MOC markdown (# title · ## section · - [[note]])
+
+DeriveProjectComponent (derive-project command, no hotkey)
+  active file → parent folder → FileService.getTfilesFromFolder → deriveOutline → renderOutlineMarkdown
+  → FileService.writeFile("_ZettelFlow/projects/<folder> outline.md", …, openAfter)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,5 +87,6 @@ nav:
       - 7.22 Knowledge patterns: development/knowledge-patterns.md
       - 7.23 Knowledge dashboard: development/knowledge-dashboard.md
       - 7.24 ZettelFlow home: development/zettelflow-home.md
+      - 7.25 Derived projects: development/derived-projects.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/architecture/knowledge/projects/deriveOutline.ts
+++ b/src/architecture/knowledge/projects/deriveOutline.ts
@@ -1,0 +1,79 @@
+import type { KnowledgeModel } from "../model/KnowledgeModel";
+
+/** A derived-project outline (#173): titled sections, each linking its source notes in order. */
+export interface Outline {
+    sections: { title: string; notes: string[] }[];
+}
+
+export interface DeriveOutlineOptions {
+    /** In-selection degree at/above which a note anchors its own section (default 2). */
+    hubThreshold?: number;
+    /** Title of the catch-all section for notes with no adjacent anchor (default "Misc"). */
+    miscTitle?: string;
+}
+
+const byPath = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+/**
+ * Pure derived-project outliner (#173, AC-1). Restricted to the indexed `selectedPaths`, it clusters
+ * the selection subgraph the #164 way — **anchors** are selected notes whose in-selection degree
+ * (neighbours, in+out, that are also selected) is ≥ `hubThreshold`; each other note joins its
+ * strongest-adjacent anchor (strength 2 bidirectional / 1 one-way; ties → anchor in-sel-degree desc
+ * then path), else the misc section. An anchor leads its section, then members by in-sel-degree desc
+ * then path; sections by anchor in-sel-degree desc then path, misc last. Every indexed selected note
+ * appears exactly once; unindexed selected paths are ignored. Deterministic, read-only, never throws.
+ */
+export function deriveOutline(
+    model: KnowledgeModel,
+    selectedPaths: string[],
+    opts: DeriveOutlineOptions = {}
+): Outline {
+    const hubThreshold = opts.hubThreshold ?? 2;
+    const miscTitle = opts.miscTitle ?? "Misc";
+
+    const selectedSet = new Set(selectedPaths.filter((path) => model.get(path) !== undefined));
+    if (selectedSet.size === 0) return { sections: [] };
+
+    const adjacency = new Map<string, Set<string>>();
+    const inSelDegree = new Map<string, number>();
+    for (const path of selectedSet) {
+        const neighbours = new Set<string>();
+        for (const n of model.outNeighbors(path)) if (selectedSet.has(n)) neighbours.add(n);
+        for (const n of model.inNeighbors(path)) if (selectedSet.has(n)) neighbours.add(n);
+        neighbours.delete(path);
+        adjacency.set(path, neighbours);
+        inSelDegree.set(path, neighbours.size);
+    }
+    const degree = (path: string): number => inSelDegree.get(path) ?? 0;
+
+    const anchorSet = new Set([...selectedSet].filter((path) => degree(path) >= hubThreshold));
+
+    const strength = (note: string, anchor: string): number =>
+        (model.outNeighbors(note).includes(anchor) ? 1 : 0) + (model.inNeighbors(note).includes(anchor) ? 1 : 0);
+
+    const members = new Map<string, string[]>();
+    for (const anchor of anchorSet) members.set(anchor, []);
+    const misc: string[] = [];
+
+    for (const path of selectedSet) {
+        if (anchorSet.has(path)) continue;
+        const adjacentAnchors = [...(adjacency.get(path) ?? [])]
+            .filter((n) => anchorSet.has(n))
+            .sort((x, y) => strength(path, y) - strength(path, x) || degree(y) - degree(x) || byPath(x, y));
+        if (adjacentAnchors.length === 0) misc.push(path);
+        else members.get(adjacentAnchors[0])!.push(path);
+    }
+
+    const byDegreeThenPath = (x: string, y: string): number => degree(y) - degree(x) || byPath(x, y);
+
+    const sections = [...anchorSet]
+        .sort(byDegreeThenPath)
+        .map((anchor) => ({
+            title: model.get(anchor)?.title ?? anchor,
+            notes: [anchor, ...(members.get(anchor) ?? []).sort(byDegreeThenPath)],
+        }));
+
+    if (misc.length > 0) sections.push({ title: miscTitle, notes: misc.sort(byDegreeThenPath) });
+
+    return { sections };
+}

--- a/src/architecture/knowledge/projects/renderOutlineMarkdown.ts
+++ b/src/architecture/knowledge/projects/renderOutlineMarkdown.ts
@@ -1,0 +1,21 @@
+import type { Outline } from "./deriveOutline";
+
+/** Strip folders and the `.md` extension so a path renders as a wikilink target. */
+function basename(path: string): string {
+    const file = path.split("/").pop() ?? path;
+    return file.replace(/\.md$/i, "");
+}
+
+/**
+ * Pure MOC renderer for a derived-project {@link Outline} (#173): an H1 title, a `##` heading per
+ * section, and a `- [[basename]]` bullet per source note. Obsidian-free and i18n-free (the title is
+ * injected). Ends with a single trailing newline.
+ */
+export function renderOutlineMarkdown(outline: Outline, opts: { title: string }): string {
+    const lines: string[] = [`# ${opts.title}`];
+    for (const section of outline.sections) {
+        lines.push("", `## ${section.title}`, "");
+        for (const note of section.notes) lines.push(`- [[${basename(note)}]]`);
+    }
+    return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/src/architecture/knowledge/projects/renderOutlineMarkdown.ts
+++ b/src/architecture/knowledge/projects/renderOutlineMarkdown.ts
@@ -1,6 +1,11 @@
 import type { Outline } from "./deriveOutline";
 
-/** Strip folders and the `.md` extension so a path renders as a wikilink target. */
+/** The `.md`-stripped path — an unambiguous wikilink target (avoids basename collisions vault-wide). */
+function linkTarget(path: string): string {
+    return path.replace(/\.md$/i, "");
+}
+
+/** Folders + `.md` stripped — the readable display name for the wikilink. */
 function basename(path: string): string {
     const file = path.split("/").pop() ?? path;
     return file.replace(/\.md$/i, "");
@@ -8,14 +13,15 @@ function basename(path: string): string {
 
 /**
  * Pure MOC renderer for a derived-project {@link Outline} (#173): an H1 title, a `##` heading per
- * section, and a `- [[basename]]` bullet per source note. Obsidian-free and i18n-free (the title is
- * injected). Ends with a single trailing newline.
+ * section, and a `- [[path|name]]` bullet per source note (path-qualified so a basename shared with a
+ * note elsewhere in the vault can't mis-resolve). Obsidian-free and i18n-free (the title is injected).
+ * Ends with a single trailing newline.
  */
 export function renderOutlineMarkdown(outline: Outline, opts: { title: string }): string {
     const lines: string[] = [`# ${opts.title}`];
     for (const section of outline.sections) {
         lines.push("", `## ${section.title}`, "");
-        for (const note of section.notes) lines.push(`- [[${basename(note)}]]`);
+        for (const note of section.notes) lines.push(`- [[${linkTarget(note)}|${basename(note)}]]`);
     }
     return `${lines.join("\n").trimEnd()}\n`;
 }

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -791,6 +791,15 @@ export default {
     home_section_empty: 'Nothing here yet.',
     settings_toolkit_home_name: 'Home',
     settings_toolkit_home_desc: 'Your front door — the state of your mind at a glance, with the next session to continue.',
+    // Derived projects (#173)
+    derive_project_command_name: 'Derive project outline',
+    derive_project_title_suffix: 'project outline',
+    derive_project_misc_section: 'Other notes',
+    derive_project_not_ready: 'The knowledge index is still building — try again in a moment.',
+    derive_project_no_active_note: 'Open a note in the folder you want to outline first.',
+    derive_project_empty: 'No indexed notes in this folder to outline.',
+    derive_project_success: 'Outlined {0} notes into {1}.',
+    derive_project_error: 'Could not derive the project outline.',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -791,6 +791,15 @@ export default {
     home_section_empty: 'Aún no hay nada aquí.',
     settings_toolkit_home_name: 'Inicio',
     settings_toolkit_home_desc: 'Tu puerta de entrada — el estado de tu mente de un vistazo, con la próxima sesión que continuar.',
+    // Proyectos derivados (#173)
+    derive_project_command_name: 'Derivar esquema del proyecto',
+    derive_project_title_suffix: 'esquema del proyecto',
+    derive_project_misc_section: 'Otras notas',
+    derive_project_not_ready: 'El índice de conocimiento aún se está construyendo — inténtalo de nuevo en un momento.',
+    derive_project_no_active_note: 'Abre primero una nota de la carpeta que quieres esquematizar.',
+    derive_project_empty: 'No hay notas indexadas en esta carpeta para esquematizar.',
+    derive_project_success: 'Se han esquematizado {0} notas en {1}.',
+    derive_project_error: 'No se ha podido derivar el esquema del proyecto.',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -23,6 +23,7 @@ import { EvolutionTimelineComponent } from "../zcomponents/EvolutionTimelineComp
 import { EvidenceMapComponent } from "../zcomponents/EvidenceMapComponent";
 import { KnowledgeDashboardComponent } from "../zcomponents/KnowledgeDashboardComponent";
 import { HomeComponent } from "../zcomponents/HomeComponent";
+import { DeriveProjectComponent } from "../zcomponents/DeriveProjectComponent";
 import { StarterFlowsComponent } from "../zcomponents/StarterFlowsComponent";
 import { MocBuilderComponent } from "../zcomponents/MocBuilderComponent";
 import { AtomicitySplitComponent } from "../zcomponents/AtomicitySplitComponent";
@@ -53,6 +54,7 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.registerComponent(new EvidenceMapComponent(plugin));
     ZComponentsManager.registerComponent(new KnowledgeDashboardComponent(plugin));
     ZComponentsManager.registerComponent(new HomeComponent(plugin));
+    ZComponentsManager.registerComponent(new DeriveProjectComponent(plugin));
     ZComponentsManager.registerComponent(new StarterFlowsComponent(plugin));
     ZComponentsManager.registerComponent(new MocBuilderComponent(plugin));
     ZComponentsManager.registerComponent(new AtomicitySplitComponent(plugin));

--- a/src/starters/zcomponents/DeriveProjectComponent.ts
+++ b/src/starters/zcomponents/DeriveProjectComponent.ts
@@ -1,0 +1,64 @@
+import { PluginComponent, log } from "architecture";
+import ZettelFlow from "main";
+import { t } from "architecture/lang";
+import { Notice } from "obsidian";
+import { KnowledgeIndex } from "architecture/knowledge";
+import { deriveOutline } from "architecture/knowledge/projects/deriveOutline";
+import { renderOutlineMarkdown } from "architecture/knowledge/projects/renderOutlineMarkdown";
+import { FileService, FILE_EXTENSIONS } from "architecture/plugin";
+
+/**
+ * Registers the `derive-project` command (#173): clusters the active note's folder into an ordered
+ * outline (book/course/article structure) and writes/opens a structure note linking every source
+ * note. No hotkey, offline, no AI. Safe Notices when the index isn't ready / no active note / the
+ * folder has no indexed notes; failures degrade to a Notice + `log.error`.
+ */
+export class DeriveProjectComponent extends PluginComponent {
+    constructor(plugin: ZettelFlow) {
+        super(plugin);
+        this.plugin = plugin;
+    }
+
+    private plugin: ZettelFlow;
+
+    onLoad(): void {
+        this.plugin.addCommand({
+            id: "derive-project",
+            name: t("derive_project_command_name"),
+            callback: () => void this.derive(),
+        });
+    }
+
+    private async derive(): Promise<void> {
+        const index = KnowledgeIndex.getInstance();
+        if (index.status !== "ready") {
+            new Notice(t("derive_project_not_ready"));
+            return;
+        }
+        const folder = this.plugin.app.workspace.getActiveFile()?.parent;
+        if (!folder) {
+            new Notice(t("derive_project_no_active_note"));
+            return;
+        }
+        try {
+            const paths = FileService.getTfilesFromFolder(folder.path, FILE_EXTENSIONS.ONLY_MD, false).map(
+                (file) => file.path
+            );
+            const outline = deriveOutline(index.getModel(), paths, { miscTitle: t("derive_project_misc_section") });
+            const linked = outline.sections.reduce((total, section) => total + section.notes.length, 0);
+            if (linked === 0) {
+                new Notice(t("derive_project_empty"));
+                return;
+            }
+            const folderName = folder.name || "Vault";
+            const title = `${folderName} — ${t("derive_project_title_suffix")}`;
+            const markdown = renderOutlineMarkdown(outline, { title });
+            const outPath = `_ZettelFlow/projects/${folderName} outline.md`;
+            await FileService.writeFile(outPath, markdown, true);
+            new Notice(t("derive_project_success", String(linked), outPath));
+        } catch (error) {
+            log.error(`[derive-project] failed: ${error instanceof Error ? error.message : "unknown error"}`);
+            new Notice(t("derive_project_error"));
+        }
+    }
+}

--- a/test/architecture/knowledge/projects/deriveOutline.test.ts
+++ b/test/architecture/knowledge/projects/deriveOutline.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "@jest/globals";
+import { deriveOutline } from "architecture/knowledge/projects/deriveOutline";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// a: anchor (in-sel degree 4) · b: anchor (3) · shared: bridges a & b (assigned to a, strength 2) ·
+// m*/n*: leaves · lonely: isolated → Misc. ghost.md is selected but unindexed → ignored.
+const model = buildModel([
+    idea("book/a.md", "permanent", [{ to: "book/m1.md" }, { to: "book/m2.md" }, { to: "book/m3.md" }, { to: "book/shared.md" }]),
+    idea("book/b.md", "permanent", [{ to: "book/n1.md" }, { to: "book/n2.md" }, { to: "book/shared.md" }]),
+    idea("book/shared.md", "permanent", [{ to: "book/a.md" }]),
+    idea("book/m1.md", "permanent", []),
+    idea("book/m2.md", "permanent", []),
+    idea("book/m3.md", "permanent", []),
+    idea("book/n1.md", "permanent", []),
+    idea("book/n2.md", "permanent", []),
+    idea("book/lonely.md", "permanent", []),
+]);
+
+const selection = [
+    "book/a.md", "book/b.md", "book/shared.md",
+    "book/m1.md", "book/m2.md", "book/m3.md",
+    "book/n1.md", "book/n2.md", "book/lonely.md",
+    "book/ghost.md",
+];
+
+describe("deriveOutline (#173, FR-3..FR-6/FR-10, AC-1)", () => {
+    it("clusters the selection into ordered, titled sections with anchors leading", () => {
+        expect(deriveOutline(model, selection, { hubThreshold: 3 })).toEqual({
+            sections: [
+                { title: "book/a.md", notes: ["book/a.md", "book/shared.md", "book/m1.md", "book/m2.md", "book/m3.md"] },
+                { title: "book/b.md", notes: ["book/b.md", "book/n1.md", "book/n2.md"] },
+                { title: "Misc", notes: ["book/lonely.md"] },
+            ],
+        });
+    });
+
+    it("links every indexed selected note exactly once, dropping the unindexed one", () => {
+        const linked = deriveOutline(model, selection, { hubThreshold: 3 }).sections.flatMap((s) => s.notes);
+        expect([...linked].sort()).toEqual([
+            "book/a.md", "book/b.md", "book/lonely.md",
+            "book/m1.md", "book/m2.md", "book/m3.md",
+            "book/n1.md", "book/n2.md", "book/shared.md",
+        ]);
+        expect(new Set(linked).size).toBe(linked.length);
+    });
+
+    it("defaults the hub threshold to 2", () => {
+        const small = buildModel([
+            idea("x.md", "permanent", [{ to: "c1.md" }, { to: "c2.md" }]),
+            idea("c1.md", "permanent", []),
+            idea("c2.md", "permanent", []),
+        ]);
+        expect(deriveOutline(small, ["x.md", "c1.md", "c2.md"])).toEqual({
+            sections: [{ title: "x.md", notes: ["x.md", "c1.md", "c2.md"] }],
+        });
+    });
+
+    it("returns no sections for an empty/indexless selection, deterministically and read-only", () => {
+        expect(deriveOutline(model, [])).toEqual({ sections: [] });
+        expect(deriveOutline(model, ["book/ghost.md"])).toEqual({ sections: [] });
+        const before = model.size();
+        expect(deriveOutline(model, selection, { hubThreshold: 3 })).toEqual(deriveOutline(model, selection, { hubThreshold: 3 }));
+        expect(model.size()).toBe(before);
+    });
+});

--- a/test/architecture/knowledge/projects/renderOutlineMarkdown.test.ts
+++ b/test/architecture/knowledge/projects/renderOutlineMarkdown.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "@jest/globals";
+import { renderOutlineMarkdown } from "architecture/knowledge/projects/renderOutlineMarkdown";
+
+describe("renderOutlineMarkdown (#173, AC-1 render)", () => {
+    it("renders a MOC: H1 title, ## per section, - [[basename]] per note", () => {
+        const outline = {
+            sections: [
+                { title: "Foundations", notes: ["book/a.md", "book/shared.md"] },
+                { title: "Misc", notes: ["book/lonely.md"] },
+            ],
+        };
+        expect(renderOutlineMarkdown(outline, { title: "book — project outline" })).toBe(
+            "# book — project outline\n\n## Foundations\n\n- [[a]]\n- [[shared]]\n\n## Misc\n\n- [[lonely]]\n"
+        );
+    });
+
+    it("renders just the title for an empty outline", () => {
+        expect(renderOutlineMarkdown({ sections: [] }, { title: "book — project outline" })).toBe(
+            "# book — project outline\n"
+        );
+    });
+});

--- a/test/architecture/knowledge/projects/renderOutlineMarkdown.test.ts
+++ b/test/architecture/knowledge/projects/renderOutlineMarkdown.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "@jest/globals";
 import { renderOutlineMarkdown } from "architecture/knowledge/projects/renderOutlineMarkdown";
 
 describe("renderOutlineMarkdown (#173, AC-1 render)", () => {
-    it("renders a MOC: H1 title, ## per section, - [[basename]] per note", () => {
+    it("renders a MOC: H1 title, ## per section, path-qualified [[path|name]] per note", () => {
         const outline = {
             sections: [
                 { title: "Foundations", notes: ["book/a.md", "book/shared.md"] },
@@ -10,7 +10,7 @@ describe("renderOutlineMarkdown (#173, AC-1 render)", () => {
             ],
         };
         expect(renderOutlineMarkdown(outline, { title: "book — project outline" })).toBe(
-            "# book — project outline\n\n## Foundations\n\n- [[a]]\n- [[shared]]\n\n## Misc\n\n- [[lonely]]\n"
+            "# book — project outline\n\n## Foundations\n\n- [[book/a|a]]\n- [[book/shared|shared]]\n\n## Misc\n\n- [[book/lonely|lonely]]\n"
         );
     });
 

--- a/test/architecture/knowledge/pure-is-obsidian-free.test.ts
+++ b/test/architecture/knowledge/pure-is-obsidian-free.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 
 // src/architecture/knowledge, reached from test/architecture/knowledge/
 const KNOWLEDGE_ROOT = join(__dirname, "..", "..", "..", "src", "architecture", "knowledge");
-const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map", "traverse", "questions", "timeline", "synthesis", "dashboard", "home"];
+const PURE_DIRS = ["model", "parse", "derive", "query", "lifecycle", "relations", "claims", "debt", "review", "balance", "journal", "discovery", "map", "traverse", "questions", "timeline", "synthesis", "dashboard", "home", "projects"];
 
 function collectTsFiles(dir: string): string[] {
     const out: string[] = [];

--- a/test/config/deriveProjectsLocale.test.ts
+++ b/test/config/deriveProjectsLocale.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "derive_project_command_name",
+    "derive_project_title_suffix",
+    "derive_project_misc_section",
+    "derive_project_not_ready",
+    "derive_project_no_active_note",
+    "derive_project_empty",
+    "derive_project_success",
+    "derive_project_error",
+];
+
+describe("derive project i18n parity (#173)", () => {
+    it("defines all 8 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(8);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Derived projects — turn a set of notes into a book/course/article outline (#173)

Knowledge stays trapped as notes; turning it into output is manual. **Derive project outline** turns a
folder of notes into the *structure* of a book / course / article — an ordered outline that **links
every source note**. It organizes what you already know; it doesn't write prose. Offline, no AI (AC-2).

### What ships
- **Pure `deriveOutline(model, selectedPaths, opts?)`** (new `projects/` dir, in `PURE_DIRS`, off the barrel) — selection-restricted clustering the #164 way: anchors (in-selection degree ≥ 2) head sections; each other note joins its strongest-adjacent anchor (else a "misc" section); anchor leads, members by degree-desc then path; sections by anchor degree; **every indexed selected note linked exactly once**, unindexed ignored. Exact-fixture tested (AC-1).
- **Pure `renderOutlineMarkdown(outline, { title })`** — the MOC markdown (H1 · `##` per section · path-qualified `[[folder/note|name]]` bullets). Exact-fixture tested.
- **`derive-project` command** (mirrors #160, no hotkey) — reads the **active note's folder**, guards not-ready / no-active-note / empty (Notice, **no write**), and writes/opens `_ZettelFlow/projects/<folder> outline.md` via the sanctioned `FileService.writeFile`.

### Scope
Selection source = the active note's folder (a richer picker is a follow-up). **AI polish** and **per-type structure** (book/course/… label only for v1) are deferred follow-ups.

### Guardrails / AC
- Pure cores Obsidian-free, off the barrel, in `PURE_DIRS`. en/es parity (8 keys), docs `development/derived-projects.md` + nav 7.25, README (📖 toolkit bullet + Features row; no action-count change). One disclosed FS write.
- `npm run verify` green — typecheck + oxlint + **lint:obsidian 0** + **789** jest tests.
- Reviewed by `obsidian-plugin-reviewer`: **no blocking, raises the score**; the write is sanctioned and the empty-guard prevents a title-only MOC. Applied the robustness nit (path-qualified wikilinks so a basename collision can't mis-resolve).

Closes #173. Relates to #144, #123.
