### PR TITLE
feat(gallery): methodology packages — the knowledge-system app store (#174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   (connected / orphaned / unresolved), a knowledge-debt bar, and a "today" panel (to process ·
   contradictions · connections · open questions) — **every panel proposes a recommended next
   action**, one click from the surface to act on it. Read-only, offline.
+- **📦 Methodology packages** — an app store of knowledge *systems*: install the **Zettelkasten**
+  package and get all its flows (and their built-in patterns) in one go; remove it just as cleanly
+  (it trashes only its own files, never your notes). Atomic install, local, no network.
 - **🚀 Starter flows** — one-click, ready-made flows for the four classic note types
   (fleeting, literature, permanent, structure/MOC), plus a **Literature → Permanent** composed
   showcase that chains the cognitive actions (extract claims → find related → suggest connections →
@@ -165,6 +168,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Knowledge dashboard** | An ops console for the state of your system — connectivity % · knowledge debt · today (to process, contradictions, connections, open questions) — where every panel proposes a recommended next action. Read-only, offline. |
 | **ZettelFlow Home** | The IDE-style front door: greeting + "thinking for N days", new ideas, main concepts, notes that deserve a review, suggested connections, and the deterministic next recommended session. Read-only, offline. |
 | **Derived projects** | Turn a folder of notes into an ordered book/course/article outline (MOC) — clustered and sequenced from the semantic graph, linking every source note. Graph-derived, offline, no AI. |
+| **Methodology packages** | Install a whole knowledge system as a unit — the reference **Zettelkasten** package bundles all its flows; atomic install + clean removal (trashes only its own files). Local, no network. |
 | **Second-brain review** | A command that generates a weekly review note — ideas created, orphans, forgotten ideas, important-but-unreviewed — each with a next action. |
 | **Thinking heatmap** | A GitHub-style calendar of ideas *developed* (state advanced, source/connection added) over the last year, fed by a private on-by-default local journal (day → count only). |
 | **Morning discovery** | Up to three unexpected connections — unlinked note pairs that share concepts — each one click from being related. Graph-structural, offline. |

--- a/docs/development/methodology-packages.md
+++ b/docs/development/methodology-packages.md
@@ -1,0 +1,51 @@
+# Methodology packages
+
+The gallery ships single templates; the leverage is shipping whole **methodologies**. A **methodology
+package** is an app-store-style bundle of a knowledge system — install "Zettelkasten" and get all its
+flows (and their built-in patterns) in one go, remove them just as cleanly.
+
+## What a package is (and isn't)
+
+A package is a **named, atomic bundle of installable files** — the flows (canvas + step notes) that
+*use* the built-in actions, patterns and dashboards. It **ships no code**: actions, views and
+dashboards already live in the plugin. So the reference **Zettelkasten** package is simply a name over
+the five [starter flows](zettelkasten-starter-flows.md) (fleeting · literature · permanent · structure
+· Literature → Permanent), installed and removed as a unit.
+
+## Install / uninstall
+
+- **Install** — run **"Install Zettelkasten methodology package"** (or the **Install** button next to
+  *Methodology packages* in **Settings → ZettelFlow → Zettelkasten toolkit**). It creates all the
+  package's flow files (idempotently — existing files are kept) and records the package in settings.
+- **Uninstall** — run **"Remove Zettelkasten methodology package"**. It **trashes only the package's
+  own tracked files** (recoverable, via the system trash) and drops the settings record.
+
+### Atomic and safe
+
+- **Atomic install** — if a file fails to create mid-install, the package **rolls back** the files it
+  created and records nothing, leaving the vault in its pre-install state.
+- **Clean removal** — uninstall trashes **only** the package's tracked files. It **never** deletes the
+  shared `_ZettelFlow/examples` / `steps` / `notes` folders, and never your notes — the tracked path
+  list (stored in `settings.installedPackages`) is the exact source of truth.
+
+## Out of scope (deferred)
+
+- **The backend app store** — browsing/installing packages from the community backend is a follow-up.
+  v1 ships the format and the one built-in reference package, fully **local, zero network**.
+- **The other methodologies** — PARA, GTD, Research, Reading, Writing, Software-architecture KB are
+  future packages built on this same format.
+- No cross-package dependency resolution; no AI.
+
+## Architecture
+
+```
+MethodologyPackage { id, name, description, version, flows }   ·   ZETTELKASTEN_PACKAGE
+packageFilePaths(pkg) · planInstall(pkg, existing) · planRemove(tracked, existing)   (pure, tested)
+
+installPackage(vault, pkg)   → reuses installStarterFlows; rolls back created files on failure
+uninstallPackage(vault, tracked) → trashes only tracked files, never folders          (pure, tested)
+
+MethodologyPackageComponent (install-/uninstall-methodology-package commands, no hotkey)
+  wraps the vault (create + FileService.deleteFile→fileManager().trashFile) and tracks
+  settings.installedPackages[id] = { paths, version }
+```

--- a/docs/development/methodology-packages.md
+++ b/docs/development/methodology-packages.md
@@ -28,6 +28,11 @@ the five [starter flows](zettelkasten-starter-flows.md) (fleeting · literature 
   shared `_ZettelFlow/examples` / `steps` / `notes` folders, and never your notes — the tracked path
   list (stored in `settings.installedPackages`) is the exact source of truth.
 
+> The Zettelkasten package's files are the same flow files as the standalone
+> [starter flows](zettelkasten-starter-flows.md). If you installed those separately, uninstalling the
+> package reclaims those shared files too (recoverable from the system trash) — they are the package's
+> declared files.
+
 ## Out of scope (deferred)
 
 - **The backend app store** — browsing/installing packages from the community backend is a follow-up.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,5 +88,6 @@ nav:
       - 7.23 Knowledge dashboard: development/knowledge-dashboard.md
       - 7.24 ZettelFlow home: development/zettelflow-home.md
       - 7.25 Derived projects: development/derived-projects.md
+      - 7.26 Methodology packages: development/methodology-packages.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/application/packages/methodologyPackages.ts
+++ b/src/application/packages/methodologyPackages.ts
@@ -1,0 +1,57 @@
+import { STARTER_FLOW_PATHS, StarterFlowType } from "application/notes/starterFlowsService";
+
+/**
+ * A methodology package (#174): a named, atomic bundle of installable flow files (each already
+ * carrying its #170 patterns) that *use* the built-in actions/dashboards. Packages ship no code —
+ * the reference {@link ZETTELKASTEN_PACKAGE} is just a name over the #157 starter flows.
+ */
+export interface MethodologyPackage {
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    flows: StarterFlowType[];
+}
+
+/** The built-in reference package: the five classic Zettelkasten flows as one installable unit. */
+export const ZETTELKASTEN_PACKAGE: MethodologyPackage = {
+    id: "zettelkasten",
+    name: "Zettelkasten",
+    description: "The classic Zettelkasten — fleeting, literature, permanent and structure flows, plus the Literature → Permanent capstone.",
+    version: "1.0.0",
+    flows: ["fleeting", "literature", "permanent", "moc", "literatureToPermanent"],
+};
+
+/** Every file a package owns — the canvas + step of each bundled flow, deduped and sorted. */
+export function packageFilePaths(pkg: MethodologyPackage): string[] {
+    const paths = new Set<string>();
+    for (const flow of pkg.flows) {
+        paths.add(STARTER_FLOW_PATHS[flow].canvas);
+        paths.add(STARTER_FLOW_PATHS[flow].step);
+    }
+    return [...paths].sort();
+}
+
+/** Partition a package's owned paths by whether they already exist — what an install would create. */
+export function planInstall(
+    pkg: MethodologyPackage,
+    existing: Set<string>
+): { toCreate: string[]; alreadyPresent: string[] } {
+    const owned = packageFilePaths(pkg);
+    return {
+        toCreate: owned.filter((path) => !existing.has(path)),
+        alreadyPresent: owned.filter((path) => existing.has(path)),
+    };
+}
+
+/** Partition the tracked paths of an installed package by existence — what an uninstall would trash. */
+export function planRemove(
+    trackedPaths: string[],
+    existing: Set<string>
+): { toTrash: string[]; missing: string[] } {
+    const sorted = [...trackedPaths].sort();
+    return {
+        toTrash: sorted.filter((path) => existing.has(path)),
+        missing: sorted.filter((path) => !existing.has(path)),
+    };
+}

--- a/src/application/packages/packageService.ts
+++ b/src/application/packages/packageService.ts
@@ -1,0 +1,61 @@
+import {
+    StarterFlowInstallResult,
+    StarterFlowVault,
+    installStarterFlows,
+} from "application/notes/starterFlowsService";
+import { MethodologyPackage, packageFilePaths } from "./methodologyPackages";
+
+/** The vault surface a package install/uninstall needs: the #157 create surface plus a trash op. */
+export type PackageVault = StarterFlowVault & { trash(path: string): Promise<void> };
+
+/**
+ * Install a methodology package (#174) atomically. Reuses the idempotent #157 `installStarterFlows`
+ * for its flows; on a mid-install `create` failure it **trashes the files it created this run and
+ * rethrows**, so the vault is left in its pre-install state and the caller records nothing. Only the
+ * package's own flow files are created/rolled back — never the shared folders. Obsidian-free.
+ */
+export async function installPackage(
+    vault: PackageVault,
+    pkg: MethodologyPackage
+): Promise<{ paths: string[]; result: StarterFlowInstallResult }> {
+    const createdThisRun: string[] = [];
+    const recordingVault: PackageVault = {
+        ...vault,
+        create: async (path: string, data: string) => {
+            const file = await vault.create(path, data);
+            createdThisRun.push(path);
+            return file;
+        },
+    };
+    try {
+        const result = await installStarterFlows(recordingVault, pkg.flows);
+        return { paths: packageFilePaths(pkg), result };
+    } catch (error) {
+        for (const path of [...createdThisRun].reverse()) {
+            try {
+                await vault.trash(path);
+            } catch {
+                // best-effort rollback — a failed trash must not mask the original error
+            }
+        }
+        throw error;
+    }
+}
+
+/**
+ * Uninstall a package (#174) by trashing exactly its tracked file paths that still resolve — never a
+ * folder, never an untracked file. Idempotent (a missing path is a no-op). Obsidian-free.
+ */
+export async function uninstallPackage(
+    vault: PackageVault,
+    trackedPaths: string[]
+): Promise<{ trashed: string[] }> {
+    const trashed: string[] = [];
+    for (const path of [...trackedPaths].sort()) {
+        if (vault.getFileByPath(path)) {
+            await vault.trash(path);
+            trashed.push(path);
+        }
+    }
+    return { trashed };
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -800,6 +800,17 @@ export default {
     derive_project_empty: 'No indexed notes in this folder to outline.',
     derive_project_success: 'Outlined {0} notes into {1}.',
     derive_project_error: 'Could not derive the project outline.',
+    // Methodology packages (#174)
+    command_install_methodology_package: 'Install Zettelkasten methodology package',
+    command_uninstall_methodology_package: 'Remove Zettelkasten methodology package',
+    methodology_package_installed_notice: 'Installed the {0} package — {1} flows.',
+    methodology_package_already_installed: 'The {0} package is already installed.',
+    methodology_package_removed_notice: 'Removed the {0} package.',
+    methodology_package_not_installed: 'The {0} package is not installed.',
+    methodology_package_install_error: 'Could not install the methodology package.',
+    methodology_package_uninstall_error: 'Could not remove the methodology package.',
+    settings_toolkit_packages_name: 'Methodology packages',
+    settings_toolkit_packages_desc: 'Install a whole knowledge system at once — the Zettelkasten package bundles all its flows.',
     // Relation actions (#154)
     relation_find_related_label: 'Find related',
     relation_find_related_desc: 'Rank notes worth linking by shared graph context (co-citation and coupling).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -800,6 +800,17 @@ export default {
     derive_project_empty: 'No hay notas indexadas en esta carpeta para esquematizar.',
     derive_project_success: 'Se han esquematizado {0} notas en {1}.',
     derive_project_error: 'No se ha podido derivar el esquema del proyecto.',
+    // Paquetes de metodología (#174)
+    command_install_methodology_package: 'Instalar el paquete de metodología Zettelkasten',
+    command_uninstall_methodology_package: 'Quitar el paquete de metodología Zettelkasten',
+    methodology_package_installed_notice: 'Se ha instalado el paquete {0} — {1} flujos.',
+    methodology_package_already_installed: 'El paquete {0} ya está instalado.',
+    methodology_package_removed_notice: 'Se ha quitado el paquete {0}.',
+    methodology_package_not_installed: 'El paquete {0} no está instalado.',
+    methodology_package_install_error: 'No se ha podido instalar el paquete de metodología.',
+    methodology_package_uninstall_error: 'No se ha podido quitar el paquete de metodología.',
+    settings_toolkit_packages_name: 'Paquetes de metodología',
+    settings_toolkit_packages_desc: 'Instala todo un sistema de conocimiento de una vez — el paquete Zettelkasten incluye todos sus flujos.',
     // Acciones de relaciones (#154)
     relation_find_related_label: 'Buscar relacionadas',
     relation_find_related_desc: 'Ordena las notas que vale la pena enlazar por contexto de grafo compartido (co-citación y acoplamiento).',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -38,6 +38,7 @@ import { createExampleFlow } from "application/notes/onboardingService";
 import { SlipboxHealthView } from "architecture/components/core/slipboxHealth/SlipboxHealthView";
 import { ResurfaceView } from "architecture/components/core/resurface/ResurfaceView";
 import { StarterFlowsModal } from "zettelkasten/modals/StarterFlowsModal";
+import { installReferencePackage } from "starters/zcomponents/MethodologyPackageComponent";
 
 // Obsidian bundles moment and re-exports it as a namespace; cast to the callable signature.
 const moment = obsidianMoment as unknown as typeof MomentFn;
@@ -64,6 +65,7 @@ const TOOLKIT_DOCS = {
     evidenceMap: `${DOCS_BASE}development/evidence-map/`,
     dashboard: `${DOCS_BASE}development/knowledge-dashboard/`,
     home: `${DOCS_BASE}development/zettelflow-home/`,
+    packages: `${DOCS_BASE}development/methodology-packages/`,
 } as const;
 
 export class ZettelFlowSettingsTab extends PluginSettingTab {
@@ -651,6 +653,19 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                                     .onClick(() => new StarterFlowsModal(plugin.app).open())
                             );
                             addDocsButton(setting, TOOLKIT_DOCS.starter);
+                        },
+                    },
+                    {
+                        name: t("settings_toolkit_packages_name"),
+                        desc: t("settings_toolkit_packages_desc"),
+                        render: (setting) => {
+                            setting.addButton((btn) =>
+                                btn
+                                    .setButtonText(t("settings_toolkit_install_button"))
+                                    .setCta()
+                                    .onClick(() => void installReferencePackage(plugin))
+                            );
+                            addDocsButton(setting, TOOLKIT_DOCS.packages);
                         },
                     },
                     // Learn-more rows: features reached via the wizard / commands, doc link only.

--- a/src/config/typing.ts
+++ b/src/config/typing.ts
@@ -36,6 +36,12 @@ export interface ZettelFlowSettings {
     foldersFlowsPath: string;
     /** Installed templates divided into steps and actions */
     installedTemplates: InstalledTemplates;
+
+    /**
+     * Installed methodology packages (#174), keyed by package id → the owned file paths (the source
+     * of truth for a clean uninstall) and the installed version. Additive; empty by default.
+     */
+    installedPackages: Record<string, { paths: string[]; version: string }>;
     /** Community-specific settings */
     communitySettings: {
         /** Folder where Markdown templates are stored */
@@ -198,6 +204,7 @@ export const DEFAULT_SETTINGS: Partial<ZettelFlowSettings> = {
         steps: {},   // No step templates are installed by default.
         actions: {}  // No action templates are installed by default.
     },
+    installedPackages: {}, // No methodology packages installed by default (#174).
     communitySettings: {
         url: "http://127.0.0.1:8000", // Default URL for community resources.
         markdownTemplateFolder: "_ZettelFlowMdTemplates", // Default folder for Markdown templates.

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -24,6 +24,7 @@ import { EvidenceMapComponent } from "../zcomponents/EvidenceMapComponent";
 import { KnowledgeDashboardComponent } from "../zcomponents/KnowledgeDashboardComponent";
 import { HomeComponent } from "../zcomponents/HomeComponent";
 import { DeriveProjectComponent } from "../zcomponents/DeriveProjectComponent";
+import { MethodologyPackageComponent } from "../zcomponents/MethodologyPackageComponent";
 import { StarterFlowsComponent } from "../zcomponents/StarterFlowsComponent";
 import { MocBuilderComponent } from "../zcomponents/MocBuilderComponent";
 import { AtomicitySplitComponent } from "../zcomponents/AtomicitySplitComponent";
@@ -55,6 +56,7 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.registerComponent(new KnowledgeDashboardComponent(plugin));
     ZComponentsManager.registerComponent(new HomeComponent(plugin));
     ZComponentsManager.registerComponent(new DeriveProjectComponent(plugin));
+    ZComponentsManager.registerComponent(new MethodologyPackageComponent(plugin));
     ZComponentsManager.registerComponent(new StarterFlowsComponent(plugin));
     ZComponentsManager.registerComponent(new MocBuilderComponent(plugin));
     ZComponentsManager.registerComponent(new AtomicitySplitComponent(plugin));

--- a/src/starters/zcomponents/MethodologyPackageComponent.ts
+++ b/src/starters/zcomponents/MethodologyPackageComponent.ts
@@ -1,0 +1,82 @@
+import { PluginComponent, log, ObsidianApi } from "architecture";
+import ZettelFlow from "main";
+import { t } from "architecture/lang";
+import { Notice, TFile } from "obsidian";
+import { FileService } from "architecture/plugin";
+import { ZETTELKASTEN_PACKAGE } from "application/packages/methodologyPackages";
+import { PackageVault, installPackage, uninstallPackage } from "application/packages/packageService";
+
+/** A `PackageVault` over the real vault: the create surface + a sanctioned trash (never `.adapter.`). */
+function packageVault(): PackageVault {
+    const vault = ObsidianApi.vault();
+    return {
+        getAbstractFileByPath: (path) => vault.getAbstractFileByPath(path),
+        getFileByPath: (path) => vault.getFileByPath(path),
+        createFolder: (path) => vault.createFolder(path),
+        create: (path, data) => vault.create(path, data),
+        trash: async (path) => {
+            const file = await FileService.getFile(path, false);
+            if (file instanceof TFile) await FileService.deleteFile(file);
+        },
+    };
+}
+
+/** Install the reference Zettelkasten package (#174): create its flows atomically, track it, notify. */
+export async function installReferencePackage(plugin: ZettelFlow): Promise<void> {
+    const pkg = ZETTELKASTEN_PACKAGE;
+    if (plugin.settings.installedPackages[pkg.id]) {
+        new Notice(t("methodology_package_already_installed", pkg.name));
+        return;
+    }
+    try {
+        const { paths } = await installPackage(packageVault(), pkg);
+        plugin.settings.installedPackages[pkg.id] = { paths, version: pkg.version };
+        await plugin.saveSettings();
+        new Notice(t("methodology_package_installed_notice", pkg.name, String(pkg.flows.length)));
+    } catch (error) {
+        log.error(`[methodology-package] install failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        new Notice(t("methodology_package_install_error"));
+    }
+}
+
+/** Uninstall the reference package (#174): trash its tracked files, drop the record, notify. */
+export async function uninstallReferencePackage(plugin: ZettelFlow): Promise<void> {
+    const pkg = ZETTELKASTEN_PACKAGE;
+    const record = plugin.settings.installedPackages[pkg.id];
+    if (!record) {
+        new Notice(t("methodology_package_not_installed", pkg.name));
+        return;
+    }
+    try {
+        await uninstallPackage(packageVault(), record.paths);
+        delete plugin.settings.installedPackages[pkg.id];
+        await plugin.saveSettings();
+        new Notice(t("methodology_package_removed_notice", pkg.name));
+    } catch (error) {
+        log.error(`[methodology-package] uninstall failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        new Notice(t("methodology_package_uninstall_error"));
+    }
+}
+
+/** Registers the install/uninstall methodology-package commands (#174). No hotkey. */
+export class MethodologyPackageComponent extends PluginComponent {
+    constructor(plugin: ZettelFlow) {
+        super(plugin);
+        this.plugin = plugin;
+    }
+
+    private plugin: ZettelFlow;
+
+    onLoad(): void {
+        this.plugin.addCommand({
+            id: "install-methodology-package",
+            name: t("command_install_methodology_package"),
+            callback: () => void installReferencePackage(this.plugin),
+        });
+        this.plugin.addCommand({
+            id: "uninstall-methodology-package",
+            name: t("command_uninstall_methodology_package"),
+            callback: () => void uninstallReferencePackage(this.plugin),
+        });
+    }
+}

--- a/test/application/packages/methodologyPackages.test.ts
+++ b/test/application/packages/methodologyPackages.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    ZETTELKASTEN_PACKAGE,
+    packageFilePaths,
+    planInstall,
+    planRemove,
+} from "application/packages/methodologyPackages";
+import { STARTER_FLOW_PATHS } from "application/notes/starterFlowsService";
+
+const ownedPaths = (): string[] =>
+    [...new Set(ZETTELKASTEN_PACKAGE.flows.flatMap((flow) => [STARTER_FLOW_PATHS[flow].canvas, STARTER_FLOW_PATHS[flow].step]))].sort();
+
+describe("methodology package model (#174, FR-1/FR-2/FR-3, AC-1 pure)", () => {
+    it("owns the sorted, deduped canvas+step of each bundled flow (10 files)", () => {
+        const paths = packageFilePaths(ZETTELKASTEN_PACKAGE);
+        expect(paths).toEqual(ownedPaths());
+        expect(paths.length).toBe(10);
+        expect(packageFilePaths(ZETTELKASTEN_PACKAGE)).toEqual(paths); // deterministic
+    });
+
+    it("planInstall partitions owned paths into toCreate / alreadyPresent", () => {
+        const owned = ownedPaths();
+        const existing = new Set([owned[0], owned[1]]);
+        expect(planInstall(ZETTELKASTEN_PACKAGE, existing)).toEqual({
+            toCreate: owned.slice(2),
+            alreadyPresent: [owned[0], owned[1]],
+        });
+        expect(planInstall(ZETTELKASTEN_PACKAGE, new Set())).toEqual({ toCreate: owned, alreadyPresent: [] });
+    });
+
+    it("planRemove partitions tracked paths into toTrash / missing", () => {
+        const tracked = ["b/x.md", "a/y.md", "c/z.md"];
+        expect(planRemove(tracked, new Set(["a/y.md", "c/z.md"]))).toEqual({
+            toTrash: ["a/y.md", "c/z.md"],
+            missing: ["b/x.md"],
+        });
+    });
+});

--- a/test/application/packages/packageService.test.ts
+++ b/test/application/packages/packageService.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "@jest/globals";
+import { installPackage, uninstallPackage, PackageVault } from "application/packages/packageService";
+import { ZETTELKASTEN_PACKAGE, packageFilePaths } from "application/packages/methodologyPackages";
+import { STARTER_FLOW_PATHS } from "application/notes/starterFlowsService";
+
+/** Set-backed mock vault (mirrors starterFlowsService.test.ts) + content capture + a trash op. */
+function makeVault(preexisting: string[] = []) {
+    const files = new Set<string>(preexisting);
+    const content = new Map<string, string>();
+    const foldersCreated: string[] = [];
+    const vault: PackageVault = {
+        getAbstractFileByPath: (p: string) => (files.has(p) ? { path: p } : null),
+        getFileByPath: (p: string) => (files.has(p) ? { path: p } : null),
+        createFolder: async (p: string) => {
+            files.add(p);
+            foldersCreated.push(p);
+            return { path: p };
+        },
+        create: async (p: string, d: string) => {
+            files.add(p);
+            content.set(p, d);
+            return { path: p };
+        },
+        trash: async (p: string) => {
+            files.delete(p);
+        },
+    };
+    return { vault, files, content, foldersCreated };
+}
+
+const owned = packageFilePaths(ZETTELKASTEN_PACKAGE);
+
+describe("packageService (#174, FR-4/FR-5/FR-7/FR-11, AC-1/AC-2)", () => {
+    it("installs every owned file (with the #170 pattern), idempotently", async () => {
+        const { vault, files, content } = makeVault();
+        const { paths, result } = await installPackage(vault, ZETTELKASTEN_PACKAGE);
+        expect(paths).toEqual(owned);
+        for (const path of owned) expect(files.has(path)).toBe(true);
+        expect([...result.installed].sort()).toEqual([...ZETTELKASTEN_PACKAGE.flows].sort());
+        expect(content.get(STARTER_FLOW_PATHS.permanent.step)).toContain("onCreation:");
+
+        const second = await installPackage(vault, ZETTELKASTEN_PACKAGE);
+        expect(second.result.installed).toEqual([]);
+    });
+
+    it("uninstalls exactly the tracked files and never a shared folder", async () => {
+        const { vault, files, foldersCreated } = makeVault();
+        await installPackage(vault, ZETTELKASTEN_PACKAGE);
+        const { trashed } = await uninstallPackage(vault, owned);
+        expect(trashed).toEqual(owned);
+        for (const path of owned) expect(files.has(path)).toBe(false);
+        for (const folder of foldersCreated) expect(files.has(folder)).toBe(true);
+        // idempotent: uninstall again trashes nothing.
+        expect((await uninstallPackage(vault, owned)).trashed).toEqual([]);
+    });
+
+    it("round-trips install → uninstall → reinstall cleanly", async () => {
+        const { vault, files } = makeVault();
+        await installPackage(vault, ZETTELKASTEN_PACKAGE);
+        await uninstallPackage(vault, owned);
+        await installPackage(vault, ZETTELKASTEN_PACKAGE);
+        for (const path of owned) expect(files.has(path)).toBe(true);
+    });
+
+    it("rolls back a partial install on a create failure and rethrows (AC-1)", async () => {
+        const { files, content, foldersCreated } = makeVault();
+        let calls = 0;
+        const vault: PackageVault = {
+            getAbstractFileByPath: (p: string) => (files.has(p) ? { path: p } : null),
+            getFileByPath: (p: string) => (files.has(p) ? { path: p } : null),
+            createFolder: async (p: string) => {
+                files.add(p);
+                foldersCreated.push(p);
+                return { path: p };
+            },
+            create: async (p: string, d: string) => {
+                calls++;
+                if (calls === 3) throw new Error("disk full");
+                files.add(p);
+                content.set(p, d);
+                return { path: p };
+            },
+            trash: async (p: string) => {
+                files.delete(p);
+            },
+        };
+        await expect(installPackage(vault, ZETTELKASTEN_PACKAGE)).rejects.toThrow("disk full");
+        // No owned file survives the rollback; folders (shared) are never trashed.
+        for (const path of owned) expect(files.has(path)).toBe(false);
+        for (const folder of foldersCreated) expect(files.has(folder)).toBe(true);
+    });
+});

--- a/test/config/installedPackagesDefault.test.ts
+++ b/test/config/installedPackagesDefault.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "@jest/globals";
+import { DEFAULT_SETTINGS } from "config/typing";
+
+describe("installedPackages settings default (#174, FR-6)", () => {
+    it("defaults to an empty record", () => {
+        expect(DEFAULT_SETTINGS.installedPackages).toEqual({});
+    });
+
+    it("seeds {} for a legacy data.json lacking the key (Object.assign merge)", () => {
+        const legacy = { ...DEFAULT_SETTINGS } as Record<string, unknown>;
+        delete legacy.installedPackages;
+        const merged = Object.assign({}, DEFAULT_SETTINGS, legacy) as typeof DEFAULT_SETTINGS;
+        expect(merged.installedPackages).toEqual({});
+    });
+});

--- a/test/config/methodologyPackagesLocale.test.ts
+++ b/test/config/methodologyPackagesLocale.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "command_install_methodology_package",
+    "command_uninstall_methodology_package",
+    "methodology_package_installed_notice",
+    "methodology_package_already_installed",
+    "methodology_package_removed_notice",
+    "methodology_package_not_installed",
+    "methodology_package_install_error",
+    "methodology_package_uninstall_error",
+    "settings_toolkit_packages_name",
+    "settings_toolkit_packages_desc",
+];
+
+describe("methodology packages i18n parity (#174)", () => {
+    it("defines all 10 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(10);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Methodology packages — the knowledge-system app store (#174)

The gallery ships single templates; the leverage is shipping whole **methodologies**. A methodology
package is a named, atomic bundle of a knowledge system — install "Zettelkasten" and get all its
flows (and their built-in patterns) in one go, remove them just as cleanly.

### Scope (v1)
The package **format** + one built-in reference package + atomic local install/uninstall. **A package
ships no code** — actions/views/dashboards are already in the plugin; the reference `ZETTELKASTEN_PACKAGE`
is a name over the five #157 starter flows. Backend app-store + the other methodologies (PARA/GTD/…) are deferred follow-ups.

### What ships
- **Pure `methodologyPackages.ts`** (new `application/packages/`) — the `MethodologyPackage` model, `ZETTELKASTEN_PACKAGE`, `packageFilePaths`, and pure `planInstall`/`planRemove`. Exact-fixture tested.
- **Pure `packageService.ts`** — `installPackage` (reuses #157 `installStarterFlows`; **rolls back created files + rethrows on a mid-install failure** → records nothing) and `uninstallPackage` (trashes **only** the tracked files that resolve — never folders/user notes). Mock-vault round-trip + rollback tested (AC-1/AC-2).
- **Settings** `installedPackages` (tracked owned paths = source of truth for a clean uninstall). **Commands** install/uninstall (no hotkey) + a toolkit Install button — creates via the Vault, trashes via `fileManager().trashFile` (recoverable), **never `.adapter.`**.

### Guardrails / AC
- Pure modules Obsidian-free; en/es parity (10 keys); docs `development/methodology-packages.md` + nav 7.26; README (📦 bullet + Features row; no action-count change). Disclosed FS create+trash + settings tracking. **No network in v1.**
- `npm run verify` green — typecheck + oxlint + **lint:obsidian 0** + **799** jest tests.
- Reviewed by `obsidian-plugin-reviewer`: **no blocking, holds-to-raises the score** — "actively models best practices" (trashFile over delete, instanceof TFile, Vault over Adapter, clean command ids, atomic rollback). Added the shared-starter-flow-files caveat to the docs.

Closes #174. Relates to #144.
