### PR TITLE
refactor(structure): reposition map + five-layer framing (docs) (#175)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,17 @@ main.ts (Plugin)
  → hooks/        vault hooks: folder automation + property hooks + context-menu integrations
 ```
 
+**The five layers (the organizing principle, epic #144).** Conceptually the code is understood as
+**Knowledge Model** (the pure `architecture/knowledge/` idea graph) → **Workflow Engine** (canvas →
+note: `main.ts`/`starters`, `architecture/api`, `actions`, `application/notes` engine + `zettelkasten`
++ `architecture/plugin` canvas/services + `hooks`) → **Knowledge State** (analyses over the model:
+`architecture/knowledge/{debt,review,balance,discovery,map,traverse,questions,timeline,synthesis,dashboard,home,projects,journal}`)
+→ **Experience** (`architecture/components/core` views + `config` settings UX) → **Community Gallery**
+(`application/{community,packages}` + starter flows), over a cross-cutting **Foundation**
+(`lang`/`styles`/`monitoring`/`ai`/`plugin` facade). Every capability has one home layer; the full
+inventory is [`docs/architecture/reposition-map.md`](docs/architecture/reposition-map.md). The `src/`
+folders are being repositioned to match, incrementally — nothing is deleted or renamed.
+
 Full detail: [`docs/architecture/overview.md`](docs/architecture/overview.md) and the pages it
 links (plugin core, actions & note builder, vault hooks, community & backend).
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,6 +4,15 @@
 > [Home](../index.md). This section explains how the plugin is built so you (or an AI
 > assistant driving the [harness](../development/getting-started.md)) can extend it safely.
 
+## The five layers (the organizing principle)
+
+As of the Knowledge OS epic (#144), the codebase is understood as **five layers** (plus a
+cross-cutting **Foundation**): **Knowledge Model** (the pure idea graph) → **Workflow Engine** (canvas
+→ note) → **Knowledge State** (analyses over the model) → **Experience** (views, dashboards, Home) →
+**Community Gallery** (sharing whole systems). Every capability has one home layer — the full
+inventory is the [reposition map](reposition-map.md). The `src/` folders are being repositioned to
+match, incrementally and without deleting or renaming any feature.
+
 ## What ZettelFlow is, technically
 
 ZettelFlow is an **Obsidian plugin** that turns a native **Canvas** file into a directed

--- a/docs/architecture/reposition-map.md
+++ b/docs/architecture/reposition-map.md
@@ -1,0 +1,87 @@
+# Reposition map — every feature → its home layer
+
+ZettelFlow grew organized by *mechanism*. This map re-frames the whole codebase around the
+architecture it now stands for — the **five layers** of the Knowledge OS (epic #144), plus a
+**Foundation** bucket for genuinely cross-cutting infrastructure:
+
+**Knowledge Model · Workflow Engine · Knowledge State · Experience · Community Gallery** (+ Foundation).
+
+> **The rule: keep every feature, reposition it — nothing is deleted or renamed.** This is a *map*,
+> not a move. Every `src/` area below appears **exactly once**. The actual folder moves land as small,
+> `verify`-green follow-up PRs (see the roadmap at the end); the *target layer* column is the home a
+> capability belongs to, not a path that exists today.
+
+## Knowledge Model — the pure, Obsidian-free model of your ideas
+
+| Capability | Today's path |
+|---|---|
+| The idea graph, incremental index & queries | `architecture/knowledge/{model,parse,derive,query}` |
+| Relations & claims/sources vocabulary | `architecture/knowledge/{relations,claims}` |
+| Lifecycle states | `architecture/knowledge/lifecycle` |
+| The Obsidian→model feed (index service + snapshot) | `architecture/knowledge/{KnowledgeIndex,snapshot}` |
+
+## Workflow Engine — turning a canvas into a note
+
+| Capability | Today's path |
+|---|---|
+| Plugin bootstrap, ribbon, command/view registration | `main.ts`, `starters/` |
+| The action framework (ActionsStore, `CustomZettelAction`, `zf` script API) | `architecture/api` |
+| The 28 built-in actions + shared helpers | `actions/*` |
+| Note-builder engine core (assembly, preview, condition eval, context tokens) | `application/notes/{NoteBuilder,previewAssembly,conditionEvaluator,contextTokens}` |
+| Knowledge Patterns (on-creation behavior) | `application/patterns` (#170) |
+| Template resolution | `application/template` |
+| The note-builder wizard (Zustand) + its UI parts | `application/components/noteBuilder/*` |
+| Step/flow authoring modals, mappers, phases | `zettelkasten/*` |
+| Canvas integration, workflow triggers/wait, events, write-services | `architecture/plugin/{canvas,workflow,events,services}` |
+| Vault hooks (folder automation, property hooks, context menus) | `hooks/*` |
+
+## Knowledge State — analyses *over* the model
+
+| Capability | Today's path |
+|---|---|
+| Health: debt · review · balance | `architecture/knowledge/{debt,review,balance}` (#159/#160/#161) |
+| Discovery: morning discoveries · living map | `architecture/knowledge/{discovery,map}` (#163/#164) |
+| Graph: reasoning paths · concept navigation | `architecture/knowledge/traverse` (#166) |
+| Open questions & answer detection | `architecture/knowledge/questions` (#167) |
+| Evolution timeline · development journal (recorders) | `architecture/knowledge/{timeline,journal}` + `architecture/plugin/{timeline,journal}` (#162/#168) |
+| Compound thinking / evidence map | `architecture/knowledge/synthesis` (#169) |
+| Ops-console dashboard · Home aggregate · derived projects | `architecture/knowledge/{dashboard,home,projects}` (#171/#172/#173) |
+| Note-builder state helpers (atomicity, connections, MOC, resurface, weekly-review render, history) | `application/notes/{atomicitySplit,connectionSuggestions,mocMembership,mocMerge,resurfaceRanking,weeklyReviewMarkdown,historyUtils}` |
+
+## Experience — how you *see and act on* the system
+
+| Capability | Today's path |
+|---|---|
+| The 13 sidebar views (health, discoveries, map, heatmap, concept-nav, open-questions, timeline, evidence-map, dashboard, Home, …) + CodeView | `architecture/components/core/*` |
+| View/command/ribbon registrars | `starters/zcomponents/*` |
+| Settings tab + declarative handlers | `config/modals`, `config/modals/ZettelFlowSettingsTab` |
+| Settings primitives + shared UI (icon, navbar) | `architecture/components/settings`, `components/icon` |
+
+## Community Gallery — sharing whole systems
+
+| Capability | Today's path |
+|---|---|
+| Community browser + backend client | `application/community/*`, `backend/` |
+| Starter flows | `application/notes/starterFlowsService`, `starters/zcomponents/StarterFlowsComponent` (#157) |
+| Methodology packages | `application/packages`, `starters/zcomponents/MethodologyPackageComponent` (#174) |
+| Onboarding · template export/share | `application/notes/onboardingService`, `architecture/share`, `TemplateExportComponent` |
+
+## Foundation — cross-cutting infrastructure (home-agnostic)
+
+| Capability | Today's path |
+|---|---|
+| i18n (en/es) | `architecture/lang` |
+| Styles (SCSS) + `c()` prefixer | `architecture/styles`, `src/styles` |
+| Logging & exceptions | `architecture/monitoring` |
+| Patterns (AbstractChain) & shared typing | `architecture/patterns`, `architecture/typing` |
+| Optional AI provider layer (#156) | `architecture/ai` |
+| The Obsidian facade (`ObsidianApi`, `Lifecycle`) | `architecture/plugin` (facade) |
+| Settings model & defaults | `config/typing` |
+
+## The `src/` move roadmap (follow-up PRs)
+
+The actual folder moves are **out of scope for this map PR** and land incrementally, leaf-first, each
+keeping `npm run verify` and `lint:obsidian` green — tracked as a single follow-up (linked to #144):
+State analyses → Model → Experience views → Actions → note-builder → authoring → plugin services →
+Gallery → Foundation → bootstrap. No feature is deleted; nothing is renamed as part of a move except
+its containing folder.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - 6.9 Knowledge lifecycle: architecture/knowledge-lifecycle.md
       - 6.10 Workflow phases: architecture/workflow-phases.md
       - 6.11 Event-driven & visual workflows: architecture/event-driven-workflows.md
+      - 6.12 Reposition map (feature → layer): architecture/reposition-map.md
   - 7. Development:
       - 7.1 Getting started: development/getting-started.md
       - 7.2 Contributing & conventions: development/contributing-and-conventions.md


### PR DESCRIPTION
## Reposition — map every feature to the new architecture (#175)

The code grew organized by *mechanism*. This publishes the **living map** re-framing the whole
codebase around the five layers (**Knowledge Model · Workflow Engine · Knowledge State · Experience ·
Community Gallery**, + a cross-cutting **Foundation**). **The rule: keep every feature, reposition it —
nothing deleted or renamed.**

### What ships (docs/nav/comment-only — zero code, zero behavior change)
- **`docs/architecture/reposition-map.md`** — the complete capability→layer inventory (every `src/` area exactly once). AC-1.
- **`docs/architecture/overview.md`** — a "five layers" framing section linking the map.
- **CLAUDE.md** — the "Architecture in 60 seconds" reframed around the five layers.
- **`mkdocs.yml`** — the map added to the Architecture nav (6.12).
- The map is also **published in the issue** (comment) per AC-1.

### AC verification
- **AC-1:** the mapping covers every `src/` capability area exactly once, in the issue + docs.
- **AC-2:** `git diff --name-only` touches **no `src/` code path** — only `docs/`, `mkdocs.yml`, `CLAUDE.md`. `npm run verify` green (**799 tests, unchanged**), `lint:obsidian` 0. Zero feature regressions; nothing deleted.
- **AC-3 / roadmap:** the actual `src/` folder moves are tracked as a single leaf-first, `verify`-green follow-up (**#209**, linked to #144) — so the reorg "lands in small PRs" as required, without a risky big-bang move now.

Closes #175. Relates to #144.
