### PR TITLE
docs(philosophy): the ZettelFlow manifesto & README reframe (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,27 @@
 [![Total downloads](https://img.shields.io/github/downloads/RafaelGB/Obsidian-ZettelFlow/total?style=for-the-badge)](https://github.com/RafaelGB/Obsidian-ZettelFlow/releases)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/RafaelGB?label=Sponsor&logo=GitHub%20Sponsors&style=for-the-badge)](https://github.com/sponsors/RafaelGB)
 
-**ZettelFlow turns an Obsidian Canvas into a guided note-creation wizard.** Draw your workflow as a graph — steps as nodes, order as arrows — and the plugin walks you through it every time you create a note, filling in frontmatter, body content, dates, selectors, and more without you touching a template manually.
+> **Most plugins help you _write_. Almost none help you _think_.**
 
-> **[Full documentation →](https://rafaelgb.github.io/Obsidian-ZettelFlow/)**
+**Stop managing notes. Start managing knowledge.** Obsidian is the store; **ZettelFlow is the engine
+that makes the knowledge inside it evolve** — it doesn't manage notes, it manages the *processes that
+transform knowledge*. It stands on **four pillars**:
+
+- 🌱 **Knowledge Lifecycle** — every idea has a state (fleeting → permanent → evergreen); ZettelFlow knows the phase and proposes the next move.
+- 🕸️ **Semantic Knowledge Graph** — relations with *meaning*: ask *"show me every idea that contradicts this"* and follow reasoning chains.
+- 🔭 **Knowledge Discovery** — surface the unexpected: connections you didn't know you'd made, ideas worth challenging, a book outline hiding in a folder.
+- 🩺 **Knowledge Health** — measure balance and richness, not volume: maturity, knowledge debt, a weekly review, a heatmap of ideas *developed*.
+
+**AI is one Action, never the product** — every pillar works fully with AI disabled. And **nothing is
+removed, only repositioned**: the canvas wizard you know is the engine's front end.
+
+> Read the **[manifesto →](https://rafaelgb.github.io/Obsidian-ZettelFlow/manifesto/)** · **[full documentation →](https://rafaelgb.github.io/Obsidian-ZettelFlow/)**
+
+---
+
+### How it works, in one line
+
+**ZettelFlow turns an Obsidian Canvas into a guided note-creation wizard.** Draw your workflow as a graph — steps as nodes, order as arrows — and the plugin walks you through it every time you create a note, filling in frontmatter, body content, dates, selectors, and more without you touching a template manually. Each step is a piece of the cognitive engine; each note lands already related, cross-checked and scored.
 
 ---
 

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -1,0 +1,72 @@
+# The ZettelFlow manifesto
+
+> **Most plugins help you _write_. Almost none help you _think_.**
+
+ZettelFlow is not a note plugin. It is an **engine that makes knowledge evolve**.
+
+## Stop managing notes. Start managing knowledge.
+
+Obsidian is a wonderful place to *store* notes. But a store is not a mind. Luhmann's insight was
+that the value of a slip-box is not in *keeping* information — it is in making ideas **evolve and
+connect** until they produce new knowledge.
+
+> **Obsidian is the store. ZettelFlow is the engine that makes the knowledge inside it evolve.**
+
+Everything ZettelFlow does follows from one architectural idea:
+
+> **ZettelFlow does not manage notes. It manages the processes that transform knowledge.**
+
+A **Step** used to mean *"do this operation on a note."* It now means *"advance this piece of
+knowledge."* Steps compose into workflows — programmable thinking — that walk an idea through its
+life:
+
+```
+CAPTURE → CLASSIFY → PROCESS → CONNECT → DEVELOP → REVIEW → CONSOLIDATE
+```
+
+## The four pillars (the soul)
+
+- 🌱 **Knowledge Lifecycle** — every idea has a state (fleeting → literature → permanent → developing
+  → evergreen → archived). ZettelFlow knows the phase and proposes the next move.
+- 🕸️ **Semantic Knowledge Graph** — relations that carry *meaning*, so you can ask *"show me every
+  idea that contradicts this"* and follow reasoning chains — not just backlinks.
+- 🔭 **Knowledge Discovery** — surface the *unexpected*: connections you didn't know you'd made,
+  challenges to your ideas, the hubs your thinking clusters around, a book outline hiding in a folder.
+- 🩺 **Knowledge Health** — measure *balance and richness*, not volume: maturity, knowledge debt, a
+  weekly review, composition, a heatmap of the ideas you actually **developed**.
+
+Metrics are **consequences, not inventions**. When a workflow runs *find related* and gets nothing,
+the note is unconnected. When *find contradiction* returns empty, the idea has no opposing view.
+Knowledge debt is a natural byproduct of doing the work — never an arbitrary number.
+
+## What we will not become
+
+- **"Obsidian + AI"** — competing with a thousand tools. **AI is one Action, never the product.** The
+  system works fully — every pillar, every dashboard — for a user who never enables AI.
+- **"Another plugin to create Zettelkasten notes."** That ceiling is too low.
+- A generic manager that pleases everyone and marks no one.
+
+## Keep every feature — reposition it
+
+This is the promise that made the whole thing possible without a rewrite: **almost nothing is
+deleted; what changes is its _position_ in the product.**
+
+| Today | Becomes |
+|---|---|
+| Steps + Actions | The **cognitive engine** — each step advances a piece of knowledge |
+| Workflows | **Programmable thinking** |
+| Templates | **Knowledge Patterns** — structure **+ behavior** |
+| Community gallery | A **methodology app store** — install a whole knowledge system |
+| Dashboards | The **observability** of your knowledge system |
+| Slip-box health, discovery, timelines | The **Knowledge State** layer |
+
+The engineering shape follows the philosophy in five layers — **Knowledge Model → Workflow Engine →
+Knowledge State → Experience → Community Gallery** — mapped feature-by-feature in the
+[reposition map](architecture/reposition-map.md).
+
+## For the few who will love it
+
+This is not a feature list; it is an **identity**. ZettelFlow is not trying to be something everyone
+likes a little. It is trying to be something a few people **love** — because it changes how they
+think. If *"stop managing notes, start managing knowledge"* made something click for you, you're one
+of them. Welcome.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ plugins:
   - search
 nav:
   - 1. Home: index.md
+  - The manifesto: manifesto.md
   - 2. Actions:
       - 2.1 Prompt: actions/Prompt.md
       - 2.2 Number: actions/Number.md


### PR DESCRIPTION
## The ZettelFlow manifesto & README reframe (#176)

The epic's capstone. The identity — *"an engine that makes knowledge evolve, not a note plugin"* —
wasn't written anywhere users see it. Now it is.

### What ships (docs-only)
- **`docs/manifesto.md`** — the manifesto: *"Most plugins help you write; almost none help you think."* · "Obsidian is the store, ZettelFlow is the engine that makes knowledge evolve" · the **four pillars** (🌱 Lifecycle · 🕸️ Semantic Graph · 🔭 Discovery · 🩺 Health) · **AI is one Action, never the product** · **keep every feature, reposition it**. Linked in the nav (top-level, right after Home). AC-1.
- **README reframed** — now leads with the mindset shift + the four pillars + "AI is one Action" + "reposition, don't remove", links the manifesto, and keeps the canvas-wizard framing as *"how it works, in one line"*. The **Features table and Zettelkasten-toolkit sections are preserved untouched** — nothing advertised is lost. AC-2.

### AC verification
- **AC-1:** manifesto published (`docs/manifesto.md`) + linked in `mkdocs.yml` nav.
- **AC-2:** README reframed; the Features table is byte-for-byte preserved (only the intro changed).
- Docs-only — `npm run verify` green (**799 tests, unchanged**), `lint:obsidian` 0, no `src/` touched.

Closes #176. Relates to #144.
