### PR TITLE
feat(community): one-click .zftemplate system install (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Visual workflow language** | Compose a reactive flow on the canvas: WHEN a vault event happens, IF a condition holds, run an ACTION, then WAIT for your confirmation — human-in-the-loop pauses, off by default and loop-guarded. |
 | **Action picker by capability** | The action picker groups actions by cognitive capability (Manipulation · Relations · Knowledge · Research · AI) instead of a flat list. |
 | **Community templates** | Browse, install, and share flows, steps, and actions from the community browser. |
+| **Community systems** | Install a whole knowledge system in one click — the community browser fetches a `.zftemplate` bundle and writes its canvas + step notes to a folder (no clipboard). |
 | **.zftemplate export/import** | Bundle a canvas and its step files into a single portable file to share with others. |
 | **Notes history** | Sidebar leaf showing recently built notes with quick-open links. |
 | **Mobile support** | Works on iOS and Android (`isDesktopOnly: false`). |

--- a/docs/architecture/community-and-backend.md
+++ b/docs/architecture/community-and-backend.md
@@ -1,8 +1,8 @@
 # Community feature & backend
 
 ZettelFlow lets users **browse, preview, install and reuse** shareable building blocks —
-*actions*, *steps*, *markdown* notes and whole *flows*. This page covers the frontend community
-module and the optional FastAPI/MongoDB backend.
+*actions*, *steps*, *markdown* notes, whole *flows*, and complete *systems*. This page covers the
+frontend community module and the optional FastAPI/MongoDB backend.
 
 ## 1. Two data sources
 
@@ -11,7 +11,7 @@ is set in `communitySettings`:
 
 | Source | Component | Backing service | Supports |
 |---|---|---|---|
-| **Static** (default) | `StaticTemplatesGallery` | `raw.githubusercontent.com/RafaelGB/Obsidian-ZettelFlow/.../main` | steps, actions, **markdown, flows** |
+| **Static** (default) | `StaticTemplatesGallery` | `raw.githubusercontent.com/RafaelGB/Obsidian-ZettelFlow/.../main` | steps, actions, **markdown, flows, systems** |
 | **Dynamic** (token set) | `CommunityTemplatesGallery` | the FastAPI backend at `communitySettings.url` | steps, actions |
 
 ```ts
@@ -40,6 +40,13 @@ else                          render(<StaticTemplatesGallery/>);      // GitHub 
   clipboard" (stores the flow in `communitySettings.clipboardTemplate`), "Download flow files"
   (writes referenced markdown into the vault and rewrites node `file` paths), and renders the
   nodes (grouped by type) and edges.
+- **`CommunitySystemModal`** (#214) — previews a whole **system** shipped as the unified
+  [`.zftemplate`](zftemplate-schema.md) bundle: name, author, description, an optional
+  sibling preview image, and the list of files that will be written. "Install system" picks a
+  target folder (default `foldersFlowsPath`), then `planSystemInstall` + `FileService.writeFile`
+  create the canvas and every step note in one click (no clipboard, no manual paste) and open the
+  canvas. The pure planner/validator lives in `systemInstall.ts` (Obsidian-free, so it is
+  unit-testable and every shipped system is checked against the registered action ids).
 - **`ManageInstalledTemplatesModal`** — manages installed templates; "Add template from
   clipboard" imports `clipboardTemplate` into `installedTemplates`.
 - **`UsedInstalledStepsModal`** — a picker (`StepTemplatesSelector`) used to drop an installed
@@ -59,6 +66,7 @@ COMMUNITY_BASE_URL = "https://raw.githubusercontent.com/RafaelGB/Obsidian-Zettel
 | `fetchActionTemplate(ref)` | `${BASE}${ref}` | `CommunityAction` |
 | `fetchStepTemplate(ref)` | `${BASE}${ref}` | `CommunityStepSettings` |
 | `fetchFlowTemplate(ref)` | `${BASE}${ref}/flow.json` | `CommunityFlowData` |
+| `fetchSystemTemplate(ref)` | `${BASE}${ref}` | `ZfTemplate` (parsed `.zftemplate`) |
 | `fetchMarkdownTemplate(ref)` | `${BASE}${ref}` | raw markdown |
 
 The **dynamic** gallery has its own inline fetchers (in `CommunityTemplatesGallery.tsx`) hitting
@@ -75,6 +83,10 @@ search, All/Step/Action filters, and **infinite scroll** (`IntersectionObserver`
 - **Flows** — "Copy to clipboard" → `clipboardTemplate`; "Download flow files" writes the
   markdown and rewrites node paths; the clipboard flow is imported via
   `ManageInstalledTemplatesModal`.
+- **Systems** (#214) — the modern one-click path. `planSystemInstall` turns a `.zftemplate` into a
+  deterministic file list (canvas + steps under the chosen folder); the modal writes each with
+  `FileService.writeFile` and opens the canvas. No clipboard round-trip; the same unified format
+  the local export/import commands use.
 
 ## 3. Backend — `backend/`
 

--- a/docs/architecture/zftemplate-schema.md
+++ b/docs/architecture/zftemplate-schema.md
@@ -51,3 +51,11 @@ A `.zftemplate` file is a plain JSON document that bundles a ZettelFlow canvas w
 | `ZettelFlow: Import .zftemplate` | Desktop only | Opens a file picker; installs the canvas and steps into a user-chosen vault folder |
 
 On conflict (files already exist), the user is prompted to overwrite or skip — no `confirm()` is used.
+
+## Community systems (#214)
+
+The same format powers the community **systems** gallery. A shipped system is a `.zftemplate` file
+listed in `docs/main_template.json` with `template_type: "system"`; the community browser's
+`CommunitySystemModal` fetches it, lets the user pick a folder, and writes the canvas + steps in one
+click (no clipboard). See [Community feature & backend](community-and-backend.md). Authoring guide:
+[Contribute a community system](../how-to-contribute/community-examples.md).

--- a/src/application/community/CommunitySystemModal.tsx
+++ b/src/application/community/CommunitySystemModal.tsx
@@ -5,7 +5,11 @@ import { FileService } from "architecture/plugin";
 import { FolderSuggest } from "architecture/settings";
 import ZettelFlow from "main";
 import { ZfTemplate } from "application/template/zfTemplate";
-import { planSystemInstall } from "./systemInstall";
+import {
+  planSystemInstall,
+  validateSystemTemplate,
+  REGISTERED_ACTION_IDS,
+} from "./systemInstall";
 import { COMMUNITY_BASE_URL } from "./services/CommunityHttpClientService";
 
 /**
@@ -20,6 +24,8 @@ export class CommunitySystemModal extends Modal {
     ".png"
   )}`;
   private objectUrl: string | null = null;
+  /** Set in `onClose`; guards the async image load against a close-before-fetch race. */
+  private disposed = false;
 
   constructor(
     plugin: ZettelFlow,
@@ -33,29 +39,10 @@ export class CommunitySystemModal extends Modal {
 
   onOpen(): void {
     this.modalEl.addClass(c("modal"));
-    void this.renderContent();
+    this.renderContent();
   }
 
-  /**
-   * Fetches the optional sibling preview image (`<id>.png`) as a Blob URL. Systems may ship without
-   * one (the author drops it in later), so a miss is expected — logged at debug, not surfaced.
-   */
-  private async fetchSystemImage(): Promise<string | null> {
-    try {
-      const response = await requestUrl({ url: this.imageUrl });
-      const buffer = response.arrayBuffer;
-      const mimeType =
-        response.headers["content-type"] ?? "application/octet-stream";
-      const blob = new Blob([buffer], { type: mimeType });
-      this.objectUrl = URL.createObjectURL(blob);
-      return this.objectUrl;
-    } catch (error) {
-      log.debug("No preview image for system:", this.imageUrl, error);
-      return null;
-    }
-  }
-
-  private async renderContent(): Promise<void> {
+  private renderContent(): void {
     this.contentEl.empty();
 
     // --- Header ---
@@ -71,21 +58,11 @@ export class CommunitySystemModal extends Modal {
     });
     infoSection.createEl("p", { text: this.template.description });
 
-    // --- Optional preview image ---
-    const imgUrl = await this.fetchSystemImage();
-    if (imgUrl) {
-      const imgSection = this.contentEl.createDiv({
-        cls: c("modal-reader-flow-image-section"),
-      });
-      imgSection.createEl("h3", { text: t("community_system_preview") });
-      const container = imgSection.createDiv({
-        cls: c("flow-image-container"),
-      });
-      const imgEl = container.createEl("img", {
-        attr: { src: imgUrl, alt: `${this.template.name} preview` },
-      });
-      imgEl.addClass(c("flow-image-fit"));
-    }
+    // --- Optional preview image (loaded asynchronously so install stays usable offline) ---
+    const imgSection = this.contentEl.createDiv({
+      cls: c("modal-reader-flow-image-section"),
+    });
+    void this.loadImage(imgSection);
 
     // --- What gets installed ---
     const contentsSection = this.contentEl.createDiv({
@@ -121,10 +98,47 @@ export class CommunitySystemModal extends Modal {
   }
 
   /**
-   * Writes every planned file (canvas first, then each step), opens the canvas, and closes the modal.
-   * Idempotent by way of {@link FileService.writeFile} (overwrite-in-place).
+   * Fetches the optional sibling preview image (`<id>.png`) and appends it. Systems may ship without
+   * one (the author drops it in later), so a miss is expected — logged at debug, not surfaced. Bails
+   * if the modal was closed while fetching, revoking the just-created object URL.
+   */
+  private async loadImage(section: HTMLDivElement): Promise<void> {
+    let objectUrl: string | null = null;
+    try {
+      const response = await requestUrl({ url: this.imageUrl });
+      const mimeType =
+        response.headers["content-type"] ?? "application/octet-stream";
+      const blob = new Blob([response.arrayBuffer], { type: mimeType });
+      objectUrl = URL.createObjectURL(blob);
+    } catch (error) {
+      log.debug("No preview image for system:", this.imageUrl, error);
+      return;
+    }
+    if (this.disposed) {
+      URL.revokeObjectURL(objectUrl);
+      return;
+    }
+    this.objectUrl = objectUrl;
+    section.createEl("h3", { text: t("community_system_preview") });
+    const container = section.createDiv({ cls: c("flow-image-container") });
+    const imgEl = container.createEl("img", {
+      attr: { src: objectUrl, alt: t("community_system_preview") },
+    });
+    imgEl.addClass(c("flow-image-fit"));
+  }
+
+  /**
+   * Validates the fetched (remote, untrusted) system, then writes every planned file (canvas first,
+   * then each step), opens the canvas, and closes the modal. Idempotent by way of
+   * {@link FileService.writeFile} (overwrite-in-place).
    */
   private async installSystem(): Promise<void> {
+    const problems = validateSystemTemplate(this.template, REGISTERED_ACTION_IDS);
+    if (problems.length > 0) {
+      log.error("Refusing to install invalid community system:", problems);
+      new Notice(t("community_system_install_error"));
+      return;
+    }
     try {
       const { files } = planSystemInstall(this.template, this.targetFolder);
       for (const file of files) {
@@ -142,6 +156,7 @@ export class CommunitySystemModal extends Modal {
   }
 
   onClose(): void {
+    this.disposed = true;
     if (this.objectUrl) URL.revokeObjectURL(this.objectUrl);
     this.contentEl.empty();
   }

--- a/src/application/community/CommunitySystemModal.tsx
+++ b/src/application/community/CommunitySystemModal.tsx
@@ -1,0 +1,148 @@
+import { Modal, Notice, Setting, requestUrl } from "obsidian";
+import { c, log } from "architecture";
+import { t } from "architecture/lang";
+import { FileService } from "architecture/plugin";
+import { FolderSuggest } from "architecture/settings";
+import ZettelFlow from "main";
+import { ZfTemplate } from "application/template/zfTemplate";
+import { planSystemInstall } from "./systemInstall";
+import { COMMUNITY_BASE_URL } from "./services/CommunityHttpClientService";
+
+/**
+ * Modal for a community **system** (#214): a `.zftemplate` bundle installed as a canvas + step notes
+ * in one click. Mirrors {@link CommunityFlowModal} but consumes the unified `.zftemplate` format and
+ * writes real files through {@link FileService.writeFile} instead of the clipboard-paste dance.
+ */
+export class CommunitySystemModal extends Modal {
+  private targetFolder: string;
+  private imageUrl = `${COMMUNITY_BASE_URL}${this.refUrl.replace(
+    /\.zftemplate$/,
+    ".png"
+  )}`;
+  private objectUrl: string | null = null;
+
+  constructor(
+    plugin: ZettelFlow,
+    private template: ZfTemplate,
+    private refUrl: string
+  ) {
+    super(plugin.app);
+    // Default install location is the configured flows folder; the user can override it below.
+    this.targetFolder = plugin.settings.foldersFlowsPath || "";
+  }
+
+  onOpen(): void {
+    this.modalEl.addClass(c("modal"));
+    void this.renderContent();
+  }
+
+  /**
+   * Fetches the optional sibling preview image (`<id>.png`) as a Blob URL. Systems may ship without
+   * one (the author drops it in later), so a miss is expected — logged at debug, not surfaced.
+   */
+  private async fetchSystemImage(): Promise<string | null> {
+    try {
+      const response = await requestUrl({ url: this.imageUrl });
+      const buffer = response.arrayBuffer;
+      const mimeType =
+        response.headers["content-type"] ?? "application/octet-stream";
+      const blob = new Blob([buffer], { type: mimeType });
+      this.objectUrl = URL.createObjectURL(blob);
+      return this.objectUrl;
+    } catch (error) {
+      log.debug("No preview image for system:", this.imageUrl, error);
+      return null;
+    }
+  }
+
+  private async renderContent(): Promise<void> {
+    this.contentEl.empty();
+
+    // --- Header ---
+    const navbar = this.contentEl.createDiv({ cls: c("modal-navbar") });
+    navbar.createEl("h2", { text: this.template.name });
+
+    // --- Description ---
+    const infoSection = this.contentEl.createDiv({
+      cls: c("modal-reader-general-section"),
+    });
+    infoSection.createEl("p", {
+      text: `${t("template_author")}: ${this.template.author}`,
+    });
+    infoSection.createEl("p", { text: this.template.description });
+
+    // --- Optional preview image ---
+    const imgUrl = await this.fetchSystemImage();
+    if (imgUrl) {
+      const imgSection = this.contentEl.createDiv({
+        cls: c("modal-reader-flow-image-section"),
+      });
+      imgSection.createEl("h3", { text: t("community_system_preview") });
+      const container = imgSection.createDiv({
+        cls: c("flow-image-container"),
+      });
+      const imgEl = container.createEl("img", {
+        attr: { src: imgUrl, alt: `${this.template.name} preview` },
+      });
+      imgEl.addClass(c("flow-image-fit"));
+    }
+
+    // --- What gets installed ---
+    const contentsSection = this.contentEl.createDiv({
+      cls: c("modal-reader-general-section"),
+    });
+    contentsSection.createEl("h3", { text: t("community_system_contents") });
+    const list = contentsSection.createEl("ul", { cls: c("flow-nodes-list") });
+    list.createEl("li", { text: this.template.canvas.filename });
+    for (const step of this.template.steps) {
+      list.createEl("li", { text: step.filename });
+    }
+
+    // --- Install location ---
+    new Setting(this.contentEl)
+      .setName(t("community_system_install_location"))
+      .setDesc(t("community_system_install_location_desc"))
+      .addSearch((cb) => {
+        new FolderSuggest(cb.inputEl);
+        cb.setValue(this.targetFolder).onChange((value) => {
+          this.targetFolder = value;
+        });
+      });
+
+    // --- Install button ---
+    new Setting(this.contentEl).addButton((btn) => {
+      btn
+        .setButtonText(t("community_system_install_button"))
+        .setCta()
+        .onClick(() => {
+          void this.installSystem();
+        });
+    });
+  }
+
+  /**
+   * Writes every planned file (canvas first, then each step), opens the canvas, and closes the modal.
+   * Idempotent by way of {@link FileService.writeFile} (overwrite-in-place).
+   */
+  private async installSystem(): Promise<void> {
+    try {
+      const { files } = planSystemInstall(this.template, this.targetFolder);
+      for (const file of files) {
+        await FileService.writeFile(file.path, file.content, false);
+      }
+      new Notice(`${this.template.name} — ${t("community_system_installed")}`);
+      this.close();
+      if (files.length > 0) {
+        await FileService.openFile(files[0].path);
+      }
+    } catch (error) {
+      log.error("Error installing community system:", error);
+      new Notice(t("community_system_install_error"));
+    }
+  }
+
+  onClose(): void {
+    if (this.objectUrl) URL.revokeObjectURL(this.objectUrl);
+    this.contentEl.empty();
+  }
+}

--- a/src/application/community/components/StaticTemplatesGallery.tsx
+++ b/src/application/community/components/StaticTemplatesGallery.tsx
@@ -7,12 +7,14 @@ import { CommunityActionModal } from "../CommunityActionModal";
 import { CommunityStepModal } from "../CommunityStepModal";
 import { CommunityMarkdownModal } from "../CommunityMarkdownModal";
 import { CommunityFlowModal } from "../CommunityFlowModal";
+import { CommunitySystemModal } from "../CommunitySystemModal";
 import {
   fetchActionTemplate,
   fetchCommunityTemplates,
   fetchFlowTemplate,
   fetchMarkdownTemplate,
   fetchStepTemplate,
+  fetchSystemTemplate,
 } from "../services/CommunityHttpClientService";
 
 export function StaticTemplatesGallery(props: PluginComponentProps) {
@@ -23,7 +25,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [targetSearchTerm, setTargetSearchTerm] = useState("");
   const [filter, setFilter] = useState<
-    "all" | "step" | "action" | "markdown" | "flow"
+    "all" | "step" | "action" | "markdown" | "flow" | "system"
   >("all");
   const [templates, setTemplates] = useState<StaticTemplateOptions[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -83,7 +85,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
   };
 
   const handleSetFilter = (
-    value: "all" | "step" | "action" | "markdown" | "flow"
+    value: "all" | "step" | "action" | "markdown" | "flow" | "system"
   ) => {
     setFilter(value);
   };
@@ -137,6 +139,11 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
           new CommunityFlowModal(plugin, flow, template.ref, () => {}).open();
           break;
         }
+        case "system": {
+          const system = await fetchSystemTemplate(template.ref);
+          new CommunitySystemModal(plugin, system, template.ref).open();
+          break;
+        }
         default: {
           // Handle unexpected template types
           log.warn(`Unknown template type: ${String(template.template_type)}`);
@@ -158,7 +165,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
 
   // Mapping of filter types to CSS classes
   const FILTER_COLORS: Record<
-    "all" | "step" | "action" | "markdown" | "flow",
+    "all" | "step" | "action" | "markdown" | "flow" | "system",
     string
   > = {
     all: "template-type-all",
@@ -166,6 +173,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
     action: "template-type-action",
     markdown: "template-type-markdown",
     flow: "template-type-flow",
+    system: "template-type-system",
   };
 
   return (
@@ -179,7 +187,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
           className={c("community-templates-search")}
         />
         <div className={c("community-templates-filters")}>
-          {(["all", "step", "action", "markdown", "flow"] as const).map(
+          {(["all", "step", "action", "markdown", "flow", "system"] as const).map(
             (type) => {
               const classesToApply = [
                 "community-templates-filter-button",

--- a/src/application/community/services/CommunityHttpClientService.ts
+++ b/src/application/community/services/CommunityHttpClientService.ts
@@ -2,6 +2,7 @@ import { log } from "architecture";
 import { CommunityAction, CommunityStepSettings, StaticTemplateOptions } from "config";
 import { request } from "obsidian";
 import { CommunityFlowData } from "../typing";
+import { ZfTemplate, parseTemplate } from "application/template/zfTemplate";
 
 export const COMMUNITY_BASE_URL =
     "https://raw.githubusercontent.com/RafaelGB/Obsidian-ZettelFlow/refs/heads/main";
@@ -44,6 +45,16 @@ export async function fetchFlowTemplate(ref: string) {
         contentType: "application/json",
     });
     return JSON.parse(rawList) as CommunityFlowData;
+}
+
+export async function fetchSystemTemplate(ref: string): Promise<ZfTemplate> {
+    log.debug("Fetching system template", ref);
+    const raw = await request({
+        url: `${COMMUNITY_BASE_URL}${ref}`,
+        method: "GET",
+        contentType: "application/json",
+    });
+    return parseTemplate(raw);
 }
 
 export async function fetchMarkdownTemplate(ref: string) {

--- a/src/application/community/systemInstall.ts
+++ b/src/application/community/systemInstall.ts
@@ -31,6 +31,21 @@ export function planSystemInstall(template: ZfTemplate, targetFolder: string): {
     return { files };
 }
 
+/**
+ * A canvas/step `filename` is safe only when it is a bare in-folder name: no path separator, no `.`/`..`
+ * segment, no drive-absolute prefix. Systems are **remote, untrusted, one-click-installed** content, so
+ * a crafted name like `../../.obsidian/plugins/x/main.js` must never reach the disk (#214 hardening).
+ */
+export function isUnsafeFilename(filename: unknown): boolean {
+    if (typeof filename !== "string") return true;
+    const name = filename.trim();
+    if (name === "") return true;
+    if (name.includes("/") || name.includes("\\")) return true; // no subpaths, traversal or leading-slash
+    if (name === "." || name === "..") return true;
+    if (/^[a-zA-Z]:/.test(name)) return true; // Windows drive-absolute (e.g. C:foo)
+    return false;
+}
+
 /** The leading `---\n…\n---` frontmatter block of a note's content, or `null` if absent. */
 function frontmatterBlock(content: string): string | null {
     const match = content.match(/^---\n([\s\S]*?)\n---/);
@@ -57,7 +72,13 @@ export function validateSystemTemplate(template: ZfTemplate, knownActionTypes: R
         problems.push("Not a valid .zftemplate: missing required fields");
         return problems;
     }
+    if (isUnsafeFilename(template.canvas.filename)) {
+        problems.push(`Canvas "${template.canvas.filename}" has an unsafe path`);
+    }
     for (const step of template.steps) {
+        if (isUnsafeFilename(step.filename)) {
+            problems.push(`Step "${step.filename}" has an unsafe path`);
+        }
         const frontmatter = frontmatterBlock(step.content);
         if (!frontmatter || !frontmatter.includes("zettelFlowSettings:")) {
             problems.push(`Step "${step.filename}" has no zettelFlowSettings frontmatter`);

--- a/src/application/community/systemInstall.ts
+++ b/src/application/community/systemInstall.ts
@@ -1,0 +1,73 @@
+import { ZfTemplate, isValidTemplate } from "application/template/zfTemplate";
+
+/** A file a system install writes: an absolute-in-vault path and its content. */
+export interface PlannedFile {
+    path: string;
+    content: string;
+}
+
+/**
+ * The registered action `type` ids (#214) — kept in sync with `main.ts registerActions()`. A system's
+ * step frontmatter may only reference these; the validity harness rejects anything else. Obsidian-free.
+ */
+export const REGISTERED_ACTION_IDS: ReadonlySet<string> = new Set([
+    "prompt", "number", "checkbox", "selector", "dynamic-selector", "calendar",
+    "backlink", "tags", "cssclasses", "script", "task-management", "zettel-id",
+    "detect-orphan", "calculate-maturity", "find-contradiction", "find-unanswered-question",
+    "suggest-next-move", "thinking-simulator", "find-related", "suggest-link",
+    "create-semantic-relation", "extract-claims", "compare-claims", "find-sources",
+    "attach-source", "summarize", "classify", "generate-questions",
+]);
+
+/**
+ * Pure install plan for a `.zftemplate` system (#214): the canvas first, then every step, each written
+ * under `targetFolder`. Deterministic, read-only, Obsidian-free — the Obsidian shell writes these via
+ * the sanctioned `FileService.writeFile`.
+ */
+export function planSystemInstall(template: ZfTemplate, targetFolder: string): { files: PlannedFile[] } {
+    const prefix = targetFolder === "/" || targetFolder === "" ? "" : `${targetFolder}/`;
+    const files: PlannedFile[] = [{ path: `${prefix}${template.canvas.filename}`, content: template.canvas.content }];
+    for (const step of template.steps) files.push({ path: `${prefix}${step.filename}`, content: step.content });
+    return { files };
+}
+
+/** The leading `---\n…\n---` frontmatter block of a note's content, or `null` if absent. */
+function frontmatterBlock(content: string): string | null {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    return match ? match[1] : null;
+}
+
+/** Every action `type` declared in a frontmatter block (structural, no YAML dependency). */
+function extractActionTypes(frontmatter: string): string[] {
+    const types: string[] = [];
+    const pattern = /^\s*-?\s*type:\s*["']?([\w-]+)/gm;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(frontmatter)) !== null) types.push(match[1]);
+    return types;
+}
+
+/**
+ * Pure structural validator for a shipped system (#214, AC-2). Returns the list of problems (empty =
+ * valid): a malformed bundle, a step with no `zettelFlowSettings:` frontmatter, or any action `type`
+ * not in `knownActionTypes`. Obsidian-free — no YAML parse, just the load-bearing action-id invariant.
+ */
+export function validateSystemTemplate(template: ZfTemplate, knownActionTypes: ReadonlySet<string>): string[] {
+    const problems: string[] = [];
+    if (!isValidTemplate(template)) {
+        problems.push("Not a valid .zftemplate: missing required fields");
+        return problems;
+    }
+    for (const step of template.steps) {
+        const frontmatter = frontmatterBlock(step.content);
+        if (!frontmatter || !frontmatter.includes("zettelFlowSettings:")) {
+            problems.push(`Step "${step.filename}" has no zettelFlowSettings frontmatter`);
+            continue;
+        }
+        for (const type of extractActionTypes(frontmatter)) {
+            if (!knownActionTypes.has(type)) {
+                problems.push(`Step "${step.filename}" uses unknown action type "${type}"`);
+            }
+        }
+    }
+    return problems;
+}

--- a/src/application/template/zfTemplate.ts
+++ b/src/application/template/zfTemplate.ts
@@ -32,7 +32,7 @@ export function parseTemplate(json: string): ZfTemplate {
     return parsed;
 }
 
-function isValidTemplate(value: unknown): value is ZfTemplate {
+export function isValidTemplate(value: unknown): value is ZfTemplate {
     if (typeof value !== "object" || value === null) return false;
     const obj = value as Record<string, unknown>;
     return (

--- a/src/application/template/zfTemplate.ts
+++ b/src/application/template/zfTemplate.ts
@@ -32,14 +32,23 @@ export function parseTemplate(json: string): ZfTemplate {
     return parsed;
 }
 
+/** A `.zftemplate` file entry is valid only when both `filename` and `content` are strings. */
+function isValidTemplateFile(value: unknown): value is ZfTemplateFile {
+    if (typeof value !== "object" || value === null) return false;
+    const file = value as Record<string, unknown>;
+    return typeof file.filename === "string" && typeof file.content === "string";
+}
+
 export function isValidTemplate(value: unknown): value is ZfTemplate {
     if (typeof value !== "object" || value === null) return false;
     const obj = value as Record<string, unknown>;
     return (
         typeof obj.zfVersion === "string" &&
         typeof obj.name === "string" &&
-        typeof obj.canvas === "object" &&
-        obj.canvas !== null &&
-        Array.isArray(obj.steps)
+        typeof obj.description === "string" &&
+        typeof obj.author === "string" &&
+        isValidTemplateFile(obj.canvas) &&
+        Array.isArray(obj.steps) &&
+        obj.steps.every(isValidTemplateFile)
     );
 }

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -283,6 +283,15 @@ export default {
     template_download_flow_files: 'Download flow files',
     template_download_flow_title: 'Download templates associated to the flow into your vault',
 
+    // Community system modal (#214)
+    community_system_preview: 'System preview',
+    community_system_contents: 'What gets installed',
+    community_system_install_location: 'Install location',
+    community_system_install_location_desc: 'Folder where the canvas and its step notes will be created.',
+    community_system_install_button: 'Install system',
+    community_system_installed: 'system installed',
+    community_system_install_error: 'Could not install the system. Check the console for details.',
+
     // Community markdown modal
     remove_markdown_button: 'Remove',
     remove_markdown_button_title: 'Remove the markdown file',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -283,6 +283,15 @@ export default {
     template_download_flow_files: 'Descargar archivos del flujo',
     template_download_flow_title: 'Descarga en tu vault las plantillas asociadas al flujo',
 
+    // Community system modal (#214)
+    community_system_preview: 'Vista previa del sistema',
+    community_system_contents: 'Qué se instala',
+    community_system_install_location: 'Ubicación de instalación',
+    community_system_install_location_desc: 'Carpeta donde se crearán el canvas y las notas de sus pasos.',
+    community_system_install_button: 'Instalar sistema',
+    community_system_installed: 'sistema instalado',
+    community_system_install_error: 'No se pudo instalar el sistema. Revisa la consola para más detalles.',
+
     // Modal de markdown de la comunidad
     remove_markdown_button: 'Eliminar',
     remove_markdown_button_title: 'Eliminar el archivo markdown',

--- a/src/config/typing.ts
+++ b/src/config/typing.ts
@@ -163,9 +163,10 @@ export type StaticTemplateOptions = {
     /** Author of the template */
     author: string;
     /**
-     * Type of the template: can be "step", "action", or "markdown"
+     * Type of the template: a "step"/"action"/"markdown" fragment, a "flow" (clipboard paste), or a
+     * "system" — a `.zftemplate` bundle installed as a canvas + steps in one click (#214).
      */
-    template_type: "step" | "action" | "markdown" | "flow";
+    template_type: "step" | "action" | "markdown" | "flow" | "system";
 };
 
 /**

--- a/src/styles/components/community.scss
+++ b/src/styles/components/community.scss
@@ -109,6 +109,10 @@
     border-left: 4px solid var(--code-keyword);
 }
 
+.zettelkasten-flow__template-type-system {
+    border-left: 4px solid var(--color-purple);
+}
+
 /* Badge indicating template type */
 .zettelkasten-flow__community-templates-card-type-badge {
     position: absolute;
@@ -136,6 +140,10 @@
 
 .zettelkasten-flow__template-type-flow .zettelkasten-flow__community-templates-card-type-badge {
     background-color: var(--code-keyword);
+}
+
+.zettelkasten-flow__template-type-system .zettelkasten-flow__community-templates-card-type-badge {
+    background-color: var(--color-purple);
 }
 
 /* Icon in the top-right corner */

--- a/test/application/community/fixtures/seed.zftemplate
+++ b/test/application/community/fixtures/seed.zftemplate
@@ -1,0 +1,16 @@
+{
+  "zfVersion": "1.0",
+  "name": "Seed system",
+  "description": "A minimal valid system exercised by the validity harness.",
+  "author": "ZettelFlow",
+  "canvas": {
+    "filename": "Seed.canvas",
+    "content": "{\"nodes\":[{\"id\":\"seed-step\",\"type\":\"file\",\"file\":\"_ZettelFlow/folders/Seed step.md\",\"x\":-175,\"y\":-80,\"width\":350,\"height\":160}],\"edges\":[]}"
+  },
+  "steps": [
+    {
+      "filename": "Seed step.md",
+      "content": "---\nzettelFlowSettings:\n  root: true\n  actions:\n    - type: prompt\n      hasUI: true\n      key: title\n      zone: context\n      label: Title\n      placeholder: Name the note...\n  label: Seed step\n  childrenHeader: ''\n---\n# {{title}}\n"
+    }
+  ]
+}

--- a/test/application/community/pure-is-obsidian-free.test.ts
+++ b/test/application/community/pure-is-obsidian-free.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// test/application/community → 3 ups → repo root
+const SYSTEM_INSTALL = join(__dirname, "..", "..", "..", "src", "application", "community", "systemInstall.ts");
+
+describe("systemInstall stays Obsidian-free (#214, AC-3)", () => {
+    it("does not import from 'obsidian'", () => {
+        expect(readFileSync(SYSTEM_INSTALL, "utf8")).not.toMatch(/from\s+["']obsidian["']/);
+    });
+});

--- a/test/application/community/shippedSystems.test.ts
+++ b/test/application/community/shippedSystems.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync, readdirSync, statSync, existsSync } from "fs";
+import { join } from "path";
+import { parseTemplate } from "application/template/zfTemplate";
+import { validateSystemTemplate, REGISTERED_ACTION_IDS } from "application/community/systemInstall";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const DOCS = join(REPO_ROOT, "docs");
+const SEED = join(__dirname, "fixtures", "seed.zftemplate");
+
+function findTemplates(dir: string): string[] {
+    if (!existsSync(dir)) return [];
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) out.push(...findTemplates(full));
+        else if (entry.endsWith(".zftemplate")) out.push(full);
+    }
+    return out;
+}
+
+describe("every shipped .zftemplate system is valid (#214, FR-8, AC-2)", () => {
+    const files = [SEED, ...findTemplates(DOCS)];
+
+    it("parses and validates every system against the registered action ids", () => {
+        expect(files.length).toBeGreaterThan(0);
+        for (const file of files) {
+            const template = parseTemplate(readFileSync(file, "utf8"));
+            expect({ file, problems: validateSystemTemplate(template, REGISTERED_ACTION_IDS) }).toEqual({
+                file,
+                problems: [],
+            });
+        }
+    });
+});

--- a/test/application/community/systemInstall.test.ts
+++ b/test/application/community/systemInstall.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    planSystemInstall,
+    validateSystemTemplate,
+    REGISTERED_ACTION_IDS,
+} from "application/community/systemInstall";
+import type { ZfTemplate } from "application/template/zfTemplate";
+
+const stepContent = "---\nzettelFlowSettings:\n  root: true\n  actions:\n    - type: prompt\n      key: title\n---\n# {{title}}\n";
+
+const template: ZfTemplate = {
+    zfVersion: "1.0",
+    name: "Academic",
+    description: "d",
+    author: "a",
+    canvas: { filename: "academic.canvas", content: '{"nodes":[],"edges":[]}' },
+    steps: [{ filename: "Capture.md", content: stepContent }],
+};
+
+describe("planSystemInstall (#214, FR-6, AC-1)", () => {
+    it("plans the canvas first then the steps under the target folder", () => {
+        expect(planSystemInstall(template, "Systems/Academic")).toEqual({
+            files: [
+                { path: "Systems/Academic/academic.canvas", content: '{"nodes":[],"edges":[]}' },
+                { path: "Systems/Academic/Capture.md", content: stepContent },
+            ],
+        });
+    });
+
+    it("writes at the vault root when the target is '/' or empty", () => {
+        expect(planSystemInstall(template, "/").files[0].path).toBe("academic.canvas");
+        expect(planSystemInstall(template, "").files[1].path).toBe("Capture.md");
+    });
+});
+
+describe("validateSystemTemplate (#214, FR-7, AC-2)", () => {
+    it("accepts a valid system", () => {
+        expect(validateSystemTemplate(template, REGISTERED_ACTION_IDS)).toEqual([]);
+    });
+
+    it("flags a malformed bundle", () => {
+        expect(validateSystemTemplate({} as ZfTemplate, REGISTERED_ACTION_IDS)).toEqual([
+            "Not a valid .zftemplate: missing required fields",
+        ]);
+    });
+
+    it("flags a step with no zettelFlowSettings frontmatter", () => {
+        const bad: ZfTemplate = { ...template, steps: [{ filename: "Bare.md", content: "# just a note\n" }] };
+        expect(validateSystemTemplate(bad, REGISTERED_ACTION_IDS)).toEqual([
+            'Step "Bare.md" has no zettelFlowSettings frontmatter',
+        ]);
+    });
+
+    it("flags an unknown action type", () => {
+        const unknown = "---\nzettelFlowSettings:\n  actions:\n    - type: teleport-note\n---\n";
+        const bad: ZfTemplate = { ...template, steps: [{ filename: "Bad.md", content: unknown }] };
+        expect(validateSystemTemplate(bad, REGISTERED_ACTION_IDS)).toEqual([
+            'Step "Bad.md" uses unknown action type "teleport-note"',
+        ]);
+    });
+
+    it("knows the cognitive action ids the epic shipped", () => {
+        for (const id of ["calculate-maturity", "find-related", "extract-claims", "thinking-simulator"]) {
+            expect(REGISTERED_ACTION_IDS.has(id)).toBe(true);
+        }
+    });
+});

--- a/test/application/community/systemInstall.test.ts
+++ b/test/application/community/systemInstall.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "@jest/globals";
 import {
     planSystemInstall,
     validateSystemTemplate,
+    isUnsafeFilename,
     REGISTERED_ACTION_IDS,
 } from "application/community/systemInstall";
 import type { ZfTemplate } from "application/template/zfTemplate";
@@ -62,6 +63,31 @@ describe("validateSystemTemplate (#214, FR-7, AC-2)", () => {
     it("knows the cognitive action ids the epic shipped", () => {
         for (const id of ["calculate-maturity", "find-related", "extract-claims", "thinking-simulator"]) {
             expect(REGISTERED_ACTION_IDS.has(id)).toBe(true);
+        }
+    });
+
+    it("flags an unsafe canvas or step filename (path traversal) before any write", () => {
+        const evil: ZfTemplate = {
+            ...template,
+            canvas: { filename: "../../.obsidian/plugins/x/main.js", content: "{}" },
+            steps: [{ filename: "sub/Nested.md", content: stepContent }],
+        };
+        expect(validateSystemTemplate(evil, REGISTERED_ACTION_IDS)).toEqual([
+            'Canvas "../../.obsidian/plugins/x/main.js" has an unsafe path',
+            'Step "sub/Nested.md" has an unsafe path',
+        ]);
+    });
+});
+
+describe("isUnsafeFilename (#214 hardening)", () => {
+    it("accepts a bare in-folder filename", () => {
+        expect(isUnsafeFilename("Capture.md")).toBe(false);
+        expect(isUnsafeFilename("My system.canvas")).toBe(false);
+    });
+
+    it("rejects separators, traversal, drive-absolute and empties", () => {
+        for (const bad of ["../escape.md", "a/b.md", "a\\b.md", "/abs.md", "..", ".", "", "   ", "C:evil.md"]) {
+            expect(isUnsafeFilename(bad)).toBe(true);
         }
     });
 });

--- a/test/application/template/zfTemplate.test.ts
+++ b/test/application/template/zfTemplate.test.ts
@@ -46,6 +46,16 @@ describe("parseTemplate", () => {
         expect(() => parseTemplate(JSON.stringify(bad))).toThrow();
     });
 
+    it("throws when canvas.content is not a string", () => {
+        const bad = { zfVersion: "1.0", name: "T", description: "", author: "", canvas: { filename: "f.canvas", content: 42 }, steps: [] };
+        expect(() => parseTemplate(JSON.stringify(bad))).toThrow();
+    });
+
+    it("throws when a step entry is malformed", () => {
+        const bad = { zfVersion: "1.0", name: "T", description: "", author: "", canvas: CANVAS_FILE, steps: [{ filename: "s.md" }] };
+        expect(() => parseTemplate(JSON.stringify(bad))).toThrow();
+    });
+
     it("throws on non-object JSON", () => {
         expect(() => parseTemplate('"just a string"')).toThrow();
     });

--- a/test/config/communitySystemLocale.test.ts
+++ b/test/config/communitySystemLocale.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "@jest/globals";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+const KEYS = [
+    "community_system_preview",
+    "community_system_contents",
+    "community_system_install_location",
+    "community_system_install_location_desc",
+    "community_system_install_button",
+    "community_system_installed",
+    "community_system_install_error",
+];
+
+describe("community system modal i18n parity (#214, AC-6)", () => {
+    it("defines all 7 keys in both en and es, non-empty", () => {
+        expect(KEYS.length).toBe(7);
+        const enMap = en as Record<string, string>;
+        const esMap = es as Record<string, string>;
+        for (const key of KEYS) {
+            expect(typeof enMap[key]).toBe("string");
+            expect(enMap[key].length).toBeGreaterThan(0);
+            expect(typeof esMap[key]).toBe("string");
+            expect(esMap[key].length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
Closes #214. First sub-task of the Systems Gallery epic (#213) — the enabler.

## What

Teaches the community browser to fetch and **one-click install** a unified `.zftemplate` **system**: it writes a real canvas + its step notes to a folder via the sanctioned Vault API, no clipboard round-trip. Existing `flow`/`step`/`action`/`markdown` catalog entries are untouched — this only adds the `system` type.

## How

- **Pure core** — `application/community/systemInstall.ts` (Obsidian-free): `planSystemInstall` (canvas first, then steps, under the target folder) + `validateSystemTemplate` (frontmatter present, every action `type` a registered id, filenames safe) + `REGISTERED_ACTION_IDS` (kept in sync with `main.ts`). Guarded Obsidian-free by a test.
- **Validity harness** — `shippedSystems.test.ts` scans every `docs/**/*.zftemplate` and asserts it parses + validates clean, so a broken shipped system fails CI.
- **Obsidian shell** — `CommunitySystemModal` (preview + optional sibling `<id>.png` + folder picker defaulting to `foldersFlowsPath` → `FileService.writeFile` → opens the canvas), `fetchSystemTemplate`, the `system` type wired through the gallery / typing / SCSS accent, 7 en/es i18n keys + parity test.
- **Security hardening (review)** — reject path-traversal/absolute filenames, enforce `validateSystemTemplate` at install before any write, tighten `isValidTemplate` to check the file shape, guard the async image object-URL against a close race, render install UI synchronously.

## Verify

`npm run verify` green — 814 tests, `lint:obsidian` 0. Reviewed by the obsidian-plugin-reviewer agent; all must-fix findings applied.

## Note

No system content ships here — this is only the install path. The real systems land in #215–#217; the catalog/README/image-tracker overhaul in #218.