### PR TITLE
docs(gallery): systems gallery catalog, readme and contributor overhaul (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   (connected / orphaned / unresolved), a knowledge-debt bar, and a "today" panel (to process ·
   contradictions · connections · open questions) — **every panel proposes a recommended next
   action**, one click from the surface to act on it. Read-only, offline.
+- **🧩 Systems Gallery** — *somewhere to start.* Install a complete knowledge **system** in one click
+  from the community browser: pick a folder and ZettelFlow writes a ready-to-run canvas plus its step
+  notes (no clipboard, no manual paste). Seven shipped systems — **Academic research · Zettelkasten v2 ·
+  PARA v2 · GTD · Reading · Writing · Software architecture KB** — each composing the cognitive actions
+  on creation, so a new note lands already related, cross-checked and scored. Offline, no AI.
 - **📦 Methodology packages** — an app store of knowledge *systems*: install the **Zettelkasten**
   package and get all its flows (and their built-in patterns) in one go; remove it just as cleanly
   (it trashes only its own files, never your notes). Atomic install, local, no network.

--- a/docs/how-to-contribute/community-examples.md
+++ b/docs/how-to-contribute/community-examples.md
@@ -38,7 +38,7 @@ Shipped systems:
 - **Writing** — from idea to finished draft: Draft (thesis + related source notes), Section (one point + suggested connections) and Review (surfaces contradictions to resolve) entry points.
 - **Software architecture KB** — a decision log: an ADR entry point records context/decision/consequences and checks new decisions against existing ones for contradictions; a Component entry point captures a component and its dependencies.
 
-To install a system: open the Community Templates browser, select the **Systems** tab, click a system to preview it, choose an install folder and press **Install system**.
+To install a system: open the Community Templates browser, select the **Systems** tab, click a system to preview it, choose an install folder and press **Install system**. See the full [Systems Gallery](systems-gallery.md) for the catalog of shipped systems and a guide to authoring your own.
 
 ## How to Access Community Resources
 1. Open Obsidian and make sure ZettelFlow is installed

--- a/docs/how-to-contribute/systems-gallery.md
+++ b/docs/how-to-contribute/systems-gallery.md
@@ -31,8 +31,8 @@ Each system offers several **independent entry points** on one canvas — pick t
 | **Writing** | Draft · Section · Review | drafts pull in related source notes; sections suggest connections; reviews surface contradictions |
 | **Software architecture KB** | Decision record (ADR) · Component | new decisions are checked against existing ones for contradictions and linked to related decisions |
 
-> Previews: each system shows a preview image in the browser. Some previews are placeholders pending
-> final artwork — the system itself is fully functional regardless.
+> Previews: each system shows a preview image in the browser. Previews currently ship as placeholders
+> pending final artwork (tracked in issue #223) — the system itself is fully functional regardless.
 
 ## Author your own system
 

--- a/docs/how-to-contribute/systems-gallery.md
+++ b/docs/how-to-contribute/systems-gallery.md
@@ -1,0 +1,60 @@
+# Systems Gallery
+
+A **system** is a whole knowledge methodology you can install in **one click** — a ready-to-run
+canvas plus its step notes, written straight into your vault. Systems are the fastest way to get
+started with ZettelFlow: instead of a blank canvas you begin from a real workflow that already
+composes the cognitive actions, so a note you create through a system lands **already related,
+cross-checked, link-suggested and maturity-scored** against your own graph.
+
+Systems ship in the unified [`.zftemplate`](../architecture/zftemplate-schema.md) format and install
+from the **Community Templates** browser — see [Community resources](community-examples.md#5-systems-one-click).
+Everything is **offline** (no network, no AI) and additive (nothing in your vault is removed).
+
+## Install a system
+
+1. Open the **Community Templates** browser (ZettelFlow ribbon → *Community templates*).
+2. Select the **Systems** tab and click a system to preview it.
+3. Choose an install folder (a per-system subfolder is suggested) and press **Install system**.
+4. ZettelFlow writes the canvas and every step note, then opens the canvas — pick an entry point and go.
+
+## Shipped systems
+
+Each system offers several **independent entry points** on one canvas — pick the note type you want to create.
+
+| System | Entry points | What lands on creation |
+|---|---|---|
+| **Academic research** | Literature note · Permanent note | claims extracted · candidate sources · contradictions flagged · maturity scored → connected permanent notes |
+| **Zettelkasten v2** | Fleeting · Literature · Permanent | the permanent note is related, cross-checked, link-suggested and maturity-scored (the on-creation pattern) |
+| **PARA v2** | Project · Area · Resource · Archive | each note lands in its PARA folder, tagged by category and connected with *find related* |
+| **GTD** | Inbox capture · Next action · Project | a thought moves from capture to a context-tagged next action, connected with *find related* |
+| **Reading** | Reading source · Reading note | highlights mined for claims and candidate sources; insights connected to your graph |
+| **Writing** | Draft · Section · Review | drafts pull in related source notes; sections suggest connections; reviews surface contradictions |
+| **Software architecture KB** | Decision record (ADR) · Component | new decisions are checked against existing ones for contradictions and linked to related decisions |
+
+> Previews: each system shows a preview image in the browser. Some previews are placeholders pending
+> final artwork — the system itself is fully functional regardless.
+
+## Author your own system
+
+A system is a single `.zftemplate` JSON bundle: a `canvas` (a real `.canvas`) plus its `steps` (the
+`.md` files with `zettelFlowSettings` frontmatter). To contribute one:
+
+1. **Build it in Obsidian.** Compose a canvas whose step nodes are `.md` files carrying valid
+   `zettelFlowSettings` frontmatter (the same frontmatter the Step Builder writes). Run the command
+   **`ZettelFlow: Export current canvas as .zftemplate`** to produce the bundle.
+2. **Use independent entry points, not a chain.** For a system that offers several note types, give
+   each its own `root: true` step and leave the canvas **edges empty** — a chained child auto-advances
+   and merges the notes into one. (See any shipped system under `docs/systems/`.)
+3. **Stay offline.** Compose the graph-computing actions in an `onCreation` block (`find-related`,
+   `suggest-link`, `find-contradiction`, `calculate-maturity`, `extract-claims`, `find-sources`).
+   Do **not** use the AI actions (`classify`, `summarize`, `generate-questions`) — a shipped system
+   must run with no network. Avoid actions whose value is a build-time-fixed target
+   (`attach-source`, `create-semantic-relation`) — they are no-ops in a template; capture relations
+   with `find-related`/`suggest-link` and a plain wikilink prompt instead.
+4. **Quote YAML-unsafe values.** A prompt `placeholder`/`label` that starts with `[[`, `@`, `{`, `*`
+   (or contains `: `) must be single-quoted, or the frontmatter fails to parse and the step is dropped.
+5. **Catalog it.** Add the `.zftemplate` under `docs/systems/`, a sibling `<id>.png` preview, and a
+   `template_type: "system"` row to `docs/main_template.json` (`ref` = the `.zftemplate` path).
+6. **Validate.** `npm test` runs the validity harness (`shippedSystems.test.ts` + `catalog.test.ts`):
+   every shipped system must parse, reference only registered non-AI actions, use YAML-safe frontmatter,
+   and resolve its canvas file-nodes to real steps.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,8 @@ nav:
       - 3.2 Folder Automation: vault-hooks/OnCreate.md
   - 4. How to Contribute:
       - 4.1 Community examples: how-to-contribute/community-examples.md
-      - 4.2 Wiki: how-to-contribute/Wiki.md
+      - 4.2 Systems gallery: how-to-contribute/systems-gallery.md
+      - 4.3 Wiki: how-to-contribute/Wiki.md
   - 5. API: api/ZettelFlowAPI.md
   - 6. Architecture:
       - 6.1 Overview: architecture/overview.md


### PR DESCRIPTION
Closes #218. Final sub-task of the Systems Gallery epic (#213).

## What

Reframes the community around the **Systems Gallery** (docs/catalog/README only — nothing removed):

- **New docs page** `docs/how-to-contribute/systems-gallery.md` — user-facing catalog of all seven shipped systems (entry points + what lands on creation), one-click install steps, and an **"author your own system"** recipe (independent roots / empty edges, offline actions only, YAML-safe values, catalog row + validity harness). Wired into the mkdocs nav (4.2).
- **README** — a Systems Gallery bullet in the Zettelkasten toolkit, listing the seven systems (adoption is a first-class goal). The Features table already carries the "Community systems" row.
- **Cross-links** from the community resources guide.
- **Catalog** (`docs/main_template.json`) already lists all seven `template_type:"system"` rows (added incrementally in #215–#217; guarded by `catalog.test.ts`).
- **Image tracker** filed as #223 — the seven `docs/systems/<id>.png` previews currently ship as placeholders for @RafaelGB to replace; the systems are fully functional regardless.

## Verify

Docs/catalog/README only — no source touched. `npm run verify` remains green (826 tests, `lint:obsidian` 0). This completes epic #213.
