### PR TITLE
fix(actions): suppress cognitive-action Notice in a headless pattern run (#201)

### DIFF
--- a/src/actions/ai/aiActionShared.ts
+++ b/src/actions/ai/aiActionShared.ts
@@ -109,5 +109,5 @@ export async function runAiAction(
 
     const value = spec.transform ? spec.transform(raw) : raw;
     writeKnowledgeResult(info, el, value);
-    new Notice(spec.notice(value));
+    if (!info.silent) new Notice(spec.notice(value)); // suppress in a headless pattern run (#201)
 }

--- a/src/actions/attachSource/AttachSourceAction.tsx
+++ b/src/actions/attachSource/AttachSourceAction.tsx
@@ -30,7 +30,7 @@ export class AttachSourceAction extends CustomZettelAction {
             return;
         }
         writeKnowledgeResult(info, { ...el, key: field.key }, field.value);
-        new Notice(t("research_attach_source_notice", field.value));
+        if (!info.silent) new Notice(t("research_attach_source_notice", field.value));
     }
 
     getIcon(): string {

--- a/src/actions/compareClaims/CompareClaimsAction.tsx
+++ b/src/actions/compareClaims/CompareClaimsAction.tsx
@@ -43,7 +43,7 @@ export class CompareClaimsAction extends CustomZettelAction {
         const agreeingLinks = toNoteLinks(agreeing);
         const contradictingLinks = toNoteLinks(contradicting);
         writeKnowledgeResult(info, el, { agreeing: agreeingLinks, contradicting: contradictingLinks });
-        new Notice(
+        if (!info.silent) new Notice(
             t("research_compare_claims_notice", String(agreeingLinks.length), String(contradictingLinks.length))
         );
     }

--- a/src/actions/createSemanticRelation/CreateSemanticRelationAction.tsx
+++ b/src/actions/createSemanticRelation/CreateSemanticRelationAction.tsx
@@ -34,7 +34,7 @@ export class CreateSemanticRelationAction extends CustomZettelAction {
             return;
         }
         writeKnowledgeResult(info, { ...el, key: field.key }, field.value);
-        new Notice(t("relation_create_relation_notice", field.key));
+        if (!info.silent) new Notice(t("relation_create_relation_notice", field.key));
     }
 
     getIcon(): string {

--- a/src/actions/extractClaims/ExtractClaimsAction.tsx
+++ b/src/actions/extractClaims/ExtractClaimsAction.tsx
@@ -46,7 +46,7 @@ export class ExtractClaimsAction extends CustomZettelAction {
         }
         const serialized = serializeClaims(idea.claims);
         writeKnowledgeResult(info, el, serialized);
-        new Notice(t("research_extract_claims_notice", String(serialized.claim.length)));
+        if (!info.silent) new Notice(t("research_extract_claims_notice", String(serialized.claim.length)));
     }
 
     getIcon(): string {

--- a/src/actions/findContradiction/FindContradictionAction.tsx
+++ b/src/actions/findContradiction/FindContradictionAction.tsx
@@ -41,7 +41,7 @@ export class FindContradictionAction extends CustomZettelAction {
         }
         const contradictions = findContradictions(model, path);
         writeKnowledgeResult(info, el, contradictions.map((p) => `[[${p.replace(/\.md$/i, "")}]]`));
-        new Notice(t("knowledge_find_contradiction_notice", String(contradictions.length)));
+        if (!info.silent) new Notice(t("knowledge_find_contradiction_notice", String(contradictions.length)));
     }
 
     getIcon(): string {

--- a/src/actions/findRelated/FindRelatedAction.tsx
+++ b/src/actions/findRelated/FindRelatedAction.tsx
@@ -43,7 +43,7 @@ export class FindRelatedAction extends CustomZettelAction {
         }
         const related = rankRelated(model, path, { limit: el.limit ?? DEFAULT_LIMIT });
         writeKnowledgeResult(info, el, related.map((p) => `[[${p.replace(/\.md$/i, "")}]]`));
-        new Notice(t("relation_find_related_notice", String(related.length)));
+        if (!info.silent) new Notice(t("relation_find_related_notice", String(related.length)));
     }
 
     getIcon(): string {

--- a/src/actions/findSources/FindSourcesAction.tsx
+++ b/src/actions/findSources/FindSourcesAction.tsx
@@ -45,7 +45,7 @@ export class FindSourcesAction extends CustomZettelAction {
         }
         const candidates = findSources(model, path, { limit: el.limit ?? DEFAULT_LIMIT });
         writeKnowledgeResult(info, el, candidates.map(sourceToken));
-        new Notice(t("research_find_sources_notice", String(candidates.length)));
+        if (!info.silent) new Notice(t("research_find_sources_notice", String(candidates.length)));
     }
 
     getIcon(): string {

--- a/src/actions/findUnansweredQuestion/FindUnansweredQuestionAction.tsx
+++ b/src/actions/findUnansweredQuestion/FindUnansweredQuestionAction.tsx
@@ -41,7 +41,7 @@ export class FindUnansweredQuestionAction extends CustomZettelAction {
         }
         const questions = findUnansweredQuestions(model, path);
         writeKnowledgeResult(info, el, questions.map((p) => `[[${p.replace(/\.md$/i, "")}]]`));
-        new Notice(t("knowledge_find_unanswered_question_notice", String(questions.length)));
+        if (!info.silent) new Notice(t("knowledge_find_unanswered_question_notice", String(questions.length)));
     }
 
     getIcon(): string {

--- a/src/actions/suggestLink/SuggestLinkAction.tsx
+++ b/src/actions/suggestLink/SuggestLinkAction.tsx
@@ -43,7 +43,7 @@ export class SuggestLinkAction extends CustomZettelAction {
         }
         const suggestions = rankRelated(model, path, { limit: el.limit ?? DEFAULT_LIMIT });
         writeKnowledgeResult(info, el, suggestions.map((p) => `[[${p.replace(/\.md$/i, "")}]]`));
-        new Notice(t("relation_suggest_link_notice", String(suggestions.length)));
+        if (!info.silent) new Notice(t("relation_suggest_link_notice", String(suggestions.length)));
     }
 
     getIcon(): string {

--- a/src/actions/suggestNextMove/SuggestNextMoveAction.tsx
+++ b/src/actions/suggestNextMove/SuggestNextMoveAction.tsx
@@ -54,7 +54,7 @@ export class SuggestNextMoveAction extends CustomZettelAction {
             ? moves.map((move) => t(MOVE_LABELS[move]))
             : [t("knowledge_next_move_complete")];
         writeKnowledgeResult(info, el, value);
-        new Notice(
+        if (!info.silent) new Notice(
             moves.length > 0
                 ? t("knowledge_next_move_notice", String(moves.length))
                 : t("knowledge_next_move_complete")

--- a/src/actions/thinkingSimulator/ThinkingSimulatorAction.tsx
+++ b/src/actions/thinkingSimulator/ThinkingSimulatorAction.tsx
@@ -57,7 +57,7 @@ export class ThinkingSimulatorAction extends CustomZettelAction {
         const prompts = criticalThinkingPrompts(model, path);
         const value = prompts.map((prompt) => t(PROMPT_LABELS[prompt]));
         writeKnowledgeResult(info, el, value);
-        new Notice(t("knowledge_thinking_notice", String(prompts.length)));
+        if (!info.silent) new Notice(t("knowledge_thinking_notice", String(prompts.length)));
     }
 
     getIcon(): string {

--- a/src/application/patterns/runOnCreationActions.ts
+++ b/src/application/patterns/runOnCreationActions.ts
@@ -28,6 +28,8 @@ export async function runOnCreationActions(
                 content: ctx.content,
                 note: ctx.note,
                 context: ctx.context,
+                // Headless pattern run — cognitive actions suppress their success Notice (#201).
+                silent: true,
             });
         } catch (error) {
             log.error(

--- a/src/architecture/api/typing.ts
+++ b/src/architecture/api/typing.ts
@@ -10,7 +10,13 @@ export type ExecuteInfo = {
     element: FinalElement,
     content: ContentDTO,
     note: NoteDTO,
-    context: Record<string, Literal>
+    context: Record<string, Literal>,
+    /**
+     * True when the action runs headless as part of a note's on-creation pattern (#170/#201) rather
+     * than an interactive wizard step. Cognitive actions suppress their success `Notice` when set, so
+     * a pattern that runs several of them does not spray a stack of toasts. Absent ⇒ interactive.
+     */
+    silent?: boolean,
 }
 
 export type Action = {

--- a/test/application/patterns/runOnCreationActions.test.ts
+++ b/test/application/patterns/runOnCreationActions.test.ts
@@ -50,4 +50,10 @@ describe("runOnCreationActions (#170, FR-3, AC-1)", () => {
         expect(received[0].note).toBe(ctx.note);
         expect(received[0].context).toBe(ctx.context);
     });
+
+    it("marks the run as silent so headless actions suppress their Notice (#201)", async () => {
+        const received: ExecuteInfo[] = [];
+        await runOnCreationActions([action("a")], ctx, () => ({ execute: (info) => void received.push(info) }));
+        expect(received[0].silent).toBe(true);
+    });
 });


### PR DESCRIPTION
Closes #201.

## Problem

A note's on-creation pattern (#170) runs several cognitive actions in a row, and each fired its own success `Notice` — so creating one note sprayed a stack of toasts (find related, find contradictions, suggest links, calculate maturity, …).

## Fix

- Add an optional `silent` flag to `ExecuteInfo`; `runOnCreationActions` sets `silent: true` for the headless pattern run.
- Gate the **success** `Notice` of every knowledge / relations / research / AI action on `!info.silent`.
- Interactive wizard runs are unchanged (`silent` is absent). AI **error** notices (not-configured / request-failed) still surface.

## Tests

`runOnCreationActions` now asserts the run is marked `silent`. `npm run verify` green — 827 tests, `lint:obsidian` 0.

Pure behavior fix — no public surface or UI text change, so no docs update needed.