### PR TITLE
feat: friction epic — one adoption path, one front door, honest actions (#231)

### DIFF
--- a/docs/actions/AttachSource.md
+++ b/docs/actions/AttachSource.md
@@ -19,6 +19,15 @@ After re-index the model derives a claim carrying the source and reports the not
 Writing to an **existing foreign note** is out of scope for this action (it only writes the note
 being built).
 
+## Interactive-only (#231 Phase 4)
+
+This action reads a **fixed `source`** from its own configuration, so it is meant for **interactive**
+use (you set the source while building the note). It is a **no-op when authored into a shipped
+`.zftemplate` system's `onCreation`** — a template can't know the per-note source, so an empty value
+writes nothing. In a system, capture the source with a normal **prompt** (or use the deterministic
+[`find-sources`](FindSources.md) to suggest candidates). See the
+[Systems Gallery authoring guide](../how-to-contribute/systems-gallery.md).
+
 ## Capabilities
 
 File-system write of a single `source` frontmatter field on the note being built (the same surface

--- a/docs/actions/CreateSemanticRelation.md
+++ b/docs/actions/CreateSemanticRelation.md
@@ -24,6 +24,14 @@ the *typed* ones.)
 One typed frontmatter field, e.g. `supports: "[[Target]]"`, also exposed as `{{supports}}`. Feeding
 that field through the relation schema yields exactly one `Relation { type, from: note, to: target }`.
 
+## Interactive-only (#231 Phase 4)
+
+This action writes to a **fixed `target`** set in its own configuration, so it is meant for
+**interactive** use. It is a **no-op when authored into a shipped `.zftemplate` system's `onCreation`**
+— a template can't know the per-note target. In a system, capture the relation with a normal
+**prompt** (a `[[wikilink]]` field) or use the deterministic
+[`find-related`](FindRelated.md)/[`suggest-link`](SuggestLink.md) instead.
+
 ## Removing a relation (#181)
 
 To delete a relation you created, run the **Remove a relation** command (command palette) with the

--- a/docs/how-to-contribute/community-examples.md
+++ b/docs/how-to-contribute/community-examples.md
@@ -8,13 +8,12 @@ ZettelFlow allows the community to share templates, flows, and actions to help u
 ## Types of Community Resources
 ZettelFlow offers five main types of community resources:
 
-### 1. Flows
-Flows are complete workflows designed to guide you through specific note-taking processes. These are particularly valuable because:
-
-- Ready to use: No technical knowledge required
-- Time-saving: No need to build workflows from scratch
-- Best practice: Created by experienced users
-- Versatile: Available for many different note-taking scenarios
+### 1. Flows *(legacy — superseded by Systems)*
+Flows were complete workflows installed by copying to the clipboard and pasting onto a canvas. As of
+the **Systems Gallery**, this is superseded by one-click **[Systems](#5-systems-one-click)** (a canvas
+plus its steps, written in one click — no clipboard). The community browser now **leads with Systems**
+and hides the legacy *flow* tab; the flow install path still works for back-compat but is no longer the
+recommended way to adopt a workflow.
 
 ### 2. Steps
 Steps are individual components that can be added to your existing workflows. They represent a single action or decision point in a note creation process.

--- a/src/application/community/components/StaticTemplatesGallery.tsx
+++ b/src/application/community/components/StaticTemplatesGallery.tsx
@@ -24,9 +24,10 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
   // Estados
   const [searchTerm, setSearchTerm] = useState("");
   const [targetSearchTerm, setTargetSearchTerm] = useState("");
+  // Systems are the primary adoption path (#231 Phase 1): the browser leads with them.
   const [filter, setFilter] = useState<
     "all" | "step" | "action" | "markdown" | "flow" | "system"
-  >("all");
+  >("system");
   const [templates, setTemplates] = useState<StaticTemplateOptions[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -64,7 +65,10 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
         template.description.toLowerCase().includes(lowerCaseSearchTerm);
       const matchesFilter =
         filter === "all" || template.template_type === filter;
-      return matchesSearch && matchesFilter;
+      // Legacy "flow" entries are superseded by one-click systems (#231 Phase 1) — kept in the
+      // catalog for back-compat but hidden from the browser (consolidate & hide).
+      const isLegacyFlow = template.template_type === "flow";
+      return matchesSearch && matchesFilter && !isLegacyFlow;
     });
   }, [templates, targetSearchTerm, filter]);
 
@@ -187,7 +191,7 @@ export function StaticTemplatesGallery(props: PluginComponentProps) {
           className={c("community-templates-search")}
         />
         <div className={c("community-templates-filters")}>
-          {(["all", "step", "action", "markdown", "flow", "system"] as const).map(
+          {(["system", "all", "step", "action", "markdown"] as const).map(
             (type) => {
               const classesToApply = [
                 "community-templates-filter-button",

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -527,6 +527,7 @@ export default {
     state_transition_error: 'Could not change the note state. Check the console for details.',
     // Remove a relation command (#181)
     command_remove_relation: 'Remove a relation',
+    ribbon_open_zettelflow: 'Open ZettelFlow',
     remove_relation_modal_title: 'Pick a relation to remove…',
     remove_relation_none: 'This note has no typed relations to remove.',
     remove_relation_confirm_question: 'Remove the relation {0} → [[{1}]] from "{2}"?',

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -381,7 +381,7 @@ export default {
     onboarding_configure_canvas: 'Configure existing canvas',
     onboarding_example_created: 'Example flow created — canvas set as your flow canvas. Open the canvas to explore it.',
     onboarding_example_create_failed: 'Could not create the example flow. Check the console for details.',
-    onboarding_notice_msg: 'ZettelFlow is installed. Configure a canvas or create an example flow to get started.',
+    onboarding_notice_msg: 'ZettelFlow is installed. The quickest way to start is to install a ready-made system from the community browser — it writes a canvas and its steps in one click.',
     onboarding_notice_open_settings: 'Open settings',
     settings_get_started_title: 'Get started',
     settings_get_started_description: 'No canvas configured yet. Create an example flow to see ZettelFlow in action, or configure an existing canvas above.',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -527,6 +527,7 @@ export default {
     state_transition_error: 'No se pudo cambiar el estado de la nota. Revisa la consola para más detalles.',
     // Remove a relation command (#181)
     command_remove_relation: 'Eliminar una relación',
+    ribbon_open_zettelflow: 'Abrir ZettelFlow',
     remove_relation_modal_title: 'Elige una relación para eliminar…',
     remove_relation_none: 'Esta nota no tiene relaciones tipadas que eliminar.',
     remove_relation_confirm_question: '¿Eliminar la relación {0} → [[{1}]] de "{2}"?',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -381,7 +381,7 @@ export default {
     onboarding_configure_canvas: 'Configurar canvas existente',
     onboarding_example_created: 'Flujo de ejemplo creado — el canvas se ha establecido como tu canvas de flujo. Ábrelo para explorarlo.',
     onboarding_example_create_failed: 'No se pudo crear el flujo de ejemplo. Consulta la consola para más detalles.',
-    onboarding_notice_msg: 'ZettelFlow está instalado. Configura un canvas o crea un flujo de ejemplo para empezar.',
+    onboarding_notice_msg: 'ZettelFlow está instalado. La forma más rápida de empezar es instalar un sistema listo para usar desde el navegador de la comunidad — crea un canvas y sus pasos en un clic.',
     onboarding_notice_open_settings: 'Abrir ajustes',
     settings_get_started_title: 'Empezar',
     settings_get_started_description: 'Aún no hay un canvas configurado. Crea un flujo de ejemplo para ver ZettelFlow en acción, o configura un canvas existente arriba.',

--- a/src/starters/utils/StartersTools.ts
+++ b/src/starters/utils/StartersTools.ts
@@ -31,6 +31,7 @@ import { AtomicitySplitComponent } from "../zcomponents/AtomicitySplitComponent"
 import { KnowledgeIndexComponent } from "../zcomponents/KnowledgeIndexComponent";
 import { StateTransitionComponent } from "../zcomponents/StateTransitionComponent";
 import { RemoveRelationComponent } from "../zcomponents/RemoveRelationComponent";
+import { ZettelFlowMenuComponent } from "../zcomponents/ZettelFlowMenuComponent";
 
 /**
  * Load all components of the plugin with the ZComponent interface
@@ -64,6 +65,7 @@ export function loadPluginComponents(plugin: ZettelFlow): void {
     ZComponentsManager.registerComponent(new KnowledgeIndexComponent(plugin));
     ZComponentsManager.registerComponent(new StateTransitionComponent(plugin));
     ZComponentsManager.registerComponent(new RemoveRelationComponent(plugin));
+    ZComponentsManager.registerComponent(new ZettelFlowMenuComponent(plugin));
     ZComponentsManager.loadComponents();
 }
 

--- a/src/starters/zcomponents/ZettelFlowMenuComponent.ts
+++ b/src/starters/zcomponents/ZettelFlowMenuComponent.ts
@@ -1,0 +1,70 @@
+import { Menu } from "obsidian";
+import { PluginComponent, ObsidianApi } from "architecture";
+import { t } from "architecture/lang";
+import ZettelFlow from "main";
+
+type LocaleKey = Parameters<typeof t>[0];
+
+interface ViewEntry {
+    /** The `show-*` command id (without the plugin prefix). */
+    command: string;
+    /** i18n key of the entry's label — reuses the command's own name key (no duplication). */
+    labelKey: LocaleKey;
+    icon: string;
+}
+
+/**
+ * One discoverable front door (#231 Phase 2). ZettelFlow's ~12 views were reachable *only* through the
+ * command palette (audit finding F1); this adds a single ribbon menu that lists them, grouped, so a
+ * user has one obvious place to open Home, the health views, discovery, the graph, and the rest.
+ * Additive & consolidate-and-hide — no view is removed; labels reuse the existing command name keys and
+ * execution goes through the sanctioned {@link ObsidianApi} command runner.
+ */
+export class ZettelFlowMenuComponent extends PluginComponent {
+    constructor(private plugin: ZettelFlow) {
+        super(plugin);
+    }
+
+    /** View entries grouped by job; a separator is drawn between groups. Home leads. */
+    private static readonly GROUPS: ViewEntry[][] = [
+        [{ command: "show-home", labelKey: "command_show_home", icon: "home" }],
+        [
+            { command: "show-knowledge-dashboard", labelKey: "command_show_knowledge_dashboard", icon: "layout-dashboard" },
+            { command: "show-slipbox-health", labelKey: "command_show_slipbox_health", icon: "activity" },
+        ],
+        [
+            { command: "show-discoveries", labelKey: "command_show_discoveries", icon: "sparkles" },
+            { command: "resurface-related-notes", labelKey: "command_resurface", icon: "history" },
+        ],
+        [
+            { command: "show-knowledge-map", labelKey: "command_show_knowledge_map", icon: "network" },
+            { command: "show-concept-nav", labelKey: "command_show_concept_nav", icon: "waypoints" },
+        ],
+        [
+            { command: "show-open-questions", labelKey: "command_show_open_questions", icon: "help-circle" },
+            { command: "show-evolution-timeline", labelKey: "command_show_evolution_timeline", icon: "git-commit-horizontal" },
+            { command: "show-thinking-heatmap", labelKey: "command_show_thinking_heatmap", icon: "flame" },
+            { command: "show-evidence-map", labelKey: "command_show_evidence_map", icon: "scale" },
+        ],
+        [{ command: "show-notes-history", labelKey: "command_show_history", icon: "clock" }],
+    ];
+
+    onLoad(): void {
+        this.plugin.addRibbonIcon("brain-circuit", t("ribbon_open_zettelflow"), (evt: MouseEvent) => {
+            const menu = new Menu();
+            const prefix = `${this.plugin.manifest.id}:`;
+            ZettelFlowMenuComponent.GROUPS.forEach((group, index) => {
+                if (index > 0) menu.addSeparator();
+                for (const entry of group) {
+                    menu.addItem((item) =>
+                        item
+                            .setTitle(t(entry.labelKey))
+                            .setIcon(entry.icon)
+                            .onClick(() => ObsidianApi.executeCommandById(`${prefix}${entry.command}`))
+                    );
+                }
+            });
+            menu.showAtMouseEvent(evt);
+        });
+    }
+}


### PR DESCRIPTION
Advances the friction epic **#231** ("one obvious path — reduce friction, keep the soul") on top of Phase 0 (already on main). Stance: **consolidate & hide** — nothing deleted.

## Delivered in this PR

- **Phase 1 — one adoption path.** The community browser now **leads with Systems** and hides the legacy **flow** tab (the two old flows are superseded by the v2 systems). Flow catalog entries + code path stay for back-compat, just hidden from the browser. Kills the "5 ways to install a workflow" confusion.
- **Phase 2 — one front door.** A single **"Open ZettelFlow" ribbon menu** lists the ~12 knowledge views, grouped (Home · Health · Discovery · Graph · more · History) — they were previously reachable *only* via the command palette (audit finding F1). Additive; labels reuse the existing command names; execution via `ObsidianApi`.
- **Phase 4 — honest action set.** `create-semantic-relation` and `attach-source` documented as **interactive-only** (they read a build-time-fixed target/source, so they no-op in a shipped system's `onCreation`); authors are pointed at prompts / `find-related` / `find-sources`. Capability kept.
- **Phase 6 — first-run nudge.** The onboarding notice now points new users at **installing a system** (the one obvious start), reinforcing Phase 1.

## Tracked follow-ups (the deep, live-verification-heavy halves)

- **Phase 3** — merge Discoveries + Resurface into one Discovery *view* → **#237** (already share a door via the Phase 2 ribbon group).
- **Phase 5** — one step-config format (frontmatter) + fix the canvas hot-reload bug → **#238** (also closes #226). The largest, riskiest phase — a genuine engine migration.

## Verify

`npm run verify` green — 847 tests, `lint:obsidian` 0. Phases 1/2/6 are UI/ribbon changes best confirmed with a quick live-vault check (the ribbon menu + the systems-first browser).