### PR TITLE
feat(experience): merge Discoveries + Resurface into one Discovery view (#237)

### DIFF
--- a/src/architecture/components/core/discoveries/DiscoveriesView.ts
+++ b/src/architecture/components/core/discoveries/DiscoveriesView.ts
@@ -1,8 +1,10 @@
-import { ItemView, Notice, TFile, WorkspaceLeaf } from "obsidian";
+import { ItemView, MarkdownView, Notice, TFile, WorkspaceLeaf } from "obsidian";
 import { c, log, ObsidianApi } from "architecture";
 import { t } from "architecture/lang";
 import { KnowledgeIndex } from "architecture/knowledge";
 import { Discovery, findDiscoveries } from "architecture/knowledge/discovery/discoveries";
+import { ResurfacedNote, rankResurfacedNotes } from "application/notes/resurfaceRanking";
+import { buildResurfaceInputs } from "../resurface/resurfaceInputs";
 
 type ViewState = "computing" | "ready" | "none" | "error";
 
@@ -25,6 +27,10 @@ export class DiscoveriesView extends ItemView {
     private state: ViewState = "computing";
     private discoveries: Discovery[] = [];
     private readonly dismissed = new Set<string>();
+    // The "related to the active note" section (#231 Phase 3 — merged from the resurface view).
+    private related: ResurfacedNote[] = [];
+    private relatedActivePath: string | null = null;
+    private throttleTimer: number | undefined;
 
     constructor(leaf: WorkspaceLeaf) {
         super(leaf);
@@ -35,7 +41,7 @@ export class DiscoveriesView extends ItemView {
     }
 
     getDisplayText(): string {
-        return t("discoveries_view_title");
+        return t("discovery_view_title");
     }
 
     getIcon(): string {
@@ -43,23 +49,41 @@ export class DiscoveriesView extends ItemView {
     }
 
     async onOpen(): Promise<void> {
-        this.recompute();
+        this.registerWorkspaceListeners();
+        this.refresh();
     }
 
     async onClose(): Promise<void> {
+        window.clearTimeout(this.throttleTimer);
         this.contentEl.empty();
+    }
+
+    /** Recompute the related section (throttled) as the active note changes. */
+    private registerWorkspaceListeners(): void {
+        const throttled = () => {
+            window.clearTimeout(this.throttleTimer);
+            this.throttleTimer = window.setTimeout(() => this.refresh(), 400);
+        };
+        this.registerEvent(this.app.workspace.on("active-leaf-change", throttled));
+        this.registerEvent(this.app.workspace.on("file-open", throttled));
     }
 
     private key(discovery: Discovery): string {
         return `${discovery.a}::${discovery.b}`;
     }
 
-    private recompute(): void {
+    /** Recompute both sections and render once. */
+    private refresh(): void {
+        this.computeDiscoveries();
+        this.computeRelated();
+        this.render();
+    }
+
+    private computeDiscoveries(): void {
         try {
             const index = KnowledgeIndex.getInstance();
             if (index.status !== "ready") {
                 this.state = "computing";
-                this.render();
                 return;
             }
             const ranked = findDiscoveries(index.getModel(), { limit: LIMIT + this.dismissed.size });
@@ -69,7 +93,29 @@ export class DiscoveriesView extends ItemView {
             this.state = "error";
             log.error(`[Discoveries] compute failed: ${error instanceof Error ? error.message : "unknown error"}`);
         }
-        this.render();
+    }
+
+    /** The "related to the active note" section (#231 Phase 3) — reuses the pure resurface ranker. */
+    private computeRelated(): void {
+        try {
+            const activeFile = this.app.workspace.getActiveViewOfType(MarkdownView)?.file ?? null;
+            this.relatedActivePath = activeFile?.path ?? null;
+            if (!activeFile) {
+                this.related = [];
+                return;
+            }
+            const inputs = buildResurfaceInputs(this.app);
+            const active = inputs.buildActiveSignals(activeFile);
+            this.related = rankResurfacedNotes({
+                active,
+                candidates: inputs.candidates,
+                now: Date.now(),
+                excludePaths: [active.path],
+            }).slice(0, LIMIT);
+        } catch (error) {
+            this.related = [];
+            log.error(`[Discovery] related compute failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        }
     }
 
     private render(): void {
@@ -78,14 +124,21 @@ export class DiscoveriesView extends ItemView {
         const container = contentEl.createDiv({ cls: c("discoveries") });
 
         const header = container.createDiv({ cls: c("discoveries-header") });
-        header.createEl("h4", { text: t("discoveries_view_title"), cls: c("discoveries-title") });
+        header.createEl("h4", { text: t("discovery_view_title"), cls: c("discoveries-title") });
         const refresh = header.createEl("button", {
             text: t("discoveries_refresh_button"),
             cls: c("discoveries-refresh"),
             attr: { "aria-label": t("discoveries_refresh_button") },
         });
-        this.registerDomEvent(refresh, "click", () => this.recompute());
+        this.registerDomEvent(refresh, "click", () => this.refresh());
 
+        this.renderDiscoveries(container);
+        this.renderRelated(container);
+    }
+
+    /** Section 1 — surprising vault-wide connections (the original morning-discovery pane). */
+    private renderDiscoveries(container: HTMLElement): void {
+        container.createEl("h5", { text: t("discoveries_view_title"), cls: c("discoveries-section-heading") });
         if (this.state === "computing") {
             container.createDiv({ cls: c("discoveries-status"), text: t("discoveries_computing") });
             return;
@@ -98,9 +151,30 @@ export class DiscoveriesView extends ItemView {
             container.createDiv({ cls: c("discoveries-status"), text: t("discoveries_none") });
             return;
         }
-
         const list = container.createDiv({ cls: c("discoveries-list") });
         for (const discovery of this.discoveries) this.renderCard(list, discovery);
+    }
+
+    /** Section 2 — notes related to the active note (merged resurface surface, #231 Phase 3). */
+    private renderRelated(container: HTMLElement): void {
+        container.createEl("h5", { text: t("resurface_view_title"), cls: c("discoveries-section-heading") });
+        if (!this.relatedActivePath) {
+            container.createDiv({ cls: c("discoveries-status"), text: t("resurface_no_active") });
+            return;
+        }
+        if (this.related.length === 0) {
+            container.createDiv({ cls: c("discoveries-status"), text: t("resurface_no_relations") });
+            return;
+        }
+        const list = container.createDiv({ cls: c("discoveries-list") });
+        for (const note of this.related) {
+            const card = list.createDiv({ cls: c("discoveries-card") });
+            const nameEl = card.createSpan({ text: note.basename, cls: c("discoveries-note") });
+            nameEl.setAttribute("title", note.path);
+            const actions = card.createDiv({ cls: c("discoveries-actions") });
+            const open = actions.createEl("button", { text: t("discoveries_open"), cls: c("discoveries-open") });
+            this.registerDomEvent(open, "click", () => void ObsidianApi.workspace().openLinkText(note.path, "", false));
+        }
     }
 
     private renderCard(list: HTMLElement, discovery: Discovery): void {
@@ -123,7 +197,7 @@ export class DiscoveriesView extends ItemView {
 
     private dismiss(discovery: Discovery): void {
         this.dismissed.add(this.key(discovery));
-        this.recompute();
+        this.refresh();
     }
 
     private async accept(discovery: Discovery): Promise<void> {
@@ -148,7 +222,7 @@ export class DiscoveriesView extends ItemView {
             new Notice(t("discoveries_accepted_notice"));
             // The model re-indexes asynchronously; dismiss for the session so it can't re-appear now.
             this.dismissed.add(this.key(discovery));
-            this.recompute();
+            this.refresh();
         } catch (error) {
             log.error(`[Discoveries] accept failed: ${error instanceof Error ? error.message : "unknown error"}`);
             new Notice(t("discoveries_accept_error_notice"));

--- a/src/architecture/components/core/resurface/ResurfaceView.ts
+++ b/src/architecture/components/core/resurface/ResurfaceView.ts
@@ -1,14 +1,14 @@
-import { CachedMetadata, ItemView, MarkdownView, TFile, WorkspaceLeaf, getAllTags } from "obsidian";
+import { ItemView, MarkdownView, WorkspaceLeaf } from "obsidian";
 import { c, log } from "architecture";
 import { t } from "architecture/lang";
 import {
-    ActiveNoteSignals,
     ResurfaceCandidate,
     ResurfaceReason,
     ResurfacedNote,
     pickDailySpark,
     rankResurfacedNotes,
 } from "application/notes/resurfaceRanking";
+import { buildResurfaceInputs } from "./resurfaceInputs";
 
 const THROTTLE_MS = 400;
 const SPARK_COUNT = 3;
@@ -82,9 +82,8 @@ export class ResurfaceView extends ItemView {
 
         try {
             const start = Date.now();
-            const resolved = this.app.metadataCache.resolvedLinks;
-            const backlinkIndex = this.buildBacklinkIndex(resolved);
-            this.candidates = this.buildCandidates(resolved, backlinkIndex);
+            const inputs = buildResurfaceInputs(this.app);
+            this.candidates = inputs.candidates;
 
             const activeFile = this.app.workspace.getActiveViewOfType(MarkdownView)?.file ?? null;
             this.activePath = activeFile ? activeFile.path : null;
@@ -95,7 +94,7 @@ export class ResurfaceView extends ItemView {
                 return;
             }
 
-            const active = this.buildActiveSignals(activeFile, resolved, backlinkIndex);
+            const active = inputs.buildActiveSignals(activeFile);
             this.ranked = rankResurfacedNotes({
                 active,
                 candidates: this.candidates,
@@ -121,56 +120,6 @@ export class ResurfaceView extends ItemView {
         this.sparkResults = pickDailySpark(this.candidates, Date.now(), SPARK_COUNT, exclude);
         this.state = "spark";
         this.render();
-    }
-
-    /** Build the signal bundle for the active note from the metadata cache. */
-    private buildActiveSignals(
-        file: TFile,
-        resolved: Record<string, Record<string, number>>,
-        backlinkIndex: Map<string, string[]>
-    ): ActiveNoteSignals {
-        return {
-            path: file.path,
-            tags: this.fileTags(this.app.metadataCache.getFileCache(file)),
-            outgoingLinks: Object.keys(resolved[file.path] ?? {}),
-            backlinks: backlinkIndex.get(file.path) ?? [],
-        };
-    }
-
-    /** Build ranking candidates for every markdown file (the active note is filtered by the ranker). */
-    private buildCandidates(
-        resolved: Record<string, Record<string, number>>,
-        backlinkIndex: Map<string, string[]>
-    ): ResurfaceCandidate[] {
-        const cache = this.app.metadataCache;
-        return this.app.vault.getMarkdownFiles().map((file) => ({
-            path: file.path,
-            basename: file.basename,
-            tags: this.fileTags(cache.getFileCache(file)),
-            outgoingLinks: Object.keys(resolved[file.path] ?? {}),
-            backlinks: backlinkIndex.get(file.path) ?? [],
-            lastOpenedOrModified: file.stat.mtime,
-        }));
-    }
-
-    /** Single-pass backlink index (target path → source paths) over the resolved-link graph. */
-    private buildBacklinkIndex(resolved: Record<string, Record<string, number>>): Map<string, string[]> {
-        const index = new Map<string, string[]>();
-        for (const source of Object.keys(resolved)) {
-            for (const target of Object.keys(resolved[source])) {
-                if (source === target) continue;
-                const sources = index.get(target);
-                if (sources) sources.push(source);
-                else index.set(target, [source]);
-            }
-        }
-        return index;
-    }
-
-    /** Tags for a file cache, with the leading `#` stripped so active/candidate sets align. */
-    private fileTags(cache: CachedMetadata | null): string[] {
-        if (!cache) return [];
-        return (getAllTags(cache) ?? []).map((tag) => (tag.startsWith("#") ? tag.slice(1) : tag));
     }
 
     render(): void {

--- a/src/architecture/components/core/resurface/resurfaceInputs.ts
+++ b/src/architecture/components/core/resurface/resurfaceInputs.ts
@@ -1,0 +1,60 @@
+import { App, CachedMetadata, TFile, getAllTags } from "obsidian";
+import { ActiveNoteSignals, ResurfaceCandidate } from "application/notes/resurfaceRanking";
+
+/**
+ * Impure gathering for connection resurfacing — turns Obsidian's metadata cache into the pure
+ * ranker's inputs. Extracted from {@link ResurfaceView} (#231 Phase 3) so both the standalone
+ * resurface view and the unified Discovery view feed the same `rankResurfacedNotes` without
+ * duplicating the candidate/backlink build. Reads only the cache; writes nothing.
+ */
+
+/** Tags for a file cache, with the leading `#` stripped so active/candidate sets align. */
+function fileTags(cache: CachedMetadata | null): string[] {
+    if (!cache) return [];
+    return (getAllTags(cache) ?? []).map((tag) => (tag.startsWith("#") ? tag.slice(1) : tag));
+}
+
+/** Single-pass backlink index (target path → source paths) over the resolved-link graph. */
+function buildBacklinkIndex(resolved: Record<string, Record<string, number>>): Map<string, string[]> {
+    const index = new Map<string, string[]>();
+    for (const source of Object.keys(resolved)) {
+        for (const target of Object.keys(resolved[source])) {
+            if (source === target) continue;
+            const sources = index.get(target);
+            if (sources) sources.push(source);
+            else index.set(target, [source]);
+        }
+    }
+    return index;
+}
+
+export interface ResurfaceInputs {
+    candidates: ResurfaceCandidate[];
+    /** Build the active-note signal bundle for a file, using the same resolved-link/backlink pass. */
+    buildActiveSignals: (file: TFile) => ActiveNoteSignals;
+}
+
+/** Build the ranking candidates (every markdown file) + an active-signals factory from the cache. */
+export function buildResurfaceInputs(app: App): ResurfaceInputs {
+    const resolved = app.metadataCache.resolvedLinks;
+    const backlinkIndex = buildBacklinkIndex(resolved);
+    const cache = app.metadataCache;
+
+    const candidates: ResurfaceCandidate[] = app.vault.getMarkdownFiles().map((file) => ({
+        path: file.path,
+        basename: file.basename,
+        tags: fileTags(cache.getFileCache(file)),
+        outgoingLinks: Object.keys(resolved[file.path] ?? {}),
+        backlinks: backlinkIndex.get(file.path) ?? [],
+        lastOpenedOrModified: file.stat.mtime,
+    }));
+
+    const buildActiveSignals = (file: TFile): ActiveNoteSignals => ({
+        path: file.path,
+        tags: fileTags(cache.getFileCache(file)),
+        outgoingLinks: Object.keys(resolved[file.path] ?? {}),
+        backlinks: backlinkIndex.get(file.path) ?? [],
+    });
+
+    return { candidates, buildActiveSignals };
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -681,6 +681,7 @@ export default {
     settings_toolkit_heatmap_name: 'Thinking heatmap',
     settings_toolkit_heatmap_desc: 'A calendar heatmap of ideas developed over the last year.',
     // Morning discovery (#163)
+    discovery_view_title: 'Discovery',
     discoveries_view_title: 'Discoveries',
     command_show_discoveries: 'Show discoveries',
     discoveries_computing: 'Looking for surprising connections…',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -681,6 +681,7 @@ export default {
     settings_toolkit_heatmap_name: 'Mapa de calor del pensamiento',
     settings_toolkit_heatmap_desc: 'Un mapa de calor de calendario de las ideas desarrolladas en el último año.',
     // Descubrimiento matinal (#163)
+    discovery_view_title: 'Descubrimiento',
     discoveries_view_title: 'Descubrimientos',
     command_show_discoveries: 'Mostrar descubrimientos',
     discoveries_computing: 'Buscando conexiones sorprendentes…',

--- a/src/starters/zcomponents/ZettelFlowMenuComponent.ts
+++ b/src/starters/zcomponents/ZettelFlowMenuComponent.ts
@@ -32,10 +32,9 @@ export class ZettelFlowMenuComponent extends PluginComponent {
             { command: "show-knowledge-dashboard", labelKey: "command_show_knowledge_dashboard", icon: "layout-dashboard" },
             { command: "show-slipbox-health", labelKey: "command_show_slipbox_health", icon: "activity" },
         ],
-        [
-            { command: "show-discoveries", labelKey: "command_show_discoveries", icon: "sparkles" },
-            { command: "resurface-related-notes", labelKey: "command_resurface", icon: "history" },
-        ],
+        // Discovery is now one unified view (#231 Phase 3): surprising connections + notes related to
+        // the active note. The standalone resurface command still works but is no longer a menu entry.
+        [{ command: "show-discoveries", labelKey: "discovery_view_title", icon: "telescope" }],
         [
             { command: "show-knowledge-map", labelKey: "command_show_knowledge_map", icon: "network" },
             { command: "show-concept-nav", labelKey: "command_show_concept_nav", icon: "waypoints" },


### PR DESCRIPTION
Closes #237 (#231 Phase 3 — the deep half).

Merges the two overlapping discovery surfaces into **one Discovery view** with two sections: *surprising connections* (vault-wide unlinked pairs) and *related to the active note* (resurface). Extracts the resurface input-gathering into `resurfaceInputs.ts` shared by both views (no duplication); the unified view reuses the pure `findDiscoveries` + `rankResurfacedNotes` rankers and recomputes the related section as the active note changes. The ribbon menu now shows a single **Discovery** entry.

Consolidate & hide: the standalone resurface command/view stays registered for back-compat. `npm run verify` green (847 tests, lint 0). View code — worth a quick live check of the Discovery pane's two sections.