### PR TITLE
feat(canvas): create managed steps in the canonical frontmatter format (#238)

### DIFF
--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -528,6 +528,11 @@ export default {
     // Remove a relation command (#181)
     command_remove_relation: 'Remove a relation',
     ribbon_open_zettelflow: 'Open ZettelFlow',
+    // Managed step creation — canonical frontmatter format vs legacy inline (#238)
+    managed_step_note_option: 'Note — file with frontmatter (recommended)',
+    managed_step_text_option: 'Text card (inline, legacy)',
+    managed_step_group_option: 'Group (inline, legacy)',
+    managed_step_note_error: 'Could not create the step file. Check the console for details.',
     remove_relation_modal_title: 'Pick a relation to remove…',
     remove_relation_none: 'This note has no typed relations to remove.',
     remove_relation_confirm_question: 'Remove the relation {0} → [[{1}]] from "{2}"?',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -528,6 +528,11 @@ export default {
     // Remove a relation command (#181)
     command_remove_relation: 'Eliminar una relación',
     ribbon_open_zettelflow: 'Abrir ZettelFlow',
+    // Creación de paso gestionado — formato canónico frontmatter vs inline heredado (#238)
+    managed_step_note_option: 'Nota — archivo con frontmatter (recomendado)',
+    managed_step_text_option: 'Tarjeta de texto (inline, heredado)',
+    managed_step_group_option: 'Grupo (inline, heredado)',
+    managed_step_note_error: 'No se pudo crear el archivo del paso. Revisa la consola para más detalles.',
     remove_relation_modal_title: 'Elige una relación para eliminar…',
     remove_relation_none: 'Esta nota no tiene relaciones tipadas que eliminar.',
     remove_relation_confirm_question: '¿Eliminar la relación {0} → [[{1}]] de "{2}"?',

--- a/src/architecture/plugin/canvas/extensions/AddManagedStepExtension.ts
+++ b/src/architecture/plugin/canvas/extensions/AddManagedStepExtension.ts
@@ -6,9 +6,13 @@ import { RibbonIcon } from "starters/zcomponents/RibbonIcon";
 import { OptionsModal, Option } from "architecture/components/settings";
 import { StepSettings } from "zettelkasten";
 import { Notice } from "obsidian";
+import { t } from "architecture/lang";
+import { ObsidianApi, log } from "architecture";
+import { FileService } from "architecture/plugin";
 
 const GROUP_NODE_SIZE = { width: 300, height: 300 };
 const TEXT_NODE_SIZE = { width: 300, height: 100 };
+const FILE_NODE_SIZE = { width: 400, height: 400 };
 
 /**
  * Extension that adds a managed step option to a ZettelFlow canvas.
@@ -153,14 +157,23 @@ export default class AddManagedStepExtension extends CanvasExtension {
      * @returns {Option[]} An array of options for creating either a Text or Group node.
      */
     private getCreationOptions(canvas: Canvas, pos: Position, step: StepSettings): Option[] {
-        // Helper function to save the step configuration in the node.
+        // Legacy inline config: stamp the step JSON onto the canvas node's own data (text/group nodes).
         const saveStepConfig = (node: CanvasNode): void => {
             node.unknownData.zettelflowConfig = JSON.stringify(step);
         };
 
         return [
             {
-                label: "Text",
+                // Canonical format (#238): a real `.md` step file carrying `zettelFlowSettings`
+                // frontmatter, referenced by a file node — the same format systems and export use, so
+                // it is hot-reloadable and shareable. Offered first.
+                label: t("managed_step_note_option"),
+                onSelect: async () => {
+                    await this.createFileStep(canvas, pos, step);
+                }
+            },
+            {
+                label: t("managed_step_text_option"),
                 onSelect: async () => {
                     const node = canvas.createTextNode({
                         pos,
@@ -171,7 +184,7 @@ export default class AddManagedStepExtension extends CanvasExtension {
                 }
             },
             {
-                label: "Group",
+                label: t("managed_step_group_option"),
                 onSelect: async () => {
                     const node = canvas.createGroupNode({
                         pos,
@@ -182,5 +195,30 @@ export default class AddManagedStepExtension extends CanvasExtension {
                 }
             }
         ];
+    }
+
+    /**
+     * Create a step in the canonical **frontmatter** format (#238): write a `.md` file whose
+     * `zettelFlowSettings` frontmatter is the step config, then place a file node pointing at it. This
+     * is the format systems and `.zftemplate` export/import use — hot-reloadable (#226) and shareable —
+     * unlike the legacy inline `zettelflowConfig` on a text/group node.
+     */
+    private async createFileStep(canvas: Canvas, pos: Position, step: StepSettings): Promise<void> {
+        try {
+            const folder = this.plugin.settings.foldersFlowsPath || "_ZettelFlow/folders";
+            const base = (step.label?.trim() || "Step").replace(/[\\/:*?"<>|]/g, " ").trim() || "Step";
+            let path = `${folder}/${base}.md`;
+            for (let n = 2; await FileService.getFile(path, false); n++) {
+                path = `${folder}/${base} ${n}.md`;
+            }
+            const file = await FileService.createFile(path, `# ${step.label || base}\n`, false);
+            await ObsidianApi.fileManager().processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+                frontmatter.zettelFlowSettings = step;
+            });
+            canvas.createFileNode({ pos, size: FILE_NODE_SIZE, file });
+        } catch (error) {
+            log.error("ZettelFlow: could not create a frontmatter step", error);
+            new Notice(t("managed_step_note_error"));
+        }
     }
 }


### PR DESCRIPTION
Closes #238 — the single-config-format migration (#231 Phase 5).

**What.** "Create managed step" now offers, as the **primary** option, a canonical **Note** step: a real `.md` file with `zettelFlowSettings` frontmatter, referenced by a **file node** — the exact format systems and `.zftemplate` export/import use. So a managed step is now hot-reloadable (#226) and shareable, instead of inline-only.

**Consolidate & hide.** The legacy inline **Text/Group** options (`zettelflowConfig` on the node) remain below it, clearly marked *legacy*; the flow loader (`Flows.get`) still reads inline config for existing canvases, so nothing breaks. The three option labels are now i18n-routed (were hardcoded English).

**How it works.** Writes `{folder}/{label}.md` (unique-named) under `foldersFlowsPath`, sets `zettelFlowSettings` via `processFrontMatter`, then `canvas.createFileNode({ pos, size, file })`. Guarded with a Notice on failure.

Canvas-API + file-write path — no unit test possible without a live canvas. **Worth a live check:** *Create managed step → Note* should drop a file-node step whose `.md` holds the config. `npm run verify` green (847 tests, lint 0).