### PR TITLE
feat(canvas): run any canvas as a flow + Run now after installing a system

### DIFF
--- a/src/application/community/CommunitySystemModal.tsx
+++ b/src/application/community/CommunitySystemModal.tsx
@@ -1,5 +1,5 @@
 import { Modal, Notice, Setting, requestUrl } from "obsidian";
-import { c, log } from "architecture";
+import { c, log, ObsidianApi } from "architecture";
 import { t } from "architecture/lang";
 import { FileService } from "architecture/plugin";
 import { FolderSuggest } from "architecture/settings";
@@ -29,7 +29,7 @@ export class CommunitySystemModal extends Modal {
   private disposed = false;
 
   constructor(
-    plugin: ZettelFlow,
+    private plugin: ZettelFlow,
     private template: ZfTemplate,
     private refUrl: string
   ) {
@@ -150,15 +150,31 @@ export class CommunitySystemModal extends Modal {
       for (const file of files) {
         await FileService.writeFile(file.path, file.content, false);
       }
-      new Notice(`${this.template.name} — ${t("community_system_installed")}`);
       this.close();
       if (files.length > 0) {
+        // Open the canvas and offer to run it immediately — so a system is usable the moment it lands,
+        // without wiring it into settings as the single ribbonCanvas (#231 / user feedback).
         await FileService.openFile(files[0].path);
       }
+      this.notifyInstalled();
     } catch (error) {
       log.error("Error installing community system:", error);
       new Notice(t("community_system_install_error"));
     }
+  }
+
+  /** Success notice with a "Run now" button that runs the just-opened canvas as a flow. */
+  private notifyInstalled(): void {
+    const notice = new Notice("", 0);
+    const message = notice.messageEl.createDiv();
+    message.createSpan({ text: `${this.template.name} — ${t("community_system_installed")}` });
+    message.createEl("br");
+    const run = message.createEl("button", { text: t("community_system_run_now") });
+    run.addClass("mod-cta");
+    run.addEventListener("click", () => {
+      ObsidianApi.executeCommandById(`${this.plugin.manifest.id}:run-canvas-flow`);
+      notice.hide();
+    });
   }
 
   onClose(): void {

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -528,6 +528,9 @@ export default {
     // Remove a relation command (#181)
     command_remove_relation: 'Remove a relation',
     ribbon_open_zettelflow: 'Open ZettelFlow',
+    command_run_canvas_flow: 'Run the current canvas as a flow',
+    run_canvas_flow_error: 'Could not run this canvas as a flow. Check the console for details.',
+    community_system_run_now: 'Run now',
     // Managed step creation — canonical frontmatter format vs legacy inline (#238)
     managed_step_note_option: 'Note — file with frontmatter (recommended)',
     managed_step_text_option: 'Text card (inline, legacy)',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -528,6 +528,9 @@ export default {
     // Remove a relation command (#181)
     command_remove_relation: 'Eliminar una relación',
     ribbon_open_zettelflow: 'Abrir ZettelFlow',
+    command_run_canvas_flow: 'Ejecutar el canvas actual como flujo',
+    run_canvas_flow_error: 'No se pudo ejecutar este canvas como flujo. Revisa la consola para más detalles.',
+    community_system_run_now: 'Ejecutar ahora',
     // Creación de paso gestionado — formato canónico frontmatter vs inline heredado (#238)
     managed_step_note_option: 'Nota — archivo con frontmatter (recomendado)',
     managed_step_text_option: 'Tarjeta de texto (inline, heredado)',

--- a/src/starters/zcomponents/RibbonIcon.ts
+++ b/src/starters/zcomponents/RibbonIcon.ts
@@ -3,7 +3,7 @@ import { log } from "architecture";
 import { t } from "architecture/lang";
 import { Flow, canvas } from "architecture/plugin/canvas";
 import ZettelFlow from "main";
-import { addIcon } from "obsidian";
+import { addIcon, Notice } from "obsidian";
 import { SelectorMenuModal } from "zettelkasten";
 
 export class RibbonIcon extends PluginComponent {
@@ -43,6 +43,18 @@ export class RibbonIcon extends PluginComponent {
                 void this.ribbonIconCallback();
             }
         });
+        // Run the ACTIVE canvas as a flow — the direct way to use any installed system without wiring
+        // it into settings as the single ribbonCanvas. Hidden unless a `.canvas` is the active file.
+        this.plugin.addCommand({
+            id: 'run-canvas-flow',
+            name: t('command_run_canvas_flow'),
+            checkCallback: (checking: boolean) => {
+                const file = this.plugin.app.workspace.getActiveFile();
+                if (file?.extension !== 'canvas') return false;
+                if (!checking) void this.runCanvasFlow(file.path);
+                return true;
+            }
+        });
         log.info('RibbonIcon loaded');
     }
     private ribbonIconCallback = async () => {
@@ -51,5 +63,16 @@ export class RibbonIcon extends PluginComponent {
             flow = await canvas.flows.update(this.plugin.settings.ribbonCanvas);
         }
         new SelectorMenuModal(this.plugin.app, this.plugin, flow).open();
+    }
+
+    /** Launch the note-creation wizard for a specific canvas path (used by the run-canvas-flow command). */
+    private runCanvasFlow = async (canvasPath: string) => {
+        try {
+            const flow = await canvas.flows.update(canvasPath);
+            new SelectorMenuModal(this.plugin.app, this.plugin, flow).open();
+        } catch (error) {
+            log.error('ZettelFlow: could not run the canvas as a flow', error);
+            new Notice(t('run_canvas_flow_error'));
+        }
     }
 }

--- a/src/starters/zcomponents/ZettelFlowMenuComponent.ts
+++ b/src/starters/zcomponents/ZettelFlowMenuComponent.ts
@@ -27,6 +27,7 @@ export class ZettelFlowMenuComponent extends PluginComponent {
 
     /** View entries grouped by job; a separator is drawn between groups. Home leads. */
     private static readonly GROUPS: ViewEntry[][] = [
+        [{ command: "run-canvas-flow", labelKey: "command_run_canvas_flow", icon: "play" }],
         [{ command: "show-home", labelKey: "command_show_home", icon: "home" }],
         [
             { command: "show-knowledge-dashboard", labelKey: "command_show_knowledge_dashboard", icon: "layout-dashboard" },


### PR DESCRIPTION
Fixes the core gap from user feedback: an installed system wrote files but couldn't be triggered (the ribbon only runs the single configured `ribbonCanvas`).

- **New command "Run the current canvas as a flow"** (hidden unless a `.canvas` is active) launches the wizard for whatever canvas you're viewing — no settings round-trip, no one-canvas limit. Added to the ZettelFlow ribbon menu.
- **"Run now" after install:** `CommunitySystemModal` opens the installed canvas and shows a Run-now button. Install → use.

i18n en/es. `npm run verify` green (847 tests, lint 0). Worth a live check: install a system → Run now → the wizard runs it.