### PR TITLE
feat(experience): guided first-run welcome + Browse systems command (#246 A1)

### DIFF
--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -508,6 +508,11 @@ export default {
     // Remove a relation command (#181)
     command_remove_relation: 'Remove a relation',
     ribbon_open_zettelflow: 'Open ZettelFlow',
+    command_browse_systems: 'Browse systems',
+    welcome_title: 'Welcome to ZettelFlow',
+    welcome_body: "ZettelFlow turns Obsidian's canvas into a note-creation workflow — and makes your knowledge evolve. The fastest way to start is to install a ready-made system (a canvas plus its steps) and run it: each note you create lands already related, cross-checked and scored.",
+    welcome_cta_browse: 'Browse systems to get started',
+    welcome_later: 'Maybe later',
     command_run_canvas_flow: 'Run the current canvas as a flow',
     run_canvas_flow_error: 'Could not run this canvas as a flow. Check the console for details.',
     community_system_run_now: 'Run now',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -508,6 +508,11 @@ export default {
     // Remove a relation command (#181)
     command_remove_relation: 'Eliminar una relación',
     ribbon_open_zettelflow: 'Abrir ZettelFlow',
+    command_browse_systems: 'Explorar sistemas',
+    welcome_title: 'Te damos la bienvenida a ZettelFlow',
+    welcome_body: 'ZettelFlow convierte el canvas de Obsidian en un flujo de creación de notas — y hace que tu conocimiento evolucione. La forma más rápida de empezar es instalar un sistema listo para usar (un canvas y sus pasos) y ejecutarlo: cada nota que creas nace ya relacionada, contrastada y puntuada.',
+    welcome_cta_browse: 'Explorar sistemas para empezar',
+    welcome_later: 'Quizá más tarde',
     command_run_canvas_flow: 'Ejecutar el canvas actual como flujo',
     run_canvas_flow_error: 'No se pudo ejecutar este canvas como flujo. Revisa la consola para más detalles.',
     community_system_run_now: 'Ejecutar ahora',

--- a/src/starters/zcomponents/OnboardingComponent.ts
+++ b/src/starters/zcomponents/OnboardingComponent.ts
@@ -1,8 +1,12 @@
 import { PluginComponent } from "architecture";
-import { t } from "architecture/lang";
 import ZettelFlow from "main";
-import { Notice } from "obsidian";
+import { WelcomeModal } from "./WelcomeModal";
 
+/**
+ * First-run onboarding (#246 A1). On the first launch after install, open the {@link WelcomeModal},
+ * which funnels the user into the Systems Gallery — the one adoption path — for an immediate first win.
+ * Shown once (guarded by `hasSeenWelcome`), after layout is ready so the workspace is interactive.
+ */
 export class OnboardingComponent extends PluginComponent {
     constructor(private plugin: ZettelFlow) {
         super(plugin);
@@ -13,21 +17,7 @@ export class OnboardingComponent extends PluginComponent {
         this.plugin.app.workspace.onLayoutReady(() => {
             this.plugin.settings.hasSeenWelcome = true;
             void this.plugin.saveSettings();
-
-            if (this.plugin.settings.ribbonCanvas) return;
-
-            const notice = new Notice("", 0);
-            const frag = notice.messageEl.createDiv();
-            frag.createSpan({ text: t("onboarding_notice_msg") });
-            frag.createEl("br");
-            const btn = frag.createEl("button", {
-                text: t("onboarding_notice_open_settings"),
-            });
-            btn.addEventListener("click", () => {
-                this.plugin.app.setting.open();
-                this.plugin.app.setting.openTabById("zettelflow");
-                notice.hide();
-            });
+            new WelcomeModal(this.plugin).open();
         });
     }
 }

--- a/src/starters/zcomponents/WelcomeModal.ts
+++ b/src/starters/zcomponents/WelcomeModal.ts
@@ -1,0 +1,41 @@
+import { Modal, Setting } from "obsidian";
+import { c } from "architecture";
+import { t } from "architecture/lang";
+import { CommunityTemplatesModal } from "application/community";
+import ZettelFlow from "main";
+
+/**
+ * First-run welcome (#246 A1). Instead of a bare notice, greet the user, say what ZettelFlow does in
+ * one breath, and funnel them straight to the **Systems Gallery** — the one adoption path — so the very
+ * first thing they do is install a system and run it (a first win), not read settings. `createEl`/`c()`
+ * only; no innerHTML/inline styles.
+ */
+export class WelcomeModal extends Modal {
+    constructor(private plugin: ZettelFlow) {
+        super(plugin.app);
+    }
+
+    onOpen(): void {
+        this.modalEl.addClass(c("modal"));
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.createEl("h2", { text: t("welcome_title") });
+        contentEl.createEl("p", { text: t("welcome_body") });
+
+        new Setting(contentEl)
+            .addButton((btn) =>
+                btn
+                    .setButtonText(t("welcome_cta_browse"))
+                    .setCta()
+                    .onClick(() => {
+                        this.close();
+                        new CommunityTemplatesModal(this.plugin).open();
+                    })
+            )
+            .addButton((btn) => btn.setButtonText(t("welcome_later")).onClick(() => this.close()));
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+}

--- a/src/starters/zcomponents/ZettelFlowMenuComponent.ts
+++ b/src/starters/zcomponents/ZettelFlowMenuComponent.ts
@@ -1,6 +1,7 @@
 import { Menu } from "obsidian";
 import { PluginComponent, ObsidianApi } from "architecture";
 import { t } from "architecture/lang";
+import { CommunityTemplatesModal } from "application/community";
 import ZettelFlow from "main";
 
 type LocaleKey = Parameters<typeof t>[0];
@@ -27,7 +28,10 @@ export class ZettelFlowMenuComponent extends PluginComponent {
 
     /** View entries grouped by job; a separator is drawn between groups. Home leads. */
     private static readonly GROUPS: ViewEntry[][] = [
-        [{ command: "run-canvas-flow", labelKey: "command_run_canvas_flow", icon: "play" }],
+        [
+            { command: "browse-systems", labelKey: "command_browse_systems", icon: "layout-grid" },
+            { command: "run-canvas-flow", labelKey: "command_run_canvas_flow", icon: "play" },
+        ],
         [{ command: "show-home", labelKey: "command_show_home", icon: "home" }],
         [
             { command: "show-knowledge-dashboard", labelKey: "command_show_knowledge_dashboard", icon: "layout-dashboard" },
@@ -50,6 +54,13 @@ export class ZettelFlowMenuComponent extends PluginComponent {
     ];
 
     onLoad(): void {
+        // The community systems browser had no command of its own (only reachable via settings) — a
+        // discoverability gap. This makes it a first-class, funnel-able entry point (#246 A1).
+        this.plugin.addCommand({
+            id: "browse-systems",
+            name: t("command_browse_systems"),
+            callback: () => new CommunityTemplatesModal(this.plugin).open(),
+        });
         this.plugin.addRibbonIcon("brain-circuit", t("ribbon_open_zettelflow"), (evt: MouseEvent) => {
             const menu = new Menu();
             const prefix = `${this.plugin.manifest.id}:`;


### PR DESCRIPTION
First phase of the organizational-reference epic #246 (Thrust A — the effortless first hour).

- **New `Browse systems` command** opens the community Systems Gallery directly — it previously had no command (only via settings). Added to the ZettelFlow ribbon menu.
- **First-run WelcomeModal** greets the user, says what ZettelFlow does in one breath, and funnels straight to the Systems Gallery (install a system → Run now) for an immediate first win — instead of pointing at settings. Once-only, after layout ready.

Easy to use: install → run, no manual. `npm run verify` green (816 tests, lint 0). Worth a live check: fresh install → welcome modal → Browse systems.