### PR TITLE
feat(experience): Home as the daily front door (#246 A2)

### DIFF
--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -370,6 +370,8 @@ export default {
     // Create in current folder
     create_in_current_folder_toggle_title: 'Create note in current folder',
     create_in_current_folder_toggle_description: 'When enabled, notes are always created in the folder of the currently active file, ignoring each step\'s configured target folder.',
+    open_home_on_startup_toggle_title: 'Open ZettelFlow Home on startup',
+    open_home_on_startup_toggle_description: 'Greet you with the ZettelFlow Home view when Obsidian launches — your daily front door. On for new installs; turn it off to keep your usual startup layout.',
 
     // Onboarding
     onboarding_welcome_title: 'Welcome to ZettelFlow',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -370,6 +370,8 @@ export default {
     // Crear en carpeta actual
     create_in_current_folder_toggle_title: 'Crear nota en la carpeta actual',
     create_in_current_folder_toggle_description: 'Cuando está activo, las notas siempre se crean en la carpeta del archivo activo, ignorando la carpeta destino configurada en cada paso.',
+    open_home_on_startup_toggle_title: 'Abrir ZettelFlow Home al iniciar',
+    open_home_on_startup_toggle_description: 'Te recibe con la vista ZettelFlow Home cuando se abre Obsidian — tu puerta de entrada diaria. Activo en instalaciones nuevas; desactívalo para mantener tu disposición de inicio habitual.',
 
     // Incorporación
     onboarding_welcome_title: 'Bienvenido a ZettelFlow',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -161,6 +161,11 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                         control: { type: "toggle", key: "createInCurrentFolder" },
                     },
                     {
+                        name: t("open_home_on_startup_toggle_title"),
+                        desc: t("open_home_on_startup_toggle_description"),
+                        control: { type: "toggle", key: "openHomeOnStartup" },
+                    },
+                    {
                         name: t("unique_prefix_toggle_title"),
                         desc: t("unique_prefix_toggle_description"),
                         control: { type: "toggle", key: "uniquePrefixEnabled" },

--- a/src/config/typing.ts
+++ b/src/config/typing.ts
@@ -122,6 +122,8 @@ export interface ZettelFlowSettings {
     hasSeenWelcome: boolean;
     /** When true, new notes are created in the active file's folder instead of the step's targetFolder. */
     createInCurrentFolder: boolean;
+    /** When true, ZettelFlow Home opens automatically on launch (the "open ZettelFlow, not Obsidian" front door, #246 A2). */
+    openHomeOnStartup: boolean;
 }
 
 export type { HistoryEntry } from "application/notes/historyUtils";
@@ -221,4 +223,5 @@ export const DEFAULT_SETTINGS: Partial<ZettelFlowSettings> = {
     history: [],
     hasSeenWelcome: false,
     createInCurrentFolder: false,
+    openHomeOnStartup: false, // Off by default; first-run onboarding turns it on for new users (#246 A2).
 };

--- a/src/starters/zcomponents/HomeComponent.ts
+++ b/src/starters/zcomponents/HomeComponent.ts
@@ -19,5 +19,12 @@ export class HomeComponent extends PluginComponent {
             name: t("command_show_home"),
             callback: () => void activateSidebarView(this.plugin.app, ZettelFlowHomeView.NAME),
         });
+        // "Open ZettelFlow, not Obsidian" (#246 A2): greet the user with Home on launch when enabled,
+        // unless a Home leaf is already restored open. Opt-in; first-run turns it on for new users.
+        this.plugin.app.workspace.onLayoutReady(() => {
+            if (!this.plugin.settings.openHomeOnStartup) return;
+            if (this.plugin.app.workspace.getLeavesOfType(ZettelFlowHomeView.NAME).length > 0) return;
+            void activateSidebarView(this.plugin.app, ZettelFlowHomeView.NAME);
+        });
     }
 }

--- a/src/starters/zcomponents/OnboardingComponent.ts
+++ b/src/starters/zcomponents/OnboardingComponent.ts
@@ -16,6 +16,8 @@ export class OnboardingComponent extends PluginComponent {
         if (this.plugin.settings.hasSeenWelcome) return;
         this.plugin.app.workspace.onLayoutReady(() => {
             this.plugin.settings.hasSeenWelcome = true;
+            // New users get Home as the daily front door on subsequent launches (#246 A2); overridable.
+            this.plugin.settings.openHomeOnStartup = true;
             void this.plugin.saveSettings();
             new WelcomeModal(this.plugin).open();
         });


### PR DESCRIPTION
Thrust A / A2 of epic #246. Adds `openHomeOnStartup` (General settings toggle): greets the user with **ZettelFlow Home** on launch — *open ZettelFlow, not Obsidian* — unless a Home leaf is already open. Off by default (existing setups unchanged); first-run onboarding enables it for new installs. i18n en/es. `npm run verify` green.