### PR TITLE
feat(engine): guided-help core for trigger conditions (#246 B1)

### DIFF
--- a/docs/architecture/trigger-conditions.md
+++ b/docs/architecture/trigger-conditions.md
@@ -1,0 +1,39 @@
+# Trigger conditions
+
+A [visual workflow](conditional-edges.md) / [event-driven](event-driven-workflows.md) step can carry a
+**condition** — the *IF* of *WHEN an event happens, IF a condition holds, run an ACTION*. A condition is
+a small `zf` script evaluated against the event; **leave it blank to mean "always."** A condition that
+throws or is invalid is caught and the trigger is safely skipped — it can never break your vault.
+
+This page is the reference the in-app help draws from (epic #246, B1). The pure vocabulary, examples and
+sanity check live in `src/architecture/plugin/events/conditionHelp.ts`.
+
+## What you can reference
+
+The event being tested is available as `event`:
+
+| Field | Holds |
+|---|---|
+| `event.event` | the event token, e.g. `property.changed`, `tag.added`, `note.created` |
+| `event.notePath` | the vault-relative path of the affected note |
+| `event.property` | the frontmatter property that changed (`property.changed` only) |
+| `event.tag` | the tag that was added (`tag.added` only) |
+| `event.oldValue` / `event.newValue` | the property's before/after values (`property.changed` only) |
+
+## Examples
+
+```js
+// Always — leave the condition blank.
+
+event.tag === 'idea'                                   // only when a note is tagged #idea
+event.property === 'status' && event.newValue === 'done'   // when a property becomes "done"
+event.notePath.startsWith('Projects/')                 // only inside the Projects folder
+!event.oldValue && !!event.newValue                    // when a property first gets a value
+```
+
+## Two mistakes the sanity check catches
+
+- **Unbalanced brackets** — a missing `)` / `]` / `}`.
+- **A single `=`** where you meant `===` — `event.property = 'status'` *assigns*; use `event.property === 'status'` to *compare*.
+
+Everything is offline and deterministic; a condition only reads the event payload.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - 6.5 Community & backend: architecture/community-and-backend.md
       - 6.6 .zftemplate schema: architecture/zftemplate-schema.md
       - 6.7 Conditional edges: architecture/conditional-edges.md
+      - 6.7.1 Trigger conditions: architecture/trigger-conditions.md
       - 6.8 Knowledge model: architecture/knowledge-model.md
       - 6.9 Knowledge lifecycle: architecture/knowledge-lifecycle.md
       - 6.10 Workflow phases: architecture/workflow-phases.md

--- a/src/architecture/plugin/events/conditionHelp.ts
+++ b/src/architecture/plugin/events/conditionHelp.ts
@@ -1,0 +1,71 @@
+/**
+ * Authoring help for workflow-trigger **conditions** (#150/#151, epic #246 B1). A condition is a small
+ * `zf` script evaluated against the event payload (see {@link evaluateBindingCondition}); a blank one
+ * means "always". Writing one is the sharpest authoring-friction point, so this pure, Obsidian-free
+ * module gives a builder UI (and the docs) the referenceable vocabulary, worked examples, and a
+ * lightweight sanity check — the guided-help core, independent of any rendering.
+ */
+
+/** A field the condition script can reference on the injected event context. */
+export interface ConditionField {
+    /** The dotted accessor to type, e.g. `event.newValue`. */
+    accessor: string;
+    /** One-line plain description of what it holds and when it is populated. */
+    note: string;
+}
+
+/** The event-payload fields a condition can inspect (mirrors `WorkflowEventPayload`). */
+export const CONDITION_FIELDS: readonly ConditionField[] = [
+    { accessor: "event.event", note: "the event token, e.g. 'property.changed' or 'tag.added'" },
+    { accessor: "event.notePath", note: "vault-relative path of the affected note" },
+    { accessor: "event.property", note: "the frontmatter property that changed (property.changed only)" },
+    { accessor: "event.tag", note: "the tag that was added (tag.added only)" },
+    { accessor: "event.oldValue", note: "the property's previous value (property.changed only)" },
+    { accessor: "event.newValue", note: "the property's new value (property.changed only)" },
+];
+
+/** A ready-to-use example condition, for a "insert an example" affordance. */
+export interface ConditionExample {
+    label: string;
+    condition: string;
+}
+
+export const CONDITION_EXAMPLES: readonly ConditionExample[] = [
+    { label: "Always (leave blank)", condition: "" },
+    { label: "Only when a note is tagged #idea", condition: "event.tag === 'idea'" },
+    { label: "When a property becomes done", condition: "event.property === 'status' && event.newValue === 'done'" },
+    { label: "Only inside the Projects folder", condition: "event.notePath.startsWith('Projects/')" },
+    { label: "When a property first gets a value", condition: "!event.oldValue && !!event.newValue" },
+];
+
+export interface ConditionCheck {
+    ok: boolean;
+    /** Present when `ok` is false: a short, human reason. */
+    error?: string;
+}
+
+/**
+ * A lightweight, dependency-free sanity check for a condition string (not a full JS parse). Catches the
+ * two mistakes that actually bite: unbalanced brackets, and a bare `=` where `===` was meant. A blank
+ * condition is valid ("always"). Deterministic and Obsidian-free.
+ */
+export function sanityCheckCondition(expr: string): ConditionCheck {
+    const source = expr.trim();
+    if (source === "") return { ok: true };
+
+    const opposite: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+    const stack: string[] = [];
+    for (const char of source) {
+        if (char === "(" || char === "[" || char === "{") stack.push(char);
+        else if (char in opposite && stack.pop() !== opposite[char]) {
+            return { ok: false, error: "unbalanced brackets" };
+        }
+    }
+    if (stack.length > 0) return { ok: false, error: "unbalanced brackets" };
+
+    // A single `=` that isn't part of ==, ===, !=, <=, >= is almost always a mistaken assignment.
+    if (/[^=!<>]=[^=]/.test(source)) {
+        return { ok: false, error: "use === for comparison, not a single =" };
+    }
+    return { ok: true };
+}

--- a/test/architecture/plugin/events/conditionHelp.test.ts
+++ b/test/architecture/plugin/events/conditionHelp.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    CONDITION_FIELDS,
+    CONDITION_EXAMPLES,
+    sanityCheckCondition,
+} from "architecture/plugin/events/conditionHelp";
+
+describe("conditionHelp vocabulary (#246 B1)", () => {
+    it("exposes the event-payload fields with accessors and notes", () => {
+        expect(CONDITION_FIELDS.length).toBeGreaterThanOrEqual(5);
+        for (const field of CONDITION_FIELDS) {
+            expect(field.accessor.startsWith("event.")).toBe(true);
+            expect(field.note.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("ships ready-to-use examples, including the blank 'always' one", () => {
+        expect(CONDITION_EXAMPLES.some((e) => e.condition === "")).toBe(true);
+        expect(CONDITION_EXAMPLES.some((e) => e.condition.includes("==="))).toBe(true);
+    });
+});
+
+describe("sanityCheckCondition (#246 B1)", () => {
+    it("accepts a blank condition (always)", () => {
+        expect(sanityCheckCondition("")).toEqual({ ok: true });
+        expect(sanityCheckCondition("   ")).toEqual({ ok: true });
+    });
+
+    it("accepts valid comparisons", () => {
+        expect(sanityCheckCondition("event.tag === 'idea'").ok).toBe(true);
+        expect(sanityCheckCondition("event.property === 'status' && event.newValue === 'done'").ok).toBe(true);
+        expect(sanityCheckCondition("event.notePath.startsWith('Projects/')").ok).toBe(true);
+        expect(sanityCheckCondition("!event.oldValue && !!event.newValue").ok).toBe(true);
+    });
+
+    it("flags unbalanced brackets", () => {
+        expect(sanityCheckCondition("event.notePath.startsWith('Projects/'").ok).toBe(false);
+        expect(sanityCheckCondition("(event.tag === 'idea'").error).toBe("unbalanced brackets");
+    });
+
+    it("flags a mistaken single = (assignment instead of comparison)", () => {
+        const check = sanityCheckCondition("event.property = 'status'");
+        expect(check.ok).toBe(false);
+        expect(check.error).toContain("===");
+    });
+});


### PR DESCRIPTION
Thrust B / B1 of epic #246 (relates #235). Trigger conditions (the IF of WHEN/IF/ACTION/WAIT) are a `zf` script over the event payload — the sharpest authoring-friction point. Adds a **pure, Obsidian-free `conditionHelp` module**: the field vocabulary (`event.*`), worked examples, and a lightweight sanity check (unbalanced brackets, mistaken single `=`) that a builder UI and the docs both draw from. Unit-tested (6); new `trigger-conditions` docs page. The in-editor builder consuming this is the remaining slice of #235. `npm run verify` green (822 tests, lint 0).