### PR TITLE
feat(experience): in-app system authoring loop, made discoverable (#246 B2)

### DIFF
--- a/docs/how-to-contribute/systems-gallery.md
+++ b/docs/how-to-contribute/systems-gallery.md
@@ -63,3 +63,7 @@ A system is a single `.zftemplate` JSON bundle: a `canvas` (a real `.canvas`) pl
 6. **Validate.** `npm test` runs the validity harness (`shippedSystems.test.ts` + `catalog.test.ts`):
    every shipped system must parse, reference only registered non-AI actions, use YAML-safe frontmatter,
    and resolve its canvas file-nodes to real steps.
+7. **Publish.** The fastest in-app route: build the workflow on a canvas, run **ZettelFlow → Export
+   current canvas as .zftemplate** (also in the *Open ZettelFlow* ribbon menu), then submit it through
+   the community browser's **Add template** link. That closes the loop — your system in the gallery for
+   everyone.

--- a/src/starters/zcomponents/ZettelFlowMenuComponent.ts
+++ b/src/starters/zcomponents/ZettelFlowMenuComponent.ts
@@ -31,6 +31,9 @@ export class ZettelFlowMenuComponent extends PluginComponent {
         [
             { command: "browse-systems", labelKey: "command_browse_systems", icon: "layout-grid" },
             { command: "run-canvas-flow", labelKey: "command_run_canvas_flow", icon: "play" },
+            // Close the creator loop (#246 B2): turn the current canvas into a shareable .zftemplate
+            // system, ready to contribute via the community browser's "Add template" link. Desktop only.
+            { command: "export-canvas-template", labelKey: "command_export_canvas_template", icon: "package-plus" },
         ],
         [{ command: "show-home", labelKey: "command_show_home", icon: "home" }],
         [


### PR DESCRIPTION
Thrust B / B2 of epic #246. The `.zftemplate` export and the community 'Add template' contribution path already exist — the gap was discoverability. Adds **Export current canvas as .zftemplate** to the *Open ZettelFlow* ribbon menu and documents the publish step, closing the creator loop: build a canvas → export as a system → contribute to the gallery. `npm run verify` green.