### PR TITLE
perf(discovery): memoize the whole-vault resurface build (#246 C1)

### DIFF
--- a/src/architecture/components/core/resurface/resurfaceInputs.ts
+++ b/src/architecture/components/core/resurface/resurfaceInputs.ts
@@ -34,8 +34,34 @@ export interface ResurfaceInputs {
     buildActiveSignals: (file: TFile) => ActiveNoteSignals;
 }
 
+/**
+ * Cache the whole-vault build (#246 C1): candidates + backlink index depend on the vault, NOT the
+ * active note, yet the views recompute on every active-note change. Rebuilding O(files) each time is
+ * heavy on large vaults, so memoize briefly — reused within `CACHE_TTL_MS` unless the markdown-file
+ * count changed (a cheap add/remove signal). Suggestions tolerate a few seconds of link/content
+ * staleness; a real add/remove invalidates immediately.
+ */
+const CACHE_TTL_MS = 4000;
+let cache: { inputs: ResurfaceInputs; at: number; fileCount: number } | null = null;
+
+/** Test-only: drop the memo so unit tests don't leak state across cases. */
+export function clearResurfaceInputsCache(): void {
+    cache = null;
+}
+
 /** Build the ranking candidates (every markdown file) + an active-signals factory from the cache. */
 export function buildResurfaceInputs(app: App): ResurfaceInputs {
+    const fileCount = app.vault.getMarkdownFiles().length;
+    const now = Date.now();
+    if (cache && now - cache.at < CACHE_TTL_MS && cache.fileCount === fileCount) {
+        return cache.inputs;
+    }
+    const inputs = buildResurfaceInputsUncached(app);
+    cache = { inputs, at: now, fileCount };
+    return inputs;
+}
+
+function buildResurfaceInputsUncached(app: App): ResurfaceInputs {
     const resolved = app.metadataCache.resolvedLinks;
     const backlinkIndex = buildBacklinkIndex(resolved);
     const cache = app.metadataCache;

--- a/test/architecture/components/core/resurface/resurfaceInputs.test.ts
+++ b/test/architecture/components/core/resurface/resurfaceInputs.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import type { App } from "obsidian";
+import {
+    buildResurfaceInputs,
+    clearResurfaceInputsCache,
+} from "architecture/components/core/resurface/resurfaceInputs";
+
+/** Minimal App mock; counts getFileCache calls so we can prove the whole-vault build is memoized. */
+function mockApp(paths: string[]): { app: App; cacheReads: () => number } {
+    let cacheReads = 0;
+    const files = paths.map((path) => ({ path, basename: path.replace(/\.md$/, ""), stat: { mtime: 0 } }));
+    const app = {
+        vault: { getMarkdownFiles: () => files },
+        metadataCache: {
+            resolvedLinks: {},
+            getFileCache: () => {
+                cacheReads++;
+                return null;
+            },
+        },
+    } as unknown as App;
+    return { app, cacheReads: () => cacheReads };
+}
+
+describe("buildResurfaceInputs caching (#246 C1)", () => {
+    beforeEach(() => clearResurfaceInputsCache());
+
+    it("builds candidates for every markdown file on a cold call", () => {
+        const { app, cacheReads } = mockApp(["a.md", "b.md", "c.md"]);
+        const inputs = buildResurfaceInputs(app);
+        expect(inputs.candidates).toHaveLength(3);
+        expect(cacheReads()).toBe(3); // one metadata read per file
+    });
+
+    it("reuses the memoized build on a second call within the TTL (no rebuild)", () => {
+        const { app, cacheReads } = mockApp(["a.md", "b.md"]);
+        const first = buildResurfaceInputs(app);
+        const second = buildResurfaceInputs(app);
+        expect(second.candidates).toBe(first.candidates); // same reference = cache hit
+        expect(cacheReads()).toBe(2); // NOT rebuilt on the second call
+    });
+
+    it("rebuilds when the markdown-file count changes (add/remove)", () => {
+        const { app, cacheReads } = mockApp(["a.md"]);
+        buildResurfaceInputs(app);
+        const grown = mockApp(["a.md", "b.md"]);
+        const inputs = buildResurfaceInputs(grown.app);
+        expect(inputs.candidates).toHaveLength(2);
+        // The first build read 1 file; a different file count forces a fresh build on the new app.
+        expect(cacheReads()).toBe(1);
+        expect(grown.cacheReads()).toBe(2);
+    });
+});


### PR DESCRIPTION
Thrust C / C1 of epic #246 — performance at scale. The Discovery/Resurface views rebuilt candidates + a backlink index over **every** markdown file on each active-note change (O(files) per change) — heavy on 10k+ vaults, even though those inputs depend on the vault, not the active note. Memoize the build for a short TTL (invalidated when the markdown-file count changes), so an active-note burst re-ranks against cached candidates. Unit-tested. `npm run verify` green (825 tests, lint 0).