### PR TITLE
feat(ux): action selector redesign — category tabs, compact chips, smart suggest (#256)

### DIFF
--- a/docs/architecture/workflow-phases.md
+++ b/docs/architecture/workflow-phases.md
@@ -65,3 +65,36 @@ primary phase each:
 
 Grouping **actions** by cognitive category (Manipulation / Relations / Knowledge / Research / AI) is
 a separate concern — see #152. In #149, an action→phase mapping is guidance only, not code.
+
+## Action selector — redesigned UI (#256)
+
+When configuring a step you add actions via the **"+" button** at the bottom of the step builder.
+The selector panel has three layered components:
+
+### Category tabs
+
+A horizontal strip of five tabs in canonical order — 📝 Manipulation, 🔗 Relations, 🧠 Knowledge,
+🔍 Research, 🤖 AI — sits at the top of the panel. The default active tab is **Manipulation**.
+Clicking a tab filters the chip grid to show only that category's actions. Arrow-key navigation
+moves focus between tabs; Enter/Space activates.
+
+Entering a search term disables tab filtering: all matching actions from every category are shown
+in a flat list and the tab strip fades to indicate search mode. Clearing the field restores the
+previously active tab.
+
+### Compact action chips
+
+Each action is displayed as a compact chip (icon + label, ≤ 80 px tall) arranged in a 4-column
+grid on panels ≥ 500 px wide and a 2-column grid on narrower panels. Hovering a chip (or tapping
+on mobile) reveals a tooltip with the action's full description and, when available, a link to
+its documentation page. Clicking the chip adds the action to the step and closes the selector.
+
+Template actions (installed from the community browser) are visually differentiated with a dashed
+border.
+
+### Smart suggest row (#256 FR-14–FR-17)
+
+When the step already has one or more actions added, a **"Suggested for this step"** row appears
+above the tab strip. It shows up to three complementary action chips derived from a static
+affinity map (for example, adding a *Prompt* action surfaces *Create semantic relation*). The row
+is absent when there are no existing actions or when the affinity map yields no new suggestions.

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -587,6 +587,9 @@ export default {
     action_category_research_label: 'Research',
     action_category_ai_label: 'AI',
     action_category_uncategorized_label: 'Other',
+    // Action selector redesign (#256)
+    action_suggest_row_label: 'Suggested for this step',
+    action_card_docs_link_label: 'Open documentation',
     // Knowledge actions (#153)
     knowledge_action_orphan_label: 'Detect orphan',
     knowledge_action_orphan_desc: 'Flag whether the note has no incoming or outgoing links (an orphan).',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -587,6 +587,9 @@ export default {
     action_category_research_label: 'Investigación',
     action_category_ai_label: 'IA',
     action_category_uncategorized_label: 'Otros',
+    // Action selector redesign (#256)
+    action_suggest_row_label: 'Sugerido para este paso',
+    action_card_docs_link_label: 'Abrir documentación',
     // Knowledge actions (#153)
     knowledge_action_orphan_label: 'Detectar huérfana',
     knowledge_action_orphan_desc: 'Marca si la nota no tiene enlaces entrantes ni salientes (una huérfana).',

--- a/src/styles/components/actionAddMenu.scss
+++ b/src/styles/components/actionAddMenu.scss
@@ -1,3 +1,4 @@
+/* ── Add button ── */
 .zettelkasten-flow__actions-management-add {
     position: relative;
     display: flex;
@@ -12,7 +13,7 @@
 .zettelkasten-flow__actions-management-add-button {
     color: var(--text-normal);
     width: 35px;
-    height: 35;
+    height: 35px;
     border: none;
     border-radius: 50%;
     display: flex;
@@ -33,16 +34,18 @@
     transform: rotate(45deg);
 }
 
+/* ── Selector panel — hidden / shown states ── */
 .zettelkasten-flow__actions-management-add-menu,
 .zettelkasten-flow__actions-management-add-menu-show {
     background-color: var(--background-secondary);
-    padding: 15px;
+    padding: 12px;
     border-radius: 5px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
     min-width: 100%;
     margin-top: 20px;
     display: flex;
     flex-direction: column;
+    gap: 8px;
     transition: opacity 0.3s, max-height 0.3s;
 }
 
@@ -55,83 +58,185 @@
 
 .zettelkasten-flow__actions-management-add-menu-show {
     opacity: 1;
-    max-height: 70vh;
+    max-height: 340px;
     overflow-y: auto;
 }
 
+/* ── Search input ── */
 .zettelkasten-flow__actions-management-add-menu-search {
     width: 100%;
-    padding: 10px;
+    padding: 6px 10px;
     border-radius: 5px;
     border: 1px solid var(--background-modifier-border);
-    margin-bottom: 10px;
-    font-size: 16px;
+    font-size: 14px;
 }
 
-.zettelkasten-flow__actions-management-add-card-custom {
-    background-color: var(--background-modifier-active);
-}
-
-.zettelkasten-flow__actions-management-add-card {
-    background-color: var(--background-secondary);
-    padding: 10px;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-    transition: box-shadow 0.3s;
+/* ── Category tab strip ── */
+.zettelkasten-flow__action-tab-strip {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    gap: 4px;
+    scrollbar-width: none;
+    transition: opacity 0.2s;
+}
+
+.zettelkasten-flow__action-tab-strip::-webkit-scrollbar {
+    display: none;
+}
+
+.zettelkasten-flow__action-tab-strip--search-mode {
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.zettelkasten-flow__action-tab {
+    display: flex;
     align-items: center;
-    margin-bottom: 10px;
-    flex: 1;
-    border: 1px solid var(--background-modifier-border);
-    padding: 1rem;
-    margin-bottom: 1rem;
+    gap: 4px;
+    white-space: nowrap;
+    padding: 4px 10px;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 4px 4px 0 0;
+    background: none;
     cursor: pointer;
-}
-
-.zettelkasten-flow__actions-management-add-card:hover {
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-}
-
-.zettelkasten-flow__actions-management-add-card-icon {
-    margin-bottom: 10px;
-}
-
-.zettelkasten-flow__actions-management-add-card-header {
-    width: 100%;
-    text-align: center;
-}
-
-.zettelkasten-flow__actions-management-add-card-header label {
-    font-weight: bold;
-    font-size: 18px;
-}
-
-.zettelkasten-flow__actions-management-add-card-link {
-    text-decoration: none;
-    color: var(--text-accent);
-    font-size: 14px;
-    margin-top: 5px;
-    display: inline-block;
-}
-
-.zettelkasten-flow__actions-management-add-card-body {
-    font-size: 14px;
+    font-size: 13px;
     color: var(--text-muted);
-    text-align: center;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.zettelkasten-flow__action-tab:hover {
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__action-tab--active {
+    color: var(--text-normal);
+    border-bottom-color: var(--color-accent);
+    font-weight: 600;
+}
+
+/* ── Chip grid ── */
+.zettelkasten-flow__actions-chip-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+    overflow: visible;
+}
+
+/* ── Individual chip ── */
+.zettelkasten-flow__action-chip {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: 44px;
+    max-height: 80px;
+    padding: 0 8px;
+    border-radius: 4px;
+    border: 1px solid var(--background-modifier-border);
+    background-color: var(--background-primary);
+    cursor: pointer;
+    font-size: 12px;
+    overflow: visible;
+    transition: background-color 0.15s, box-shadow 0.15s;
+}
+
+.zettelkasten-flow__action-chip:hover {
+    background-color: var(--background-modifier-hover);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.zettelkasten-flow__action-chip-label {
     overflow: hidden;
     text-overflow: ellipsis;
-    max-height: 3em;
-    line-height: 1.5em;
+    white-space: nowrap;
+    flex: 1;
 }
 
+/* Template chip visual differentiation */
+.zettelkasten-flow__actions-management-add-card-custom.zettelkasten-flow__action-chip {
+    background-color: var(--background-modifier-active);
+    border-style: dashed;
+}
+
+/* ── Tooltip ── */
+.zettelkasten-flow__action-chip-tooltip {
+    display: none;
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 0;
+    z-index: 100;
+    min-width: 200px;
+    max-width: 280px;
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 6px;
+    padding: 10px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    pointer-events: none;
+}
+
+.zettelkasten-flow__action-chip:hover .zettelkasten-flow__action-chip-tooltip {
+    display: block;
+}
+
+.zettelkasten-flow__action-chip-tooltip--open {
+    display: block;
+    pointer-events: auto;
+}
+
+.zettelkasten-flow__action-chip-tooltip-purpose {
+    font-size: 12px;
+    color: var(--text-normal);
+    margin: 0 0 6px 0;
+    line-height: 1.5;
+}
+
+.zettelkasten-flow__action-chip-tooltip-link {
+    display: inline-block;
+    font-size: 12px;
+    color: var(--text-accent);
+    text-decoration: none;
+    pointer-events: auto;
+}
+
+.zettelkasten-flow__action-chip-tooltip-link:hover {
+    text-decoration: underline;
+}
+
+/* ── Smart suggest row ── */
+.zettelkasten-flow__action-suggest-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.zettelkasten-flow__action-suggest-row-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+/* ── Responsive: narrow panels ── */
+@media (max-width: 500px) {
+    .zettelkasten-flow__actions-chip-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+/* ── Legacy card styles (kept for backwards compat, not rendered by ActionChip) ── */
 .zettelkasten-flow__actions-list {
     display: flex;
     flex-direction: column;
     gap: 14px;
 }
 
-/* Each cognitive-capability group: a header row + its cards wrapping in three columns (#152). */
 .zettelkasten-flow__actions-category-group {
     display: flex;
     flex-wrap: wrap;
@@ -151,27 +256,4 @@
 
 .zettelkasten-flow__actions-category-emoji {
     line-height: 1;
-}
-
-.zettelkasten-flow__actions-category-group>.zettelkasten-flow__actions-management-add-card {
-    flex: 1 1 calc(33.333% - 10px);
-    /* Tres columnas */
-    max-width: calc(33.333% - 10px);
-    /* Tres columnas */
-}
-
-@media (max-width: 600px) {
-    .zettelkasten-flow__actions-management-add {
-        flex-direction: column;
-    }
-
-    .zettelkasten-flow__actions-list {
-        flex-direction: column;
-    }
-
-        
-    .zettelkasten-flow__actions-category-group>.zettelkasten-flow__actions-management-add-card {
-        flex: 1 1 100%;
-        max-width: 100%;
-    }
 }

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
@@ -1,18 +1,19 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { ActionAddMenuProps, ActionCardInfo } from "./typing";
 import { c } from "architecture";
 import { t } from "architecture/lang";
-import { actionsStore, groupActionsByCategory, CATEGORY_EMOJI, CATEGORY_LABEL_KEY } from "architecture/api";
+import {
+  actionsStore,
+  ACTION_CATEGORIES,
+  CATEGORY_EMOJI,
+  CATEGORY_LABEL_KEY,
+} from "architecture/api";
+import type { ActionCategory } from "architecture/api/categories/categories";
 import { Icon } from "architecture/components/icon";
+import { getSuggestedActions } from "./getSuggestedActions";
 
-/**
- * ActionAddMenu component renders a button that toggles the action selector menu.
- *
- * @param props - ActionAddMenuProps including the modal and onChange callback.
- * @returns The add action menu interface.
- */
 export function ActionAddMenu(props: ActionAddMenuProps) {
-  const { onChange } = props;
+  const { onChange, existingActionIds } = props;
   const [display, setDisplay] = useState(false);
 
   return (
@@ -36,6 +37,7 @@ export function ActionAddMenu(props: ActionAddMenuProps) {
       >
         <ActionCardsMenu
           modal={props.modal}
+          existingActionIds={existingActionIds}
           onChange={(value, isTemplate) => {
             setDisplay(false);
             onChange(value, isTemplate);
@@ -46,18 +48,10 @@ export function ActionAddMenu(props: ActionAddMenuProps) {
   );
 }
 
-/**
- * ActionCardsMenu renders the list of available actions for selection.
- *
- * @param props - Contains modal and onChange callback.
- * @returns The searchable list of action cards.
- */
 function ActionCardsMenu(props: ActionAddMenuProps) {
-  const { onChange, modal } = props;
-  // Guard: installedTemplates.actions may be absent in settings saved by older versions
+  const { onChange, modal, existingActionIds = [] } = props;
   const actions = modal.getPlugin().settings.installedTemplates?.actions ?? {};
 
-  // Build the list of action cards by merging built-in and template actions.
   const actionsMemo: ActionCardInfo[] = useMemo(() => {
     const array: ActionCardInfo[] = [];
     actionsStore.getActionsKeys().forEach((key) => {
@@ -72,7 +66,6 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
       });
     });
     Object.values(actions).forEach((action) => {
-      // Skip template actions whose type no longer exists in the registry
       if (!actionsStore.getActionsKeys().includes(action.type)) return;
       const baseAction = actionsStore.getAction(action.type);
       array.push({
@@ -81,106 +74,190 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
         purpose: action.description,
         id: action.id,
         isTemplate: true,
-        // A template inherits its base action type's category (#152, FR-8).
         category: baseAction.category,
       });
     });
     return array;
   }, []);
 
-  const [filteredCards, setFilteredCards] = useState(actionsMemo);
+  const [activeTab, setActiveTab] = useState<ActionCategory>("manipulation");
+  const preSearchTab = useRef<ActionCategory>("manipulation");
+  const [searchTerm, setSearchTerm] = useState("");
+  const isSearching = searchTerm.length > 0;
+
+  const filteredCards = useMemo(() => {
+    if (isSearching) {
+      const lower = searchTerm.toLowerCase();
+      return actionsMemo.filter(
+        (card) =>
+          card.label.toLowerCase().includes(lower) ||
+          (card.purpose ?? "").toLowerCase().includes(lower)
+      );
+    }
+    return actionsMemo.filter((card) => card.category === activeTab);
+  }, [actionsMemo, searchTerm, activeTab, isSearching]);
+
+  const suggestedCards = useMemo(
+    () => getSuggestedActions(existingActionIds, actionsMemo),
+    [existingActionIds, actionsMemo]
+  );
+
+  const handleSearch = (value: string) => {
+    if (value.length > 0 && !isSearching) {
+      preSearchTab.current = activeTab;
+    }
+    if (value.length === 0 && isSearching) {
+      setActiveTab(preSearchTab.current);
+    }
+    setSearchTerm(value);
+  };
+
+  const handleChipClick = (card: ActionCardInfo) => {
+    onChange(card.id, card.isTemplate || false);
+  };
 
   return (
     <>
-      <input
-        className={c("actions-management-add-menu-search")}
-        type="text"
-        placeholder="Search actions"
-        onChange={(e) => {
-          const value = e.target.value.toLowerCase();
-          setFilteredCards(
-            value === ""
-              ? actionsMemo
-              : actionsMemo.filter(
-                  (card) =>
-                    card.label.toLowerCase().includes(value) ||
-                    (card.purpose ?? "").toLowerCase().includes(value)
-                )
-          );
-        }}
-      />
-      <div className={c("actions-list")}>
-        {groupActionsByCategory(filteredCards).map((group) => (
-          <div
-            key={group.category ?? "uncategorized"}
-            className={c("actions-category-group")}
-          >
-            <div className={c("actions-category-header")}>
-              {group.category && (
-                <span className={c("actions-category-emoji")} aria-hidden="true">
-                  {CATEGORY_EMOJI[group.category]}
-                </span>
-              )}
-              <label>
-                {group.category
-                  ? t(CATEGORY_LABEL_KEY[group.category])
-                  : t("action_category_uncategorized_label")}
-              </label>
-            </div>
-            {group.items.map((card) => (
-              <ActionCard
+      {suggestedCards.length > 0 && (
+        <div className={c("action-suggest-row")}>
+          <span className={c("action-suggest-row-label")}>
+            {t("action_suggest_row_label")}
+          </span>
+          <div className={c("actions-chip-grid")}>
+            {suggestedCards.map((card) => (
+              <ActionChip
                 key={card.id}
                 card={card}
-                trigger={() => {
-                  setFilteredCards(actionsMemo);
-                  onChange(card.id, card.isTemplate || false);
-                }}
+                trigger={() => handleChipClick(card)}
               />
             ))}
           </div>
+        </div>
+      )}
+      <CategoryTabStrip
+        activeTab={activeTab}
+        isSearching={isSearching}
+        onTabChange={(tab) => {
+          setActiveTab(tab);
+          setSearchTerm("");
+        }}
+      />
+      <input
+        className={c("actions-management-add-menu-search")}
+        type="text"
+        placeholder={t("action_category_uncategorized_label")}
+        value={searchTerm}
+        onChange={(e) => handleSearch(e.target.value)}
+      />
+      <div className={c("actions-chip-grid")}>
+        {filteredCards.map((card) => (
+          <ActionChip
+            key={card.id}
+            card={card}
+            trigger={() => handleChipClick(card)}
+          />
         ))}
       </div>
     </>
   );
 }
 
-/**
- * ActionCard represents a single action option in the add menu.
- *
- * @param props - Contains the action card info and a trigger callback.
- * @returns A clickable action card.
- */
-function ActionCard(props: { card: ActionCardInfo; trigger: () => void }) {
-  const { card } = props;
+function CategoryTabStrip(props: {
+  activeTab: ActionCategory;
+  isSearching: boolean;
+  onTabChange: (tab: ActionCategory) => void;
+}) {
+  const { activeTab, isSearching, onTabChange } = props;
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    const tabs = ACTION_CATEGORIES;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      onTabChange(tabs[(index + 1) % tabs.length]);
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      onTabChange(tabs[(index - 1 + tabs.length) % tabs.length]);
+    }
+  };
+
   return (
     <div
       className={
+        isSearching
+          ? c("action-tab-strip", "action-tab-strip--search-mode")
+          : c("action-tab-strip")
+      }
+      role="tablist"
+    >
+      {ACTION_CATEGORIES.map((cat, index) => (
+        <button
+          key={cat}
+          role="tab"
+          aria-selected={!isSearching && activeTab === cat}
+          className={
+            !isSearching && activeTab === cat
+              ? c("action-tab", "action-tab--active")
+              : c("action-tab")
+          }
+          onClick={() => onTabChange(cat)}
+          onKeyDown={(e) => handleKeyDown(e, index)}
+        >
+          <span aria-hidden="true">{CATEGORY_EMOJI[cat]}</span>
+          <span>{t(CATEGORY_LABEL_KEY[cat])}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ActionChip(props: { card: ActionCardInfo; trigger: () => void }) {
+  const { card } = props;
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={
         card.isTemplate
-          ? c(
-              "actions-management-add-card",
-              "actions-management-add-card-custom"
-            )
-          : c("actions-management-add-card")
+          ? c("action-chip", "actions-management-add-card-custom")
+          : c("action-chip")
       }
       onClick={() => props.trigger()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          props.trigger();
+        }
+      }}
+      onTouchEnd={(e) => {
+        e.preventDefault();
+        setTooltipOpen((prev) => !prev);
+      }}
     >
-      <div className={c("actions-management-add-card-icon")}>
-        <Icon name={card.icon} />
-      </div>
-      <div className={c("actions-management-add-card-header")}>
-        <label>{card.label}</label>
-      </div>
-      <div className={c("actions-management-add-card-body")}>
-        <label>{card.purpose}</label>
-      </div>
-      <a
-        href={card.link}
-        title={`${card.label} documentation`}
-        className={c("actions-management-add-card-link")}
-        onClick={(e) => e.stopPropagation()}
+      <Icon name={card.icon} />
+      <span className={c("action-chip-label")}>{card.label}</span>
+      <div
+        className={
+          tooltipOpen
+            ? c("action-chip-tooltip", "action-chip-tooltip--open")
+            : c("action-chip-tooltip")
+        }
       >
-        <Icon name="info" />
-      </a>
+        <p className={c("action-chip-tooltip-purpose")}>{card.purpose}</p>
+        {card.link && (
+          <a
+            href={card.link}
+            className={c("action-chip-tooltip-link")}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {t("action_card_docs_link_label")}
+          </a>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/ActionsManagement.tsx
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/ActionsManagement.tsx
@@ -176,7 +176,11 @@ export function ActionsManagement(props: ActionsManagementProps) {
           ))}
         </SortableContext>
       </DndContext>
-      <ActionAddMenu modal={modal} onChange={handleAddAction} />
+      <ActionAddMenu
+        modal={modal}
+        onChange={handleAddAction}
+        existingActionIds={actionsState.map((a) => a.type)}
+      />
     </>
   );
 }

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/getSuggestedActions.ts
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/getSuggestedActions.ts
@@ -1,0 +1,41 @@
+import type { ActionCardInfo } from "./typing";
+
+/** Static affinity pairs: when the left action is in the step, suggest the right one. */
+const AFFINITY: readonly [string, string][] = [
+    ["prompt", "create-semantic-relation"],
+    ["detect-orphan", "calculate-maturity"],
+    ["summarize", "suggest-connections"],
+    ["find-related", "suggest-link"],
+    ["extract-claims", "compare-claims"],
+    ["generate-questions", "thinking-simulator"],
+];
+
+/**
+ * Pure function — no side-effects, no I/O, no async.
+ * Given the action IDs already on the step and the full registry, return up to 3 complementary
+ * action cards based on a static affinity map. Cards already present in `existingActionIds` are
+ * excluded from results.
+ */
+export function getSuggestedActions(
+    existingActionIds: string[],
+    registry: ActionCardInfo[]
+): ActionCardInfo[] {
+    if (existingActionIds.length === 0) return [];
+
+    const existing = new Set(existingActionIds);
+    const suggested = new Set<string>();
+
+    for (const [from, to] of AFFINITY) {
+        if (existing.has(from) && !existing.has(to)) {
+            suggested.add(to);
+        }
+    }
+
+    const result: ActionCardInfo[] = [];
+    for (const id of suggested) {
+        if (result.length >= 3) break;
+        const card = registry.find((c) => c.id === id);
+        if (card) result.push(card);
+    }
+    return result;
+}

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/typing.ts
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/typing.ts
@@ -15,7 +15,8 @@ export type ActionAccordionProps = {
 
 export type ActionAddMenuProps = {
     modal: AbstractStepModal,
-    onChange: (value: string | null, isTemplate: boolean) => void
+    onChange: (value: string | null, isTemplate: boolean) => void,
+    existingActionIds?: string[],
 };
 
 export type ActionCardInfo = {

--- a/test/zettelkasten/modals/handlers/components/actionsManagment/getSuggestedActions.test.ts
+++ b/test/zettelkasten/modals/handlers/components/actionsManagment/getSuggestedActions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "@jest/globals";
+import { getSuggestedActions } from "zettelkasten/modals/handlers/components/actionsManagment/getSuggestedActions";
+import type { ActionCardInfo } from "zettelkasten/modals/handlers/components/actionsManagment/typing";
+
+function makeRegistry(ids: string[]): ActionCardInfo[] {
+    return ids.map((id) => ({
+        id,
+        icon: "file",
+        label: id,
+        purpose: `${id} purpose`,
+    }));
+}
+
+const FULL_REGISTRY = makeRegistry([
+    "prompt",
+    "create-semantic-relation",
+    "detect-orphan",
+    "calculate-maturity",
+    "summarize",
+    "suggest-connections",
+    "find-related",
+    "suggest-link",
+    "extract-claims",
+    "compare-claims",
+    "generate-questions",
+    "thinking-simulator",
+]);
+
+describe("getSuggestedActions (#256 FR-14, FR-18, AC-10)", () => {
+    it("returns empty array when no existing actions", () => {
+        const result = getSuggestedActions([], FULL_REGISTRY);
+        expect(result).toEqual([]);
+    });
+
+    it("returns create-semantic-relation when prompt is added", () => {
+        const result = getSuggestedActions(["prompt"], FULL_REGISTRY);
+        const ids = result.map((c) => c.id);
+        expect(ids).toContain("create-semantic-relation");
+    });
+
+    it("returns calculate-maturity when detect-orphan is added", () => {
+        const result = getSuggestedActions(["detect-orphan"], FULL_REGISTRY);
+        const ids = result.map((c) => c.id);
+        expect(ids).toContain("calculate-maturity");
+    });
+
+    it("returns empty when all suggestions are already added", () => {
+        const result = getSuggestedActions(
+            ["prompt", "create-semantic-relation"],
+            FULL_REGISTRY
+        );
+        // create-semantic-relation is the only affinity partner for prompt; already added
+        const ids = result.map((c) => c.id);
+        expect(ids).not.toContain("create-semantic-relation");
+    });
+
+    it("caps result at 3 items", () => {
+        const result = getSuggestedActions(
+            ["detect-orphan", "summarize", "find-related", "extract-claims", "generate-questions"],
+            FULL_REGISTRY
+        );
+        expect(result.length).toBeLessThanOrEqual(3);
+    });
+});


### PR DESCRIPTION
## Summary

- **Category tab strip** — 5 horizontal tabs (📝 Manipulation, 🔗 Relations, 🧠 Knowledge, 🔍 Research, 🤖 AI) replace the flat scroll. Default: Manipulation. Arrow-key navigation. Search mode fades the strip and shows all cross-category matches; clearing restores the previous tab.
- **Compact action chips** — 44 px chips (icon + label) in a 4-column CSS grid (2-column on narrow panels). Full description and docs link live in a CSS-positioned hover/tap tooltip; no `innerHTML`, no `title` attribute.
- **Smart suggest row** — when a step already has ≥1 action, a static affinity map surfaces up to 3 complementary chips above the tabs (`prompt → create-semantic-relation`, etc.). Row is absent when empty.

## Technical

- New pure function `getSuggestedActions` (Obsidian-free) with 5 unit tests.
- 2 new i18n keys in both `en.ts`/`es.ts`; global parity guard enforces sync.
- `existingActionIds?: string[]` threaded from `ActionsManagement` → `ActionAddMenu`.
- `lint:obsidian` 0 violations; `npm run verify` 832 tests green.

## Test plan

- [ ] Open step builder → "+" → confirm 5 tabs appear, Manipulation active by default
- [ ] Click Relations → only 4 relation chips shown
- [ ] Type "summary" → chips from multiple categories appear, tab strip fades
- [ ] Clear search → Manipulation tab restored
- [ ] Hover a chip → tooltip with description + docs link appears; no viewport overflow
- [ ] Add `prompt` action to a step → open selector → suggest row shows `create-semantic-relation`
- [ ] No existing actions → no suggest row in DOM
- [ ] Mobile: tap chip → tooltip toggles; 2-column grid at narrow width

Closes #256