### PR TITLE
fix(action-selector): fix search/tab overlap and layout

### DIFF
--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -590,6 +590,7 @@ export default {
     // Action selector redesign (#256)
     action_suggest_row_label: 'Suggested for this step',
     action_card_docs_link_label: 'Open documentation',
+    action_search_placeholder: 'Search actions…',
     // Usability epic (#258)
     flow_warning_notice: 'Warning: ',
     flow_fatal_hint: 'Open the canvas to review the highlighted node.',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -590,6 +590,7 @@ export default {
     // Action selector redesign (#256)
     action_suggest_row_label: 'Sugerido para este paso',
     action_card_docs_link_label: 'Abrir documentación',
+    action_search_placeholder: 'Buscar acciones…',
     // Usability epic (#258)
     flow_warning_notice: 'Advertencia: ',
     flow_fatal_hint: 'Abre el canvas para revisar el nodo destacado.',

--- a/src/styles/components/actionAddMenu.scss
+++ b/src/styles/components/actionAddMenu.scss
@@ -58,8 +58,8 @@
 
 .zettelkasten-flow__actions-management-add-menu-show {
     opacity: 1;
-    max-height: 340px;
-    overflow-y: auto;
+    max-height: 70vh;
+    overflow: hidden;
 }
 
 /* ── Search input ── */
@@ -69,6 +69,8 @@
     border-radius: 5px;
     border: 1px solid var(--background-modifier-border);
     font-size: 14px;
+    flex-shrink: 0;
+    box-sizing: border-box;
 }
 
 /* ── Category tab strip ── */
@@ -77,8 +79,11 @@
     flex-direction: row;
     overflow-x: auto;
     flex-wrap: nowrap;
+    flex-shrink: 0;
     gap: 4px;
     scrollbar-width: none;
+    border-bottom: 1px solid var(--background-modifier-border);
+    padding-bottom: 2px;
     transition: opacity 0.2s;
 }
 
@@ -117,12 +122,19 @@
     font-weight: 600;
 }
 
+/* ── Scrollable chip body (only this area scrolls, tabs/search stay fixed) ── */
+.zettelkasten-flow__action-selector-chip-body {
+    flex: 1;
+    min-height: 80px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
 /* ── Chip grid ── */
 .zettelkasten-flow__actions-chip-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 6px;
-    overflow: visible;
 }
 
 /* ── Individual chip ── */
@@ -139,7 +151,6 @@
     background-color: var(--background-primary);
     cursor: pointer;
     font-size: 12px;
-    overflow: visible;
     transition: background-color 0.15s, box-shadow 0.15s;
 }
 
@@ -165,7 +176,7 @@
 .zettelkasten-flow__action-chip-tooltip {
     display: none;
     position: absolute;
-    bottom: calc(100% + 4px);
+    top: calc(100% + 4px);
     left: 0;
     z-index: 100;
     min-width: 200px;

--- a/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
+++ b/src/zettelkasten/modals/handlers/components/actionsManagment/ActionAddMenu.tsx
@@ -134,6 +134,13 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
           </div>
         </div>
       )}
+      <input
+        className={c("actions-management-add-menu-search")}
+        type="text"
+        placeholder={t("action_search_placeholder")}
+        value={searchTerm}
+        onChange={(e) => handleSearch(e.target.value)}
+      />
       <CategoryTabStrip
         activeTab={activeTab}
         isSearching={isSearching}
@@ -142,21 +149,16 @@ function ActionCardsMenu(props: ActionAddMenuProps) {
           setSearchTerm("");
         }}
       />
-      <input
-        className={c("actions-management-add-menu-search")}
-        type="text"
-        placeholder={t("action_category_uncategorized_label")}
-        value={searchTerm}
-        onChange={(e) => handleSearch(e.target.value)}
-      />
-      <div className={c("actions-chip-grid")}>
-        {filteredCards.map((card) => (
-          <ActionChip
-            key={card.id}
-            card={card}
-            trigger={() => handleChipClick(card)}
-          />
-        ))}
+      <div className={c("action-selector-chip-body")}>
+        <div className={c("actions-chip-grid")}>
+          {filteredCards.map((card) => (
+            <ActionChip
+              key={card.id}
+              card={card}
+              trigger={() => handleChipClick(card)}
+            />
+          ))}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Problem

The action selector panel had a layout bug: the search bar visually dominated or overlapped the category tab buttons, making it hard to discover that other categories existed beyond Manipulation.

## Root causes

1. **DOM order**: search input was rendered *after* the tab strip — but visually the search occupied more space, making tabs easy to miss
2. **Monolithic scroll**: `overflow-y: auto` on the whole panel meant tabs could scroll out of view as the user interacted with chips
3. **Wrong search placeholder**: used `action_category_uncategorized_label` (renders as "Other" / "Otros") instead of a search-specific string
4. **Tooltip above chip**: `position: absolute; bottom: calc(100% + 4px)` placed the tooltip above the chip, which could visually overlap the search/tab header area

## Changes

- **Search moved above tab strip** — clear hierarchy: search → filter tabs → results
- **Scrollable chip body**: new `.action-selector-chip-body` wrapper gets `overflow-y: auto`; search + tabs stay in a fixed header that never scrolls away
- **Panel outer** now uses `overflow: hidden; max-height: 70vh` (was fixed 340px + overflow-y: auto)
- **Tab strip** gets `flex-shrink: 0` and a visual separator (bottom border)
- **Tooltip repositioned** to `top: calc(100% + 4px)` — appears below chip, never overlaps header
- **Search placeholder** corrected: new `action_search_placeholder` key in both `en.ts` and `es.ts`

Closes #260