### PR TITLE
refactor(engine): invert Note → persistence behind KnowledgeContext (#268 S6)

### DIFF
--- a/docs/architecture/actions-and-note-builder.md
+++ b/docs/architecture/actions-and-note-builder.md
@@ -51,12 +51,17 @@ type Action = {
 type ExecuteInfo = {
   element: FinalElement;          // the configured action + its runtime `result`
   content: ContentDTO;            // note body / frontmatter / tags accumulator
-  note:    NoteDTO;               // title, folder, template paths, saved actions
+  note:    NotePersistence;       // the note's persistence/representation view (path + title + folder)
   context: Record<string, Literal>; // ephemeral bag shared between actions
 };
 ```
 
 `FinalElement = { result: Literal } & Action`.
+
+Since epic [#268](https://github.com/RafaelGB/Obsidian-ZettelFlow/issues/268) S6 (#275), the action
+(and user-script) boundary sees the note as **`NotePersistence`**, not the wizard-shaped `NoteDTO` —
+see [The note DTOs](#4-the-note-dtos). Knowledge **domain** access (identity, model, relation writes)
+does not go through `note`; it flows through the [KnowledgeContext seam](#the-knowledgecontext-seam-xi-boundary).
 
 ### The 4-file convention
 
@@ -106,6 +111,14 @@ flowchart LR
 `find-related` is the first action migrated to read identity/model/sink through the seam; the rest
 follow as the epic splits actions into Commands vs Queries (Phase 3).
 
+**Note → persistence inversion (#268 S6, #275).** With the domain flowing through this seam, the note
+handed to an action no longer needs to be the wizard builder. `ExecuteInfo.note` is typed
+[`NotePersistence`](#4-the-note-dtos) — only the note's destination path, title and target folder —
+so neither an action nor the user-script sandbox (which receives `note` directly) can reach the
+builder's wizard-flow methods. `NoteDTO` `implements NotePersistence` and stays the note-builder's
+private object; the headless post-index re-run builds its stand-in with the pure
+`notePersistenceForPath(path)` factory instead of casting a fake `NoteDTO`.
+
 ## 2. Zones — where a value goes
 
 Most actions route their value by a `zone` config field:
@@ -151,7 +164,11 @@ Outliers to know:
   zone); `addFrontMatter(fm)` merges frontmatter (hoisting any `tags` field into `addTags`);
   `addTags`/`addTag` de-dupe.
 
-**`NoteDTO`** (`application/notes/model/NoteDTO.ts`) — metadata + work list:
+**`NoteDTO`** (`application/notes/model/NoteDTO.ts`) — the note-builder's private metadata + work list.
+Only its **persistence/representation** view — the `NotePersistence` interface
+(`application/notes/model/NotePersistence.ts`): `getFinalPath`, `getTitle`/`setTitle`,
+`getTargetFolder`/`setTargetFolder` — crosses the action/script boundary (`ExecuteInfo.note`, #275).
+The wizard-flow members below stay internal to the note-builder (`builder.note.*`):
 
 - `title`, `targetFolder`, `uniquePrefixPattern`.
 - `paths: Map<number, string>` — chosen step-template `.md` paths, keyed by wizard position.

--- a/src/application/notes/index.ts
+++ b/src/application/notes/index.ts
@@ -6,6 +6,9 @@ export { ContentDTO } from './model/ContentDTO';
 
 export { NoteDTO } from './model/NoteDTO';
 
+export { notePersistenceForPath } from './model/NotePersistence';
+export type { NotePersistence } from './model/NotePersistence';
+
 export { assembleNotePreview } from './previewAssembly';
 export type {
     AssembleNotePreviewInput,

--- a/src/application/notes/model/NoteDTO.ts
+++ b/src/application/notes/model/NoteDTO.ts
@@ -2,8 +2,9 @@ import { FinalElement } from "../typing";
 import { log } from "architecture";
 import { Action } from "architecture/api";
 import { FileService } from "architecture/plugin";
+import type { NotePersistence } from "./NotePersistence";
 
-export class NoteDTO {
+export class NoteDTO implements NotePersistence {
     private title = "";
     private paths = new Map<number, string>();
     private savedActions = new Map<number, FinalElement>();

--- a/src/application/notes/model/NotePersistence.ts
+++ b/src/application/notes/model/NotePersistence.ts
@@ -1,0 +1,35 @@
+/**
+ * The **persistence/representation view** of the note under construction (#275, epic #268 S6) — the
+ * *only* slice of the wizard-shaped `NoteDTO` the action/script boundary (`ExecuteInfo.note`) exposes:
+ * where the note will be written (`getFinalPath`), how it is named (`getTitle`/`setTitle`) and where
+ * it lives (`getTargetFolder`/`setTargetFolder`). These are exactly the methods the built-in actions
+ * (`ZettelIdAction`, `SynthesizeAction`, target resolution) and the public **script API** touch.
+ *
+ * Knowledge **domain** access (identity, model, relation writes) does *not* go through this view — it
+ * flows through the `KnowledgeContext` seam (#264). The wizard-flow builder (`addAction`,
+ * `getElements`, `getPaths`, `addLink`, `setPattern`, …) stays private to the note-builder.
+ */
+export interface NotePersistence {
+    /** The destination path the note will be written to: `targetFolder/title.md`. */
+    getFinalPath(): string;
+    getTitle(): string;
+    setTitle(title: string): NotePersistence;
+    getTargetFolder(): string;
+    setTargetFolder(targetFolder: string | undefined): NotePersistence;
+}
+
+/**
+ * A path-backed {@link NotePersistence} for callers that have only the note's final path and never
+ * rename it — the headless post-index re-run (#200) and unit tests. `getFinalPath` returns the path
+ * verbatim; title/folder are empty and their setters are chainable no-ops (the path is fixed).
+ */
+export function notePersistenceForPath(path: string): NotePersistence {
+    const stub: NotePersistence = {
+        getFinalPath: () => path,
+        getTitle: () => "",
+        setTitle: () => stub,
+        getTargetFolder: () => "",
+        setTargetFolder: () => stub,
+    };
+    return stub;
+}

--- a/src/application/patterns/postIndexRerunCore.ts
+++ b/src/application/patterns/postIndexRerunCore.ts
@@ -1,7 +1,7 @@
 import type { Literal } from "architecture/plugin";
 import type { Action } from "architecture/api";
-import type { NoteDTO } from "application/notes/model/NoteDTO";
 import { ContentDTO } from "application/notes/model/ContentDTO";
+import { notePersistenceForPath } from "application/notes/model/NotePersistence";
 import { runOnCreationActions, ActionLookup } from "application/patterns/runOnCreationActions";
 
 /**
@@ -30,9 +30,9 @@ export async function computeOnCreationDelta(
     content.addFrontMatter({ ...currentFrontmatter });
     const context: Record<string, Literal> = {};
     // The on-creation (knowledge) actions read only `note.getFinalPath()` to rank the note against
-    // the graph (see resolveTargetPath). A minimal stand-in keeps the core pure and byte-correct for
-    // any vault path, without reconstructing a NoteDTO from folder + title.
-    const note = { getFinalPath: () => notePath } as unknown as NoteDTO;
+    // the graph (see resolveTargetPath). A path-backed NotePersistence keeps the core pure and
+    // byte-correct for any vault path, without reconstructing a NoteDTO from folder + title.
+    const note = notePersistenceForPath(notePath);
 
     await runOnCreationActions(actions, { content, note, context }, getAction);
 

--- a/src/architecture/api/typing.ts
+++ b/src/architecture/api/typing.ts
@@ -2,7 +2,7 @@ import { Literal } from "architecture/plugin";
 import { ActionCategory } from "./categories";
 import type { ActionKind } from "architecture/knowledge/taxonomy/actionKind";
 import { WrappedActionBuilderProps } from "application/components/noteBuilder";
-import { ContentDTO, FinalElement, NoteDTO } from "application/notes"
+import { ContentDTO, FinalElement, NotePersistence } from "application/notes"
 import { TFile } from "obsidian";
 import { JSX } from "react";
 import { AbstractStepModal } from "zettelkasten/modals/AbstractStepModal";
@@ -10,7 +10,7 @@ import { AbstractStepModal } from "zettelkasten/modals/AbstractStepModal";
 export type ExecuteInfo = {
     element: FinalElement,
     content: ContentDTO,
-    note: NoteDTO,
+    note: NotePersistence,
     context: Record<string, Literal>,
     /**
      * True when the action runs headless as part of a note's on-creation pattern (#170/#201) rather

--- a/test/application/notes/model/NotePersistence.test.ts
+++ b/test/application/notes/model/NotePersistence.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "@jest/globals";
+import { NoteDTO } from "application/notes/model/NoteDTO";
+import {
+    notePersistenceForPath,
+    type NotePersistence,
+} from "application/notes/model/NotePersistence";
+
+/**
+ * #275 (S6) — `NotePersistence` is the persistence/representation view of the note under construction
+ * (destination path + title + target folder) that the action/script boundary sees, instead of the
+ * wizard-shaped `NoteDTO`. The domain (identity/model/write) flows through `KnowledgeContext`.
+ */
+describe("NotePersistence — the note's persistence/representation view (#275)", () => {
+    it("a NoteDTO is a NotePersistence and its five methods behave", () => {
+        const dto = new NoteDTO();
+        const note: NotePersistence = dto; // assignability is the point (compile-time proof)
+        note.setTargetFolder("Notes/Zettel").setTitle("My idea");
+        expect(note.getTitle()).toBe("My idea");
+        expect(note.getTargetFolder()).toBe("Notes/Zettel");
+        expect(note.getFinalPath()).toBe("Notes/Zettel/My idea.md");
+    });
+
+    it("notePersistenceForPath yields the path with stub title/folder", () => {
+        const note = notePersistenceForPath("Notes/Note.md");
+        expect(note.getFinalPath()).toBe("Notes/Note.md");
+        expect(note.getTitle()).toBe("");
+        expect(note.getTargetFolder()).toBe("");
+    });
+
+    it("notePersistenceForPath setters are chainable no-ops (the path is fixed)", () => {
+        const note = notePersistenceForPath("Notes/Note.md");
+        expect(note.setTitle("x").setTargetFolder("y").getFinalPath()).toBe("Notes/Note.md");
+    });
+});

--- a/test/application/patterns/postIndexRerunNoCast.test.ts
+++ b/test/application/patterns/postIndexRerunNoCast.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// test/application/patterns → 3 ups → repo root
+const CORE = join(__dirname, "..", "..", "..", "src", "application", "patterns", "postIndexRerunCore.ts");
+
+/**
+ * #275 (S6) — the headless post-index re-run no longer fabricates a `NoteDTO` via `as unknown as
+ * NoteDTO`; it builds a real `NotePersistence` from the note path, so the pattern call site is off
+ * the wizard-shaped domain object entirely.
+ */
+describe("postIndexRerunCore builds a NotePersistence, not a fabricated NoteDTO (#275)", () => {
+    const src = readFileSync(CORE, "utf8");
+
+    it("contains no `as unknown as NoteDTO` cast", () => {
+        expect(src).not.toMatch(/as\s+unknown\s+as\s+NoteDTO/);
+    });
+
+    it("constructs the note stand-in via notePersistenceForPath", () => {
+        expect(src).toMatch(/notePersistenceForPath\s*\(/);
+    });
+});

--- a/test/architecture/api/executeInfoNoteBoundary.test.ts
+++ b/test/architecture/api/executeInfoNoteBoundary.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { resolveTargetPath } from "actions/knowledge/knowledgeActionCore";
+import { notePersistenceForPath } from "application/notes/model/NotePersistence";
+import type { ExecuteInfo } from "architecture/api";
+
+// test/architecture/api → 3 ups → repo root
+const TYPING = join(__dirname, "..", "..", "..", "src", "architecture", "api", "typing.ts");
+
+/**
+ * #275 (S6) — the action/script boundary (`ExecuteInfo.note`) must expose the note as the
+ * persistence/representation view `NotePersistence`, not the wizard-shaped `NoteDTO`. Knowledge
+ * domain access flows through `KnowledgeContext`, so the note the boundary hands out never needs the
+ * builder's wizard-flow methods.
+ */
+describe("ExecuteInfo.note is the persistence/representation view (#275)", () => {
+    const src = readFileSync(TYPING, "utf8");
+
+    it("types ExecuteInfo.note as NotePersistence, not NoteDTO", () => {
+        expect(src).toMatch(/note:\s*NotePersistence\b/);
+        expect(src).not.toMatch(/note:\s*NoteDTO\b/);
+    });
+
+    it("resolveTargetPath needs only a NotePersistence note (falls back to its final path)", () => {
+        const info = {
+            element: { type: "find-related", id: "find-related", hasUI: false, key: "related", zone: "frontmatter" },
+            content: undefined,
+            note: notePersistenceForPath("Built/Note.md"),
+            context: {},
+        } as unknown as ExecuteInfo;
+        const el = info.element as unknown as Parameters<typeof resolveTargetPath>[1];
+        expect(resolveTargetPath(info, el)).toBe("Built/Note.md");
+    });
+
+    it("resolveTargetPath prefers a configured el.target over the note path", () => {
+        const info = {
+            element: { type: "find-related", id: "find-related", hasUI: false, key: "related", zone: "frontmatter", target: "Notes/Idea.md" },
+            content: undefined,
+            note: notePersistenceForPath("Built/Note.md"),
+            context: {},
+        } as unknown as ExecuteInfo;
+        const el = info.element as unknown as Parameters<typeof resolveTargetPath>[1];
+        expect(resolveTargetPath(info, el)).toBe("Notes/Idea.md");
+    });
+});


### PR DESCRIPTION
> **Epic:** #268 (Phase 7 of #262) — **final slice S6.** Note → persistence inversion. This closes the epic.

## What & why

`ExecuteInfo.note` handed every action — and every user **script** (`ScriptAction` passes `note`
straight into the sandbox) — the full wizard-shaped `NoteDTO`. This slice reduces that boundary to
the note's **persistence/representation** view and keeps knowledge **domain** access on the
`KnowledgeContext` seam (#264). Behaviour-preserving; no big-bang.

## Changes

- **`NotePersistence`** (`application/notes/model/NotePersistence.ts`) — the note's persistence/
  representation surface: `getFinalPath`, `getTitle`/`setTitle`, `getTargetFolder`/`setTargetFolder`
  (exactly what actions, `ZettelIdAction`, `SynthesizeAction`, target resolution and the public script
  API touch). Plus a pure `notePersistenceForPath(path)` factory for path-only callers.
- **`NoteDTO implements NotePersistence`** and stays the note-builder's private wizard builder
  (`builder.note.*`); its wizard-flow methods no longer cross the action boundary.
- **`ExecuteInfo.note: NotePersistence`** (was `NoteDTO`).
- **Post-index re-run** (`postIndexRerunCore`) builds its stand-in via `notePersistenceForPath` —
  the `as unknown as NoteDTO` cast is gone (0 such casts remain in `src/`).
- Docs: `docs/architecture/actions-and-note-builder.md`.

## Guardrails

`npm run verify` green (typecheck · oxlint · **lint:obsidian 0** · **924/924** jest, incl. the
new `NotePersistence` / boundary / no-cast suites). Existing action/pattern/event suites pass
**untouched**. No i18n or README change (internal refactor — no user-facing feature).

Closes #275
Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
