### PR TITLE
fix(experience): surfaces crash on open — construction-safe getViewType + resilient onload (#278)

### DIFF
--- a/src/architecture/components/core/surface/DiscoverySurfaceView.ts
+++ b/src/architecture/components/core/surface/DiscoverySurfaceView.ts
@@ -1,5 +1,4 @@
 import { ModeHostView } from "./ModeHostView";
-import { surfaceByType, Surface } from "./surfaceRegistry";
 import { KnowledgeModeRenderer } from "./KnowledgeModeRenderer";
 import { DiscoveriesRenderer } from "architecture/components/core/discoveries/DiscoveriesRenderer";
 import { ResurfaceRenderer } from "architecture/components/core/resurface/ResurfaceRenderer";
@@ -12,7 +11,9 @@ import { EvidenceMapRenderer } from "architecture/components/core/evidenceMap/Ev
  * Challenges (evidence map). Each mode reuses the retired view's renderer verbatim.
  */
 export class DiscoverySurfaceView extends ModeHostView {
-    protected readonly surface: Surface = surfaceByType("zettelflow-discovery");
+    getViewType(): string {
+        return "zettelflow-discovery";
+    }
 
     getIcon(): string {
         return "telescope";

--- a/src/architecture/components/core/surface/GraphSurfaceView.ts
+++ b/src/architecture/components/core/surface/GraphSurfaceView.ts
@@ -1,5 +1,4 @@
 import { ModeHostView } from "./ModeHostView";
-import { surfaceByType, Surface } from "./surfaceRegistry";
 import { KnowledgeModeRenderer } from "./KnowledgeModeRenderer";
 import { KnowledgeMapRenderer } from "architecture/components/core/knowledgeMap/KnowledgeMapRenderer";
 import { ConceptNavRenderer } from "architecture/components/core/conceptNav/ConceptNavRenderer";
@@ -10,7 +9,9 @@ import { ConceptNavRenderer } from "architecture/components/core/conceptNav/Conc
  * Each mode reuses the retired view's renderer verbatim.
  */
 export class GraphSurfaceView extends ModeHostView {
-    protected readonly surface: Surface = surfaceByType("zettelflow-graph");
+    getViewType(): string {
+        return "zettelflow-graph";
+    }
 
     getIcon(): string {
         return "network";

--- a/src/architecture/components/core/surface/HealthSurfaceView.ts
+++ b/src/architecture/components/core/surface/HealthSurfaceView.ts
@@ -1,5 +1,4 @@
 import { ModeHostView } from "./ModeHostView";
-import { surfaceByType, Surface } from "./surfaceRegistry";
 import { KnowledgeModeRenderer } from "./KnowledgeModeRenderer";
 import { SlipboxHealthRenderer } from "architecture/components/core/slipboxHealth/SlipboxHealthRenderer";
 import { KnowledgeDashboardRenderer } from "architecture/components/core/knowledgeDashboard/KnowledgeDashboardRenderer";
@@ -12,7 +11,9 @@ import { ThinkingHeatmapRenderer } from "architecture/components/core/thinkingHe
  * development heatmap). Each mode reuses the retired view's renderer verbatim.
  */
 export class HealthSurfaceView extends ModeHostView {
-    protected readonly surface: Surface = surfaceByType("zettelflow-health");
+    getViewType(): string {
+        return "zettelflow-health";
+    }
 
     getIcon(): string {
         return "stethoscope";

--- a/src/architecture/components/core/surface/HomeSurfaceView.ts
+++ b/src/architecture/components/core/surface/HomeSurfaceView.ts
@@ -1,7 +1,6 @@
 import { WorkspaceLeaf } from "obsidian";
 import ZettelFlow from "main";
 import { ModeHostView } from "./ModeHostView";
-import { surfaceByType, Surface } from "./surfaceRegistry";
 import { KnowledgeModeRenderer } from "./KnowledgeModeRenderer";
 import { HomeModeRenderer } from "architecture/components/core/home/HomeModeRenderer";
 import { HistoryRenderer } from "architecture/components/core/historyView/HistoryRenderer";
@@ -12,10 +11,12 @@ import { HistoryRenderer } from "architecture/components/core/historyView/Histor
  * Recent mode can read/clear `plugin.settings.history`.
  */
 export class HomeSurfaceView extends ModeHostView {
-    protected readonly surface: Surface = surfaceByType("zettelflow-home");
-
     constructor(leaf: WorkspaceLeaf, private readonly plugin: ZettelFlow) {
         super(leaf);
+    }
+
+    getViewType(): string {
+        return "zettelflow-home";
     }
 
     getIcon(): string {

--- a/src/architecture/components/core/surface/ModeHostView.ts
+++ b/src/architecture/components/core/surface/ModeHostView.ts
@@ -1,7 +1,7 @@
 import { ItemView, ViewStateResult } from "obsidian";
 import { c } from "architecture";
 import { t } from "architecture/lang";
-import type { Surface } from "./surfaceRegistry";
+import { surfaceByType, type Surface } from "./surfaceRegistry";
 import { KnowledgeModeRenderer } from "./KnowledgeModeRenderer";
 
 type LocaleKey = Parameters<typeof t>[0];
@@ -14,19 +14,25 @@ type LocaleKey = Parameters<typeof t>[0];
  * command targeting a specific mode — restores it.
  */
 export abstract class ModeHostView extends ItemView {
-    /** The surface definition (view type, title, ordered modes) — set as a field by the subclass. */
-    protected abstract readonly surface: Surface;
+    /**
+     * The surface's registered view type. **Must return a literal — it may not read an instance field.**
+     * Obsidian's `ItemView` base calls `getViewType()` from inside its own constructor (during the
+     * subclass `super()` call), before any subclass field initializer has run; a field-backed value
+     * would still be `undefined` at that point and crash ("Cannot read properties of undefined").
+     */
+    abstract getViewType(): string;
     /** Build the renderer for a mode id, rendering into `container`. */
     protected abstract createRenderer(modeId: string, container: HTMLElement): KnowledgeModeRenderer;
+
+    /** The surface definition (title, ordered modes), derived from the construction-safe view type. */
+    protected get surface(): Surface {
+        return surfaceByType(this.getViewType());
+    }
 
     private activeMode = "";
     private bodyEl: HTMLElement | null = null;
     private current: KnowledgeModeRenderer | null = null;
     private readonly tabButtons = new Map<string, HTMLElement>();
-
-    getViewType(): string {
-        return this.surface.viewType;
-    }
 
     getDisplayText(): string {
         return t(this.surface.titleKey as LocaleKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,10 +38,14 @@ export default class ZettelFlow extends Plugin {
 		ConceptualTimeline.getInstance().init(this); // #168: wire the conceptual evolution timeline to settings.
 		loadVariableTextProcessors(this);
 
-		loadPluginComponents(this);
-
+		// Register the core views + actions FIRST. If a UI component fails while loading, the
+		// surfaces must already be registered — an unregistered surface view type renders as
+		// Obsidian's "plugin no longer active" placeholder, which used to break every surface when
+		// a single component threw before this ran. Components (ribbon/menu/commands) load after.
 		this.registerViews();
 		this.registerActions();
+
+		loadPluginComponents(this);
 		Hooks.setup(this);
 		WorkflowEventEngine.setup(this);
 

--- a/src/starters/services/ZComponentsManager.ts
+++ b/src/starters/services/ZComponentsManager.ts
@@ -1,9 +1,9 @@
-import { PluginComponent } from "architecture";
+import { PluginComponent, log } from "architecture";
 
 class ZComponentsManagerService {
     private static instance: ZComponentsManagerService;
     private liveCycleComponents: PluginComponent[];
-    constructor() { 
+    constructor() {
         this.liveCycleComponents = [];
     }
 
@@ -12,14 +12,25 @@ class ZComponentsManagerService {
     }
 
     public loadComponents():void{
+        // Isolate each component: one throwing onLoad must not abort the rest (and must not bubble
+        // up to Plugin.onload, which would leave core views/commands unregistered). The failure is
+        // logged so the offending component is visible, and every other component still loads.
         this.liveCycleComponents.forEach(component => {
-            component.onLoad();
+            try {
+                component.onLoad();
+            } catch (error) {
+                log.error(`[ZComponents] component "${component.constructor.name}" failed to load`, error);
+            }
         });
     }
 
     public unloadComponents():void{
         this.liveCycleComponents.forEach(component => {
-            component.onUnload();
+            try {
+                component.onUnload();
+            } catch (error) {
+                log.error(`[ZComponents] component "${component.constructor.name}" failed to unload`, error);
+            }
         });
         this.liveCycleComponents = [];
     }

--- a/test/architecture/components/core/surface/surfaceViewConstruction.test.ts
+++ b/test/architecture/components/core/surface/surfaceViewConstruction.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// test/architecture/components/core/surface → 5 ups → repo root
+const SURFACE_DIR = join(__dirname, "..", "..", "..", "..", "..", "src", "architecture", "components", "core", "surface");
+const read = (file: string) => readFileSync(join(SURFACE_DIR, file), "utf8");
+
+/**
+ * Regression (#278 view-construction crash): Obsidian's `ItemView` base calls `getViewType()` from
+ * inside its constructor (during `super()`), before any subclass field initializer runs. A surface
+ * whose `getViewType()` read a `surface` field (`this.surface.viewType`) therefore crashed with
+ * "Cannot read properties of undefined (reading 'viewType')" for EVERY surface. Each surface view must
+ * return its view type as a construction-safe **literal**, and must not back it with a field.
+ */
+describe("surface views expose a construction-safe getViewType (#278)", () => {
+    const cases: Array<[string, string]> = [
+        ["HomeSurfaceView.ts", "zettelflow-home"],
+        ["HealthSurfaceView.ts", "zettelflow-health"],
+        ["DiscoverySurfaceView.ts", "zettelflow-discovery"],
+        ["GraphSurfaceView.ts", "zettelflow-graph"],
+    ];
+
+    for (const [file, viewType] of cases) {
+        it(`${file} returns "${viewType}" from a literal getViewType`, () => {
+            const src = read(file);
+            const pattern = new RegExp(`getViewType\\(\\)\\s*:\\s*string\\s*\\{\\s*return\\s*"${viewType}"`);
+            expect(src).toMatch(pattern);
+        });
+
+        it(`${file} does not back the view type with a crashing surface field`, () => {
+            const src = read(file);
+            // The field initializer runs after super(), so getViewType() would read undefined during construction.
+            expect(src).not.toMatch(/surface\s*(:\s*Surface\s*)?=\s*surfaceByType\(/);
+        });
+    }
+
+    it("ModeHostView derives the surface from getViewType, not an abstract field", () => {
+        const src = read("ModeHostView.ts");
+        expect(src).not.toMatch(/abstract\s+readonly\s+surface\b/);
+        expect(src).toMatch(/get\s+surface\(\)\s*:\s*Surface\s*\{\s*return\s+surfaceByType\(this\.getViewType\(\)\)/);
+    });
+});

--- a/test/starters/services/ZComponentsManager.test.ts
+++ b/test/starters/services/ZComponentsManager.test.ts
@@ -1,36 +1,50 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { ZComponentsManager } from "starters/services/ZComponentsManager";
+import { PluginComponent, log } from "architecture";
 
-// PluginComponent is used only as a type in the manager, so importing it here stays light.
-type FakeComponent = { onLoad: () => void; onUnload: () => void };
+/**
+ * Regression (#268 view-registration bug): a single component whose `onLoad` throws must NOT abort
+ * loading the rest — the unguarded `forEach` used to bubble up to `Plugin.onload`, leaving the
+ * surfaces unregistered so every surface rendered as Obsidian's "plugin no longer active" placeholder.
+ */
+class FakeComponent extends PluginComponent {
+    constructor(private readonly run: () => void, private readonly onDown: () => void = () => undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        super(undefined as any);
+    }
+    onLoad(): void { this.run(); }
+    onUnload(): void { this.onDown(); }
+}
 
-describe("ZComponentsManager", () => {
-  beforeEach(() => {
-    // Ensure a clean registry (the manager is a module-level singleton).
-    ZComponentsManager.unloadComponents();
-  });
+describe("ZComponentsManager isolates a failing component", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        ZComponentsManager.unloadComponents(); // reset the singleton's list between tests
+    });
 
-  it("runs onUnload on every registered component and clears the registry", () => {
-    const a: FakeComponent = { onLoad: jest.fn(), onUnload: jest.fn() };
-    const b: FakeComponent = { onLoad: jest.fn(), onUnload: jest.fn() };
+    it("loads every other component when one onLoad throws, and logs the failure", () => {
+        jest.spyOn(log, "error").mockImplementation(() => undefined);
+        const loaded: string[] = [];
+        ZComponentsManager.registerComponent(new FakeComponent(() => loaded.push("a")));
+        ZComponentsManager.registerComponent(new FakeComponent(() => { throw new Error("boom"); }));
+        ZComponentsManager.registerComponent(new FakeComponent(() => loaded.push("c")));
 
-    ZComponentsManager.registerComponent(a as unknown as never);
-    ZComponentsManager.registerComponent(b as unknown as never);
+        expect(() => ZComponentsManager.loadComponents()).not.toThrow();
 
-    ZComponentsManager.unloadComponents();
+        expect(loaded).toEqual(["a", "c"]);
+        expect(log.error).toHaveBeenCalledTimes(1);
+    });
 
-    expect(a.onUnload).toHaveBeenCalledTimes(1);
-    expect(b.onUnload).toHaveBeenCalledTimes(1);
+    it("unloads every other component when one onUnload throws", () => {
+        jest.spyOn(log, "error").mockImplementation(() => undefined);
+        const down: string[] = [];
+        ZComponentsManager.registerComponent(new FakeComponent(() => undefined, () => down.push("a")));
+        ZComponentsManager.registerComponent(new FakeComponent(() => undefined, () => { throw new Error("boom"); }));
+        ZComponentsManager.registerComponent(new FakeComponent(() => undefined, () => down.push("c")));
 
-    (a.onUnload as ReturnType<typeof jest.fn>).mockClear();
-    ZComponentsManager.unloadComponents();
-    expect(a.onUnload).not.toHaveBeenCalled();
-  });
+        expect(() => ZComponentsManager.unloadComponents()).not.toThrow();
 
-  it("runs onLoad on every registered component", () => {
-    const a: FakeComponent = { onLoad: jest.fn(), onUnload: jest.fn() };
-    ZComponentsManager.registerComponent(a as unknown as never);
-    ZComponentsManager.loadComponents();
-    expect(a.onLoad).toHaveBeenCalledTimes(1);
-  });
+        expect(down).toEqual(["a", "c"]);
+        expect(log.error).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
## Problem

After the experience-consolidation epic (#268), opening any surface (Home/Health/Discovery/Graph)
rendered Obsidian's **"the plugin that made this tab has gone away"** placeholder. Confirmed in a live
vault via the DevTools console:

```
Failed to create view of type "zettelflow-home"
TypeError: Cannot read properties of undefined (reading 'viewType')
    at getViewType (this.surface.viewType)
    at ItemView constructor        ← Obsidian calls getViewType() during super()
    at ModeHostView / HomeSurfaceView constructor
```

## Root cause

Obsidian's `ItemView` base calls `getViewType()` **from inside its constructor** (during the subclass
`super()` call), *before* subclass field initializers run. Each surface backed `getViewType()` with a
field `surface = surfaceByType(...)` and returned `this.surface.viewType` — but `this.surface` is still
`undefined` at construction time, so **every** surface crashed.

## Fix

1. **`getViewType()` is a construction-safe literal** each surface implements
   (`return "zettelflow-home"`); `ModeHostView` derives the `Surface` lazily from it via a getter.
2. **Hardened `onload`** (defense in depth): register core views + actions **before** UI components,
   and isolate each component's `onLoad`/`onUnload` in a try/catch that logs the offending component —
   so a single failing component can neither cascade nor leave views unregistered.

## Tests

- `surfaceViewConstruction.test.ts` — structural: each surface returns its view-type literal and never
  backs it with a `surface` field; `ModeHostView` derives the surface from `getViewType()`.
- `ZComponentsManager.test.ts` — a throwing component no longer aborts the rest (load + unload).
- `npm run verify` green (181 suites, 933 tests); `lint:obsidian` 0. Verified live in the test vault:
  all four surfaces open and render.

Closes #278
