### PR TITLE
fix(canvas): style the empty-state panel so it never steals canvas pointer events (#281)

### DIFF
--- a/src/styles/components/workflowCanvas.scss
+++ b/src/styles/components/workflowCanvas.scss
@@ -17,3 +17,33 @@
     outline: 1px dashed var(--color-purple, #a060c0);
     border-radius: var(--radius-s);
 }
+
+// Empty-state guide panel (#258) — a floating card injected into the canvas `wrapperEl`.
+// CRITICAL: the container is `pointer-events: none` so it never intercepts canvas hover/drag
+// (Obsidian's drag handler checks `e.targetNode === wrapperEl`; an interactive injected child
+// breaks pointer handling — the cursor flickers and edges stop responding). Only the CTA is
+// interactive. Absolute + high layer so it floats over the canvas without disturbing its layers.
+.zettelkasten-flow__empty-state-panel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: var(--layer-popover, 30);
+    pointer-events: none;
+    max-width: 22em;
+    padding: var(--size-4-4);
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    box-shadow: var(--shadow-s);
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.zettelkasten-flow__empty-state-cta-row {
+    margin-top: var(--size-4-3);
+    display: flex;
+    justify-content: center;
+    // The button is the one interactive affordance; the rest of the card lets clicks/hover fall through.
+    pointer-events: auto;
+}


### PR DESCRIPTION
Fixes the unstyled #258 empty-state panel that was injected into the canvas `wrapperEl` and disrupted pointer handling (cursor flicker between default/grab). Now an absolutely-positioned card with `pointer-events: none` on the container and `pointer-events: auto` only on the CTA, so canvas hover/drag pass straight through.

`npm run verify` green; `lint:obsidian` 0. Deployed to the test vault.

Note: the separately-reported 'edge line invisible, only arrowhead' symptom shows no ZettelFlow cause (no plugin CSS/code touches canvas edge paths) and is being triaged as Obsidian-core/theme via an ownership test.

Closes #281