### PR TITLE
feat(reliability): canvas patcher robustness against Obsidian internals (#304)

### DIFF
--- a/docs/development/canvas-integration.md
+++ b/docs/development/canvas-integration.md
@@ -1,0 +1,46 @@
+# Canvas integration & robustness
+
+ZettelFlow turns Obsidian's native Canvas into a workflow surface by **monkey-patching** a few
+internal Canvas APIs (`src/architecture/plugin/canvas/extensions/CanvasPatcher.ts` via
+`monkey-around`). Obsidian does not expose these as a public API, so they can change between app
+versions. The integration is built to **degrade gracefully** rather than break the canvas (#304).
+
+## What is patched
+
+| Patch | Target | Purpose | If the internal changed |
+|---|---|---|---|
+| `popup-menu` | `canvas.menu.render` | fire the `canvas:popup-menu` event + re-center | skipped; menu still works |
+| `view-data` | `CanvasView.getViewData` / `setViewData` | stable serialization + JSON repair + fire injection/render events | skipped; canvas save/load still works |
+| (events) | — | the `zettelflow-*` events the extensions listen to | best-effort; a throw never corrupts a save |
+
+## How it degrades (never a hard break)
+
+1. **Patch-time (missing method).** `PatchHelper.patch` checks that every method it means to override
+   exists; if one is gone it returns `null` instead of throwing, and the caller marks that patch
+   **degraded** (`CanvasPatchStatus`).
+2. **Run-time (a patched body throws).** Each patched body runs inside Obsidian's own loops, so its
+   ZettelFlow additions are wrapped: on a throw it logs, marks the patch degraded, and **falls back
+   to the original** method. The canvas keeps working without our enhancement.
+3. **Report once.** The first degrade shows a single Notice ("canvas integration partially
+   unavailable after an Obsidian update") — never a stack trace, never repeated spam.
+4. **Self-check.** On load, a one-line summary is logged, e.g. `canvas patches: 2 attached, 0
+   degraded`.
+
+The status tracker (`CanvasPatchStatus`) is pure and unit-tested; `PatchHelper`'s fail-soft path is
+tested too.
+
+## Manual-check matrix (run after an Obsidian update)
+
+Do this against the latest Obsidian when bumping `minAppVersion` or after an app update:
+
+| Check | Expected |
+|---|---|
+| Open a ZettelFlow canvas | loads; no error Notice |
+| Console on load | `ZettelFlow: canvas patches: N attached, 0 degraded` |
+| Right-click a node / open the canvas popup menu | ZettelFlow options appear |
+| Create a note through the wizard (drop-menu) | the node-connection drop menu appears and builds a note |
+| Edit + save the canvas | saves; reopen shows the same graph (getViewData/setViewData intact) |
+| Reopen an already-open canvas at startup | card-menu options + workflow styling are present (#234 re-apply) |
+
+If any row fails, the console/self-check tells you **which** patch degraded; harden that specific
+patch in `CanvasPatcher`. A degraded patch must never crash note creation.

--- a/docs/development/project-health-and-roadmap.md
+++ b/docs/development/project-health-and-roadmap.md
@@ -27,7 +27,7 @@ A candid snapshot of ZettelFlow's technical debt and a plan to give it a new lif
 | 6 | **Widespread inline styles** (`el.style.*`) | `no-static-styles-assignment` violations | community/config modals |
 | 7 | ~~**`log.error` silenced when logging off**~~ — errors always surface (wired in the constructor) | — | `Logger.ts` |
 | 8 | **`onunload` doesn't call `unloadComponents()`** | Component teardown skipped | `main.ts` |
-| 9 | **Canvas monkey-patching** of internal APIs | Fragile across Obsidian updates; manual-review flag | `canvas/CanvasPatcher` |
+| 9 | **Canvas monkey-patching** of internal APIs — now **guarded** (#304): fails soft on missing methods, catches runtime throws and falls back to the original, reports once + a self-check log | Fragile across Obsidian updates, but no longer a hard break | `canvas/CanvasPatcher`, `canvas/…/CanvasPatchStatus` |
 | 10 | ~~**Backend has no auth/CORS/health, dev-only posture**~~ — backend removed (#294); the community gallery is fully static | — | — |
 | 11 | **`es.ts` locale behind `en.ts`** | Missing Spanish strings fall back to English | `architecture/lang/locale` |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - 7.25 Derived projects: development/derived-projects.md
       - 7.28 3D knowledge graph: development/graph-3d.md
       - 7.29 Quick capture: development/quick-capture.md
+      - 7.30 Canvas integration: development/canvas-integration.md
       - 7.27 Friction audit (epic #231): development/friction-audit.md
 extra_javascript:
   - "extra_javascript/navigationInstant.js"

--- a/src/architecture/plugin/canvas/extensions/CanvasPatcher.ts
+++ b/src/architecture/plugin/canvas/extensions/CanvasPatcher.ts
@@ -2,15 +2,26 @@ import ZettelFlow from "main";
 import { Notice, requireApiVersion } from "obsidian";
 import { CanvasView, PopupMenu } from "obsidian/canvas";
 import PatchHelper from "./utils/PatchHelper";
+import { CanvasPatchStatus } from "./utils/CanvasPatchStatus";
 import { log } from "architecture";
 import { t } from "architecture/lang";
 import JSONSS from "json-stable-stringify"
 import JSONC from "tiny-jsonc"
 
 export default class CanvasPatcher {
+    /** Which patches attached vs. degraded (#304); shows a single Notice on the first degrade. */
+    private readonly status = new CanvasPatchStatus(() => this.notifyDegradedOnce());
+    private noticeShown = false;
 
     constructor(private plugin: ZettelFlow) {
         void this.patch();
+    }
+
+    /** Show the "canvas integration partially unavailable" Notice at most once per session (#304 S2). */
+    private notifyDegradedOnce() {
+        if (this.noticeShown) return;
+        this.noticeShown = true;
+        new Notice(t('notice_canvas_patch_failed'));
     }
 
     public async patch() {
@@ -57,13 +68,22 @@ export default class CanvasPatcher {
                 const menuPatched = PatchHelper.patchPrototype<PopupMenu>(this.plugin, canvasView.canvas.menu, {
                     render: (next: () => void) => function (this: PopupMenu) {
                         const result = next.call(this);
-                        that.triggerWorkspaceEvent("canvas:popup-menu", this.canvas);
-                        next.call(this) // Re-Center the popup menu
+                        // Our additions run inside Obsidian's render loop — a throw here would break the
+                        // menu, so degrade gracefully to the original render instead (#304 S2).
+                        try {
+                            that.triggerWorkspaceEvent("canvas:popup-menu", this.canvas);
+                            next.call(this) // Re-Center the popup menu
+                        } catch (e) {
+                            log.error("ZettelFlow: canvas popup-menu enhancement failed at runtime", e)
+                            that.status.markDegraded("popup-menu-render")
+                        }
                         return result;
                     }
                 });
+                this.status[menuPatched ? "markAttached" : "markDegraded"]("popup-menu")
                 if (!menuPatched) log.warn("ZettelFlow: could not patch the canvas popup menu (internals changed)")
             } else {
+                this.status.markDegraded("popup-menu")
                 log.warn("ZettelFlow: canvas popup menu not found; skipping that patch")
             }
 
@@ -102,19 +122,27 @@ export default class CanvasPatcher {
                         result = next.call(this, json)
                     }
 
-                    that.triggerWorkspaceEvent("zettelflow-node-connection-drop-menu", this.canvas)
-                    // Signal a canvas (re)render so the workflow-legibility extension can re-apply
-                    // its cosmetic block-kind styling (#151). Guarded: reuses this already-guarded
-                    // patch, adds no new patched method.
-                    that.triggerWorkspaceEvent("zettelflow-canvas-render", this.canvas)
+                    // A throwing event handler must not corrupt the save (setViewData) itself — the data
+                    // is already written; the enhancements are best-effort (#304 S2).
+                    try {
+                        that.triggerWorkspaceEvent("zettelflow-node-connection-drop-menu", this.canvas)
+                        // Signal a canvas (re)render so the workflow-legibility extension can re-apply
+                        // its cosmetic block-kind styling (#151).
+                        that.triggerWorkspaceEvent("zettelflow-canvas-render", this.canvas)
+                    } catch (e) {
+                        log.error("ZettelFlow: canvas render enhancement failed at runtime", e)
+                        that.status.markDegraded("view-render-events")
+                    }
                     return result
                 })
             })
 
             if (!viewPatched) {
+                this.status.markDegraded("view-data")
                 this.notifyCanvasUnavailable('the canvas view data methods were not found')
                 return
             }
+            this.status.markAttached("view-data")
 
             // Canvases already open when Obsidian started rendered BEFORE this patch installed, so the
             // injection events never fired for them and the plugin's canvas options never attached
@@ -122,9 +150,12 @@ export default class CanvasPatcher {
             // fires these on every canvas change and the handlers are idempotent (addCardMenuOption
             // removes any same-id element first; the restyle clears before re-applying).
             await this.reapplyToOpenCanvases()
+
+            // Self-check (#304 S3): a single line reporting which patches attached vs. degraded.
+            log.info(`ZettelFlow: ${this.status.describe()}`)
         } catch (e) {
             log.error("ZettelFlow: failed to initialize the canvas integration", e)
-            new Notice(t('notice_canvas_patch_failed'))
+            this.notifyDegradedOnce()
         }
     }
 
@@ -150,7 +181,8 @@ export default class CanvasPatcher {
 
     private notifyCanvasUnavailable(reason: string) {
         log.error(`ZettelFlow: canvas integration unavailable — ${reason}. Obsidian's canvas internals may have changed.`)
-        new Notice(t('notice_canvas_patch_failed'))
+        this.status.markDegraded("canvas-view")
+        this.notifyDegradedOnce()
     }
 
     private triggerWorkspaceEvent(event: string, ...args: unknown[]) {

--- a/src/architecture/plugin/canvas/extensions/utils/CanvasPatchStatus.ts
+++ b/src/architecture/plugin/canvas/extensions/utils/CanvasPatchStatus.ts
@@ -1,0 +1,50 @@
+/**
+ * Tracks which canvas patches attached vs. degraded (#304), so a changed Obsidian internal degrades
+ * gracefully — logged and reported once — instead of breaking the canvas. Pure and Obsidian-free: the
+ * one user-facing side effect (a Notice) is injected as `onFirstDegrade`, so this is unit-testable.
+ */
+export type PatchState = "attached" | "degraded";
+
+export class CanvasPatchStatus {
+    private readonly states = new Map<string, PatchState>();
+    private readonly notified = new Set<string>();
+
+    /** `onFirstDegrade` fires the first time each named patch degrades (e.g. to show a Notice once). */
+    constructor(private readonly onFirstDegrade: (name: string) => void = () => undefined) {}
+
+    /** Record a patch as attached — never overrides a prior `degraded` (a later success can't un-break it). */
+    markAttached(name: string): void {
+        if (this.states.get(name) !== "degraded") this.states.set(name, "attached");
+    }
+
+    /** Record a patch as degraded; the injected callback fires only the first time for this name. */
+    markDegraded(name: string): void {
+        this.states.set(name, "degraded");
+        if (!this.notified.has(name)) {
+            this.notified.add(name);
+            this.onFirstDegrade(name);
+        }
+    }
+
+    state(name: string): PatchState | undefined {
+        return this.states.get(name);
+    }
+
+    /** Snapshot of every tracked patch, insertion order. */
+    summary(): { name: string; state: PatchState }[] {
+        return [...this.states].map(([name, state]) => ({ name, state }));
+    }
+
+    degradedCount(): number {
+        let count = 0;
+        for (const state of this.states.values()) if (state === "degraded") count++;
+        return count;
+    }
+
+    /** A short human-readable line for the log (e.g. "canvas patches: 2 attached, 1 degraded"). */
+    describe(): string {
+        const total = this.states.size;
+        const degraded = this.degradedCount();
+        return `canvas patches: ${total - degraded} attached, ${degraded} degraded`;
+    }
+}

--- a/test/architecture/plugin/canvas/CanvasPatchStatus.test.ts
+++ b/test/architecture/plugin/canvas/CanvasPatchStatus.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { CanvasPatchStatus } from "architecture/plugin/canvas/extensions/utils/CanvasPatchStatus";
+
+describe("CanvasPatchStatus (#304)", () => {
+    it("tracks attached and degraded patches", () => {
+        const status = new CanvasPatchStatus();
+        status.markAttached("view-data");
+        status.markDegraded("popup-menu");
+        expect(status.state("view-data")).toBe("attached");
+        expect(status.state("popup-menu")).toBe("degraded");
+        expect(status.degradedCount()).toBe(1);
+        expect(status.summary()).toEqual([
+            { name: "view-data", state: "attached" },
+            { name: "popup-menu", state: "degraded" },
+        ]);
+    });
+
+    it("a later attach never un-breaks a degraded patch", () => {
+        const status = new CanvasPatchStatus();
+        status.markDegraded("popup-menu");
+        status.markAttached("popup-menu");
+        expect(status.state("popup-menu")).toBe("degraded");
+    });
+
+    it("fires onFirstDegrade only once per name", () => {
+        const onFirstDegrade = jest.fn();
+        const status = new CanvasPatchStatus(onFirstDegrade);
+        status.markDegraded("a");
+        status.markDegraded("a");
+        status.markDegraded("b");
+        expect(onFirstDegrade).toHaveBeenCalledTimes(2);
+        expect(onFirstDegrade).toHaveBeenCalledWith("a");
+        expect(onFirstDegrade).toHaveBeenCalledWith("b");
+    });
+
+    it("describes the attach/degrade tally", () => {
+        const status = new CanvasPatchStatus();
+        status.markAttached("view-data");
+        status.markAttached("popup-menu");
+        status.markDegraded("view-render-events");
+        expect(status.describe()).toBe("canvas patches: 2 attached, 1 degraded");
+    });
+});

--- a/test/architecture/plugin/canvas/PatchHelper.test.ts
+++ b/test/architecture/plugin/canvas/PatchHelper.test.ts
@@ -1,61 +1,45 @@
 import { describe, it, expect, jest } from "@jest/globals";
+import type { Plugin } from "obsidian";
 import PatchHelper from "architecture/plugin/canvas/extensions/utils/PatchHelper";
 
-/**
- * PatchHelper must fail SOFT: when the target is missing or a required
- * (OverrideExisting) method does not exist, it must NOT throw — it returns null
- * and does not register an uninstaller — so the caller can degrade gracefully
- * if Obsidian's internals change (issue #91).
- */
-describe("PatchHelper.patch (fail-soft)", () => {
-  const fakePlugin = () => ({ register: jest.fn() }) as any;
+/** A minimal fake plugin — PatchHelper only calls `register(uninstaller)`. */
+function fakePlugin(): { plugin: Plugin; registered: unknown[] } {
+    const registered: unknown[] = [];
+    const plugin = { register: (fn: unknown) => registered.push(fn) } as unknown as Plugin;
+    return { plugin, registered };
+}
 
-  it("patches an existing method, returns the object and registers an uninstaller", () => {
-    const plugin = fakePlugin();
-    const target = {
-      greet(this: any): string {
-        return "hi";
-      },
-    };
-
-    const result = PatchHelper.patch(plugin, target, {
-      greet: PatchHelper.OverrideExisting<typeof target, "greet", string>(
-        (next) =>
-          function (this: any, ...args: any[]): string {
-            return "patched:" + next.call(this, ...args);
-          }
-      ),
+describe("PatchHelper — fail-soft patching (#304)", () => {
+    it("returns null for a missing target instead of throwing", () => {
+        const { plugin } = fakePlugin();
+        expect(PatchHelper.patch(plugin, undefined, {})).toBeNull();
     });
 
-    expect(result).toBe(target);
-    expect(target.greet()).toBe("patched:hi");
-    expect(plugin.register).toHaveBeenCalledTimes(1);
-  });
+    it("returns null (no throw) when an OverrideExisting method is absent", () => {
+        const { plugin, registered } = fakePlugin();
+        const target = { other: () => 1 };
+        const result = PatchHelper.patch(plugin, target, {
+            missing: PatchHelper.OverrideExisting<typeof target & { missing: () => number }, "missing", number>(
+                (next) => function (this: unknown) { return next.call(this); }
+            ),
+        } as never);
+        expect(result).toBeNull();
+        expect(registered).toHaveLength(0); // never reached the install step
+    });
 
-  it("returns null and does NOT throw when a required method is missing", () => {
-    const plugin = fakePlugin();
-    const target: { greet?: () => string } = {};
-
-    let result: unknown;
-    expect(() => {
-      result = PatchHelper.patch(plugin, target as any, {
-        greet: PatchHelper.OverrideExisting<any, any, any>(
-          (next: any) =>
-            function (this: any, ...args: any[]) {
-              return next.call(this, ...args);
-            }
-        ),
-      } as any);
-    }).not.toThrow();
-
-    expect(result).toBeNull();
-    expect(plugin.register).not.toHaveBeenCalled();
-  });
-
-  it("returns null when the target is undefined", () => {
-    const plugin = fakePlugin();
-    const result = PatchHelper.patch(plugin, undefined, {});
-    expect(result).toBeNull();
-    expect(plugin.register).not.toHaveBeenCalled();
-  });
+    it("installs a wrapper for an existing method and registers an uninstaller", () => {
+        const { plugin, registered } = fakePlugin();
+        const target = { greet: (name: string) => `hi ${name}` };
+        const spy = jest.fn();
+        const result = PatchHelper.patch(plugin, target, {
+            greet: (next) => function (this: unknown, name: string) {
+                spy();
+                return `[${next.call(this, name)}]`;
+            },
+        } as never);
+        expect(result).toBe(target);
+        expect(registered).toHaveLength(1); // an uninstaller was registered
+        expect(target.greet("a")).toBe("[hi a]");
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
Closes epic #304. The canvas integration monkey-patches internal Obsidian APIs; this makes it degrade gracefully instead of breaking the canvas when those internals change.

- **S1 (already partly present, now consistent)** — `PatchHelper.patch` fails soft: a missing method to override returns `null` (no throw), recorded as **degraded** via the new `CanvasPatchStatus`.
- **S2** — the patched bodies that run inside Obsidian's loops (popup-menu render, the setViewData render/injection events) are wrapped so a runtime throw **falls back to the original** method and marks the patch degraded, rather than corrupting the menu or the save. A single "canvas integration partially unavailable" Notice shows on the first degrade (deduped).
- **S3** — a load-time **self-check** logs the tally, e.g. `ZettelFlow: canvas patches: 2 attached, 0 degraded`.
- **S4** — unit tests for `CanvasPatchStatus` and `PatchHelper` fail-soft; a new `docs/development/canvas-integration.md` documents the design + a **manual-check matrix** to run after an Obsidian update.

Only `CanvasPatcher` monkey-patches — the other canvas extensions ride the events it triggers, so hardening is concentrated here.

`npm run verify` green (979 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)