### PR TITLE
fix(hooks): resolve the add-hook crash (Icon setIcon) + harden the hooks settings (#327)

### DIFF
--- a/src/architecture/components/icon/Icon.tsx
+++ b/src/architecture/components/icon/Icon.tsx
@@ -1,18 +1,24 @@
 import { c } from "architecture/styles/helper";
 import { setIcon } from "obsidian";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { IconProps } from "./model/IconModel";
 
+/**
+ * Renders an Obsidian icon into a span. `setIcon` is invoked from an effect keyed on `name` — **not** an
+ * inline `ref` — so it runs once on mount and only again when the icon changes. An inline ref re-fires on
+ * every parent re-render, re-running `setIcon` into a node that already holds the icon, which can throw
+ * Obsidian's "appendChild: only one element on node is allowed" and unmount the surrounding React tree
+ * (#327). The span is emptied before each set so it never accumulates duplicate glyphs.
+ */
 export function Icon({ name, className }: IconProps) {
-  return (
-    <span
-      data-icon={name}
-      className={`${c("icon")} ${className || ""}`}
-      ref={(c) => {
-        if (c) {
-          setIcon(c, name);
-        }
-      }}
-    />
-  );
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.empty();
+    setIcon(el, name);
+  }, [name]);
+
+  return <span data-icon={name} className={`${c("icon")} ${className || ""}`} ref={ref} />;
 }

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -343,6 +343,8 @@ export default {
     property_hooks_test_result_set: 'Would set:',
     property_hooks_test_result_remove: 'Would remove:',
     property_hooks_test_result_flow: 'Would trigger flow: {0}',
+    property_hooks_render_error: 'The hooks panel hit an error. Your hooks are safe — reload to continue.',
+    property_hooks_reload: 'Reload hooks',
     // Step templates
     step_templates_select_step: 'Select a step',
     step_templates_search_placeholder: 'Search by title, description or author...',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -343,6 +343,8 @@ export default {
     property_hooks_test_result_set: 'Establecería:',
     property_hooks_test_result_remove: 'Eliminaría:',
     property_hooks_test_result_flow: 'Dispararía el flujo: {0}',
+    property_hooks_render_error: 'El panel de hooks tuvo un error. Tus hooks están a salvo — recarga para continuar.',
+    property_hooks_reload: 'Recargar hooks',
     // Plantillas de pasos
     step_templates_select_step: 'Selecciona un paso',
     step_templates_search_placeholder: 'Buscar por título, descripción o autor...',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -24,6 +24,7 @@ import { CommunityTemplatesModal, ManageInstalledTemplatesModal } from "applicat
 import { createRoot } from "react-dom/client";
 import React from "react";
 import { PropertyHooksManager } from "./handlers/hooks/components/PropertyHooksManager";
+import { HookErrorBoundary } from "./handlers/hooks/components/HookErrorBoundary";
 import { aiSettingsGroup } from "./handlers/aiSettingsGroup";
 import { journalSettingsGroup } from "./handlers/journalSettingsGroup";
 import { timelineSettingsGroup } from "./handlers/timelineSettingsGroup";
@@ -612,8 +613,14 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
                                 cls: c("property-hooks-container"),
                             });
                             const root = createRoot(container);
-                            root.render(<PropertyHooksManager plugin={plugin} />);
-                            return () => root.unmount();
+                            root.render(
+                                <HookErrorBoundary>
+                                    <PropertyHooksManager plugin={plugin} />
+                                </HookErrorBoundary>
+                            );
+                            // Defer unmount so React isn't torn down synchronously mid-commit if Obsidian
+                            // tears the row down during an update (avoids "unmount while rendering").
+                            return () => window.setTimeout(() => root.unmount(), 0);
                         },
                     },
                     {

--- a/src/config/modals/handlers/hooks/components/CodeEditor.tsx
+++ b/src/config/modals/handlers/hooks/components/CodeEditor.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from "react";
-import { c } from "architecture";
+import React, { useEffect, useRef, useState } from "react";
+import { c, log } from "architecture";
 import { EditorView } from "codemirror";
 import { dispatchEditor } from "architecture/components/core";
 import { hookAutocomplete } from "../extensions/autoconfiguration/HookAutocomplete";
@@ -9,47 +9,69 @@ interface CodeEditorProps {
   onChange: (value: string) => void;
 }
 
+/**
+ * A CodeMirror editor for a hook script. Its initialization is wrapped defensively (#327 hardening): if
+ * CodeMirror ever fails to mount, we log it and fall back to a plain textarea instead of letting the throw
+ * propagate and unmount the entire hooks settings tree.
+ */
 export const CodeEditor = ({ value, onChange }: CodeEditorProps) => {
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const [failed, setFailed] = useState(false);
 
   useEffect(() => {
-    if (!editorRef.current) return;
+    if (!editorRef.current || failed) return;
 
-    // Clean up previous editor instance if it exists
-    if (viewRef.current) {
-      viewRef.current.destroy();
+    try {
+      if (viewRef.current) {
+        viewRef.current.destroy();
+        viewRef.current = null;
+      }
+      const view = dispatchEditor(
+        editorRef.current,
+        value,
+        (update) => {
+          if (update.docChanged) {
+            onChange(update.state.doc.toString());
+          }
+        },
+        [hookAutocomplete]
+      );
+      viewRef.current = view;
+    } catch (error) {
+      log.error("[PropertyHooks] CodeMirror failed to initialize; falling back to a textarea", error);
+      setFailed(true);
     }
-    const view = dispatchEditor(
-      editorRef.current,
-      value,
-      (update) => {
-        if (update.docChanged) {
-          onChange(update.state.doc.toString());
-        }
-      },
-      [hookAutocomplete]
-    );
-
-    viewRef.current = view;
 
     return () => {
-      view.destroy();
+      try {
+        viewRef.current?.destroy();
+      } catch (error) {
+        log.warn("[PropertyHooks] error disposing the hook editor", error);
+      }
+      viewRef.current = null;
     };
-  }, [editorRef]);
+  }, [failed]);
 
-  // Update editor content if value prop changes
+  // Keep the editor content in sync when the value prop changes externally.
   useEffect(() => {
-    if (viewRef.current && value !== viewRef.current.state.doc.toString()) {
-      viewRef.current.dispatch({
-        changes: {
-          from: 0,
-          to: viewRef.current.state.doc.length,
-          insert: value,
-        },
-      });
+    const view = viewRef.current;
+    if (view && value !== view.state.doc.toString()) {
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: value } });
     }
   }, [value]);
+
+  if (failed) {
+    return (
+      <textarea
+        className={c("property-hook-text-input", "property-hook-script-fallback")}
+        value={value}
+        spellCheck={false}
+        rows={8}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
 
   return <div className={c("code-editor-container")} ref={editorRef} />;
 };

--- a/src/config/modals/handlers/hooks/components/HookErrorBoundary.tsx
+++ b/src/config/modals/handlers/hooks/components/HookErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { c, log } from "architecture";
+import { t } from "architecture/lang";
+
+interface HookErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface HookErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Guards the property-hooks React tree (#327 hardening). React unmounts an entire root when a render or
+ * effect throws — which is exactly the "all my hooks disappeared until I reopened settings" symptom. This
+ * boundary catches any such throw, **logs the real error** (so it is diagnosable), and shows a recoverable
+ * fallback instead of a blank panel, so a single bad hook can never wipe the whole configuration UI.
+ */
+export class HookErrorBoundary extends React.Component<HookErrorBoundaryProps, HookErrorBoundaryState> {
+  constructor(props: HookErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): HookErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    log.error("[PropertyHooks] the hooks settings UI crashed while rendering", error, info?.componentStack);
+  }
+
+  private reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      return (
+        <div className={c("property-hooks-error")}>
+          <div className={c("property-hooks-error-title")}>{t("property_hooks_render_error")}</div>
+          <div className={c("property-hooks-error-detail")}>{this.state.error.message}</div>
+          <button className={c("property-hooks-btn", "property-hooks-btn--cta")} onClick={this.reset}>
+            {t("property_hooks_reload")}
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/config/modals/handlers/hooks/components/PropertyHooksManager.tsx
+++ b/src/config/modals/handlers/hooks/components/PropertyHooksManager.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { c } from "architecture";
+import { c, log } from "architecture";
 import { t } from "architecture/lang";
 import { Keyboard, ObsidianNativeTypesManager } from "architecture/plugin";
 import ZettelFlow from "main";
 import { PropertyHookSettings } from "config/typing";
-import { log } from "architecture";
 import { Icon } from "architecture/components/icon";
 import {
   DndContext,
@@ -14,46 +13,38 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  arrayMove,
-} from "@dnd-kit/sortable";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { PropertyHookAccordion } from "./PropertyHookAccordion";
+import { HookErrorBoundary } from "./HookErrorBoundary";
 import { Search } from "architecture/components/core";
 import { ObsidianTypesModal } from "config";
 import { VaultHooks, HookDryRunResult } from "hooks/VaultHooks";
+import {
+  HookItem,
+  toItems,
+  toRecord,
+  addHook,
+  updateHook as updateHookItem,
+  deleteHook as deleteHookItem,
+  reorderHooks,
+} from "../hookItems";
 
 interface PropertyHooksManagerProps {
   plugin: ZettelFlow;
 }
 
-/** One ordered hook: the property it fires on + its settings. The array *is* the source of truth. */
-interface HookItem {
-  property: string;
-  settings: PropertyHookSettings;
-}
-
-function toItems(record: Record<string, PropertyHookSettings> | undefined): HookItem[] {
-  return Object.entries(record || {}).map(([property, settings]) => ({
-    property,
-    settings: settings ?? { script: "" },
-  }));
-}
-
 /**
  * The property-hooks manager (#327). A single ordered `items` array is the source of truth — the old
- * split `hooks`/`hookOrder` state could desync and blank the list. Adding a hook appends + auto-opens
- * it; every mutation persists atomically. Each hook can be paused, described, gated by a condition, and
- * dry-run against the active note.
+ * split `hooks`/`hookOrder` state could desync and blank the list. All mutations go through the pure,
+ * unit-tested {@link hookItems} operations; adding a hook appends + auto-opens it; every mutation persists
+ * atomically and defensively. Wrapped in a `HookErrorBoundary` at the mount site so a render throw can
+ * never silently wipe the panel.
  */
 export const PropertyHooksManager: React.FC<PropertyHooksManagerProps> = ({
   plugin,
 }) => {
-  const [items, setItems] = useState<HookItem[]>(() =>
-    toItems(plugin.settings.hooks.properties)
-  );
+  const [items, setItems] = useState<HookItem[]>(() => toItems(plugin.settings.hooks.properties));
   const [propertyTypes, setPropertyTypes] = useState<Record<string, string>>({});
   const [isAddingHook, setIsAddingHook] = useState(false);
   const [selectedNewProperty, setSelectedNewProperty] = useState("");
@@ -65,36 +56,42 @@ export const PropertyHooksManager: React.FC<PropertyHooksManagerProps> = ({
 
   useEffect(() => {
     const loadPropertyTypes = async () => {
-      const types = await ObsidianNativeTypesManager.getAllTypes();
-      setPropertyTypes(types);
+      try {
+        setPropertyTypes(await ObsidianNativeTypesManager.getAllTypes());
+      } catch (error) {
+        log.error("[PropertyHooks] could not load property types", error);
+        setPropertyTypes({});
+      }
     };
     void loadPropertyTypes();
   }, []);
 
-  /** The single write path: update state + settings + persist together, so they can never desync. */
+  /** The single write path: update React state + persist, atomically and defensively. */
   const persist = (next: HookItem[]) => {
     setItems(next);
-    const record: Record<string, PropertyHookSettings> = {};
-    next.forEach((item) => (record[item.property] = item.settings));
-    plugin.settings.hooks.properties = record;
-    void plugin.saveSettings();
-    log.debug("Hooks saved:", record);
+    try {
+      plugin.settings.hooks.properties = toRecord(next);
+      void plugin.saveSettings();
+      log.debug("[PropertyHooks] saved", next.length, "hook(s)");
+    } catch (error) {
+      log.error("[PropertyHooks] failed to persist hooks", error);
+    }
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const oldIndex = items.findIndex((i) => i.property === active.id);
-    const newIndex = items.findIndex((i) => i.property === over.id);
-    if (oldIndex !== -1 && newIndex !== -1) {
-      persist(arrayMove(items, oldIndex, newIndex));
-    }
+    const from = items.findIndex((i) => i.property === active.id);
+    const to = items.findIndex((i) => i.property === over.id);
+    const next = reorderHooks(items, from, to);
+    if (next !== items) persist(next);
   };
 
   const handleAddHookConfirm = () => {
     const property = selectedNewProperty;
-    if (!property || items.some((i) => i.property === property)) return;
-    persist([...items, { property, settings: { script: "", enabled: true } }]);
+    const next = addHook(items, property);
+    if (next === items) return; // blank or duplicate — nothing added
+    persist(next);
     setNewlyAdded(property);
     setIsAddingHook(false);
     setSelectedNewProperty("");
@@ -106,15 +103,11 @@ export const PropertyHooksManager: React.FC<PropertyHooksManagerProps> = ({
   };
 
   const updateHook = (property: string, patch: Partial<PropertyHookSettings>) => {
-    persist(
-      items.map((i) =>
-        i.property === property ? { property, settings: { ...i.settings, ...patch } } : i
-      )
-    );
+    persist(updateHookItem(items, property, patch));
   };
 
   const deleteHook = (property: string) => {
-    persist(items.filter((i) => i.property !== property));
+    persist(deleteHookItem(items, property));
     if (newlyAdded === property) setNewlyAdded(null);
   };
 
@@ -206,16 +199,18 @@ export const PropertyHooksManager: React.FC<PropertyHooksManagerProps> = ({
           >
             <div className={c("property-hooks-list")}>
               {items.map((item) => (
-                <PropertyHookAccordion
-                  key={item.property}
-                  property={item.property}
-                  propertyType={propertyTypes[item.property] || "unknown"}
-                  settings={item.settings}
-                  defaultOpen={item.property === newlyAdded}
-                  onChange={(patch) => updateHook(item.property, patch)}
-                  onDelete={() => deleteHook(item.property)}
-                  onTest={(settings) => testHook(item.property, settings)}
-                />
+                // Per-row boundary: a crash in one hook row can never blank the others (#327 hardening).
+                <HookErrorBoundary key={item.property}>
+                  <PropertyHookAccordion
+                    property={item.property}
+                    propertyType={propertyTypes[item.property] || "unknown"}
+                    settings={item.settings}
+                    defaultOpen={item.property === newlyAdded}
+                    onChange={(patch) => updateHook(item.property, patch)}
+                    onDelete={() => deleteHook(item.property)}
+                    onTest={(settings) => testHook(item.property, settings)}
+                  />
+                </HookErrorBoundary>
               ))}
             </div>
           </SortableContext>

--- a/src/config/modals/handlers/hooks/hookItems.ts
+++ b/src/config/modals/handlers/hooks/hookItems.ts
@@ -1,0 +1,53 @@
+import type { PropertyHookSettings } from "config/typing";
+
+/**
+ * Pure, framework-free operations over the ordered property-hook list (#327, hardened for the
+ * add-hook regression). The React manager holds `HookItem[]` as its single source of truth and mutates
+ * it only through these functions, so the add/edit/delete/reorder logic is deterministic and unit-tested
+ * independently of React or the DOM. Every function returns a **new** array (or the same reference when
+ * nothing changes) and never mutates its input.
+ */
+export interface HookItem {
+    property: string;
+    settings: PropertyHookSettings;
+}
+
+/** Build the ordered list from the persisted record, tolerating a missing/mangled entry. */
+export function toItems(record: Record<string, PropertyHookSettings> | undefined): HookItem[] {
+    return Object.entries(record ?? {}).map(([property, settings]) => ({
+        property,
+        settings: settings ?? { script: "" },
+    }));
+}
+
+/** Serialize the ordered list back to the persisted record shape. */
+export function toRecord(items: HookItem[]): Record<string, PropertyHookSettings> {
+    const record: Record<string, PropertyHookSettings> = {};
+    for (const item of items) record[item.property] = item.settings;
+    return record;
+}
+
+/** Append a hook for `property`. No-op (same reference) for a blank or already-present property. */
+export function addHook(items: HookItem[], property: string): HookItem[] {
+    if (!property || items.some((i) => i.property === property)) return items;
+    return [...items, { property, settings: { script: "", enabled: true } }];
+}
+
+/** Patch one hook's settings, preserving order and the other hooks. */
+export function updateHook(items: HookItem[], property: string, patch: Partial<PropertyHookSettings>): HookItem[] {
+    return items.map((i) => (i.property === property ? { property, settings: { ...i.settings, ...patch } } : i));
+}
+
+/** Remove the hook for `property`. */
+export function deleteHook(items: HookItem[], property: string): HookItem[] {
+    return items.filter((i) => i.property !== property);
+}
+
+/** Move the hook at `from` to `to` (clamped/no-op for out-of-range or equal indices). */
+export function reorderHooks(items: HookItem[], from: number, to: number): HookItem[] {
+    if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) return items;
+    const next = [...items];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    return next;
+}

--- a/src/styles/components/hooksConfig.scss
+++ b/src/styles/components/hooksConfig.scss
@@ -604,3 +604,33 @@
     border-left-color: var(--text-error);
     color: var(--text-error);
 }
+
+/* Error boundary fallback + textarea fallback (#327 hardening) */
+.zettelkasten-flow__property-hooks-error {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    background-color: var(--background-secondary);
+    border-left: 3px solid var(--text-error);
+}
+
+.zettelkasten-flow__property-hooks-error-title {
+    font-weight: var(--font-semibold);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__property-hooks-error-detail {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    font-family: var(--font-monospace);
+    word-break: break-word;
+}
+
+.zettelkasten-flow__property-hook-script-fallback {
+    width: 100%;
+    min-height: 8rem;
+    resize: vertical;
+}

--- a/test/config/hooks/hookItems.test.ts
+++ b/test/config/hooks/hookItems.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  toItems,
+  toRecord,
+  addHook,
+  updateHook,
+  deleteHook,
+  reorderHooks,
+  type HookItem,
+} from "config/modals/handlers/hooks/hookItems";
+
+const base: HookItem[] = [
+  { property: "status", settings: { script: "a" } },
+  { property: "rating", settings: { script: "b" } },
+];
+
+describe("hookItems — the add-hook regression is fixed at the logic level (#327)", () => {
+  it("addHook appends a new, enabled hook without touching the others", () => {
+    const next = addHook(base, "due");
+    expect(next).toHaveLength(3);
+    expect(next.map((i) => i.property)).toEqual(["status", "rating", "due"]);
+    expect(next[2].settings).toEqual({ script: "", enabled: true });
+    // existing entries preserved by reference (no needless remount / no data loss)
+    expect(next[0]).toBe(base[0]);
+    expect(next[1]).toBe(base[1]);
+  });
+
+  it("addHook is a no-op (same reference) for a duplicate or blank property", () => {
+    expect(addHook(base, "status")).toBe(base);
+    expect(addHook(base, "")).toBe(base);
+  });
+
+  it("round-trips through the persisted record shape, preserving order + settings", () => {
+    const record = toRecord(base);
+    expect(record).toEqual({ status: { script: "a" }, rating: { script: "b" } });
+    expect(toItems(record).map((i) => i.property)).toEqual(["status", "rating"]);
+    expect(toItems(undefined)).toEqual([]);
+  });
+
+  it("toItems tolerates a missing settings entry", () => {
+    const items = toItems({ ghost: undefined as never });
+    expect(items[0].settings).toEqual({ script: "" });
+  });
+
+  it("updateHook patches one hook's settings and leaves the rest", () => {
+    const next = updateHook(base, "status", { enabled: false, condition: "event.newValue === 'done'" });
+    expect(next[0].settings).toEqual({ script: "a", enabled: false, condition: "event.newValue === 'done'" });
+    expect(next[1]).toBe(base[1]);
+  });
+
+  it("deleteHook removes exactly the named hook", () => {
+    expect(deleteHook(base, "status").map((i) => i.property)).toEqual(["rating"]);
+    expect(deleteHook(base, "missing")).toHaveLength(2);
+  });
+
+  it("reorderHooks moves an item and no-ops out of range", () => {
+    expect(reorderHooks(base, 0, 1).map((i) => i.property)).toEqual(["rating", "status"]);
+    expect(reorderHooks(base, 0, 0)).toBe(base);
+    expect(reorderHooks(base, -1, 5)).toBe(base);
+  });
+});

--- a/test/config/hooks/propertyHooks.test.ts
+++ b/test/config/hooks/propertyHooks.test.ts
@@ -10,6 +10,8 @@ const MANAGER = read("src", "config", "modals", "handlers", "hooks", "components
 const ACCORDION = read("src", "config", "modals", "handlers", "hooks", "components", "PropertyHookAccordion.tsx");
 const RUNTIME = read("src", "hooks", "VaultHooks.ts");
 const TYPING = read("src", "config", "typing.ts");
+const SETTINGS_TAB = read("src", "config", "modals", "ZettelFlowSettingsTab.tsx");
+const CODE_EDITOR = read("src", "config", "modals", "handlers", "hooks", "components", "CodeEditor.tsx");
 
 /**
  * Property-hooks manager invariants (#327). These lock the fixes so they can't regress: a single ordered
@@ -23,16 +25,33 @@ describe("property hooks manager (#327 S1)", () => {
         expect(MANAGER).toContain("HookItem[]");
     });
 
-    it("persists atomically (state + settings + save in one path) and guards missing entries", () => {
+    it("persists atomically through one guarded write path, via the pure ops", () => {
         expect(MANAGER).toContain("const persist = (next: HookItem[])");
-        expect(MANAGER).toContain("plugin.settings.hooks.properties = record");
+        expect(MANAGER).toContain("plugin.settings.hooks.properties = toRecord(next)");
         expect(MANAGER).toContain("plugin.saveSettings()");
-        expect(MANAGER).toMatch(/settings: settings \?\? \{ script: "" \}/); // guarded mapping
+        expect(MANAGER).toMatch(/from "\.\.\/hookItems"/); // mutations delegated to the tested pure ops
     });
 
     it("appends and auto-opens a newly added hook", () => {
         expect(MANAGER).toContain("setNewlyAdded");
         expect(MANAGER).toContain("defaultOpen={item.property === newlyAdded}");
+    });
+});
+
+describe("property hooks resilience (#327 hardening)", () => {
+    it("wraps the manager in an error boundary so a render throw can't blank the panel", () => {
+        expect(SETTINGS_TAB).toContain("HookErrorBoundary");
+        expect(SETTINGS_TAB).toMatch(/<HookErrorBoundary>[\s\S]*PropertyHooksManager[\s\S]*<\/HookErrorBoundary>/);
+    });
+
+    it("wraps each hook row in its own boundary so one bad row can't blank the others", () => {
+        expect(MANAGER).toMatch(/<HookErrorBoundary key=\{item\.property\}>[\s\S]*PropertyHookAccordion/);
+    });
+
+    it("hardens the CodeMirror editor with a try/catch + textarea fallback", () => {
+        expect(CODE_EDITOR).toContain("try {");
+        expect(CODE_EDITOR).toContain("setFailed(true)");
+        expect(CODE_EDITOR).toContain("textarea");
     });
 });
 


### PR DESCRIPTION
## Fix the add-hook crash at its root + harden the hooks settings (#327)

A user reported the add-hook bug **still reproduced** after the initial fix. With an error boundary in
place, the real error surfaced: **`appendChild: only one element on node is allowed`** — Obsidian's DOM
guard firing during the hooks render and unmounting the whole React root (the "all my hooks disappear
until I reopen settings" symptom).

### Root cause
The shared `Icon` component ran `setIcon` from an **inline `ref`**, which React re-invokes on *every*
re-render. The hooks panel re-renders on the Add interaction, so `setIcon` kept firing into an icon node
that already held its glyph → Obsidian's single-child guard threw → React unmounted the tree. This is why
it hit the hooks panel specifically (it re-renders far more than other settings) and why it survived the
earlier state-logic rewrites (they never touched `Icon`).

### Fix
- **`Icon` now runs `setIcon` from an effect keyed on `name`** (once on mount, again only when the icon
  changes), emptying the node first — so it can never double-append. Fixes the crash app-wide.

### Hardening (defense in depth, so a render throw can never silently blank the panel again)
- **Per-row + top-level error boundaries** — a throw in one hook row shows a small fallback, never blanks
  the others; the real error (with component stack) is logged.
- **Hardened CodeMirror mount** — `CodeEditor` catches an init failure and falls back to a textarea.
- **Pure, unit-tested list ops** (`hookItems.ts` + `hookItems.test.ts`) — add/update/delete/reorder/
  round-trip proven correct independent of React.
- Guarded persistence + async; deferred unmount.

### Quality
`npm run verify` green (1051 tests); typecheck + oxlint + eslint-obsidian clean; production build OK; en/es
parity kept.

Part of #327.
