### PR TITLE
fix(hooks): resolve the add-hook crash — Search called createEl on the document (#327)

### DIFF
--- a/src/application/community/shareSystem.ts
+++ b/src/application/community/shareSystem.ts
@@ -51,7 +51,8 @@ export async function buildActiveCanvasTemplate(plugin: ZettelFlow): Promise<Act
 export function downloadTemplate(name: string, json: string): void {
     const blob = new Blob([json], { type: "application/json" });
     const url = URL.createObjectURL(blob);
-    const anchor = activeDocument.createEl("a");
+    // Native createElement (detached) — Obsidian's createEl would append to the document and throw.
+    const anchor = activeDocument.createElement("a");
     anchor.href = url;
     anchor.setAttr("download", `${name}.zftemplate`);
     anchor.click();

--- a/src/architecture/components/core/search/Search.tsx
+++ b/src/architecture/components/core/search/Search.tsx
@@ -10,8 +10,10 @@ export function Search<T>(props: SearchType<T>) {
   // Refs
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  // Initial mockup of HTMLUListElement
-  const listRef = useRef<HTMLUListElement>(activeDocument.createEl("ul"));
+  // Initial detached placeholder. Use native `createElement` here — Obsidian's `createEl` helper appends
+  // the node to its receiver, so building a "ul" on the document appended a second element to the document
+  // and threw "appendChild: Only one element on document allowed", unmounting the React tree (#327).
+  const listRef = useRef<HTMLUListElement>(activeDocument.createElement("ul"));
   // States
   const [value, setValue] = useState<string>("");
   const [selectedValue, setSelectedValue] = useState<string>("");

--- a/src/starters/zcomponents/TemplateExportComponent.ts
+++ b/src/starters/zcomponents/TemplateExportComponent.ts
@@ -79,7 +79,8 @@ export class TemplateExportComponent extends PluginComponent {
         const json = JSON.stringify(template, null, 2);
         const blob = new Blob([json], { type: "application/json" });
         const url = URL.createObjectURL(blob);
-        const anchor = activeDocument.createEl("a");
+        // Native createElement (detached) — Obsidian's createEl would append to the document and throw.
+        const anchor = activeDocument.createElement("a");
         anchor.href = url;
         anchor.setAttr("download", `${name}.zftemplate`);
         anchor.click();
@@ -88,7 +89,7 @@ export class TemplateExportComponent extends PluginComponent {
     }
 
     private pickAndImport(): void {
-        const input = activeDocument.createEl("input");
+        const input = activeDocument.createElement("input");
         input.type = "file";
         input.accept = ".zftemplate";
         input.addEventListener("change", () => {

--- a/test/architecture/noDocumentCreateEl.test.ts
+++ b/test/architecture/noDocumentCreateEl.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "@jest/globals";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+// test/architecture → 2 ups → repo root
+const SRC = join(__dirname, "..", "..", "src");
+
+function collect(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collect(full));
+    else if (/\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Regression guard (#327). Obsidian's `createEl` **appends the new element to its receiver**. Calling it
+ * on `document`/`activeDocument` therefore appends a second element to the document, throwing
+ * "appendChild: Only one element on document allowed" and unmounting any surrounding React tree — the
+ * add-hook crash. Use native `document.createElement(...)` (detached) instead. This test fails if the
+ * anti-pattern reappears anywhere in `src`.
+ */
+describe("no createEl on the document node (#327)", () => {
+  it("never calls (active)document.createEl(...)", () => {
+    const offenders: string[] = [];
+    for (const file of collect(SRC)) {
+      const text = readFileSync(file, "utf8");
+      if (/\b(activeDocument|document)\.createEl\s*\(/.test(text)) {
+        offenders.push(file.replace(SRC, "src"));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Fix the real add-hook crash: `Search` called `createEl` on the document (#327)

The precise error a user captured — `Failed to execute 'appendChild' on 'Node': Only one element on
document allowed` — pinpointed the true root cause (the earlier Icon/state fixes were real improvements
but not the cause).

### Root cause
Clicking **Add hook** renders the shared `Search` component, whose list ref was initialized with
`activeDocument.createEl("ul")`. Obsidian's `createEl` **appends the created node to its receiver** — here
the *document* — so it tried to add a second element to the document (which allows only one, `<html>`),
threw, and React unmounted the hooks tree.

### Fix
- `Search` now uses native `activeDocument.createElement("ul")` — a **detached** node that is never
  appended. One-line, conclusive fix.
- Fixed the identical latent bug in the `.zftemplate` **export/import** download anchors
  (`shareSystem.ts`, `TemplateExportComponent.ts`) — they'd have thrown the same way.
- **Guardrail test** `test/architecture/noDocumentCreateEl.test.ts` fails if `(active)document.createEl(...)`
  reappears anywhere in `src`.

The defense-in-depth from the prior PR remains (error boundaries, hardened CodeMirror editor, pure
unit-tested list ops), so a render throw can never silently blank the panel again.

### Quality
`npm run verify` green; typecheck + oxlint + eslint-obsidian clean; production build OK.

Fixes the add-hook crash reported on #327.
