### PR TITLE
fix(scope): auto-exclude ZettelFlow system folders + honour scope in resurface

### DIFF
--- a/docs/development/knowledge-scope.md
+++ b/docs/development/knowledge-scope.md
@@ -26,9 +26,16 @@ Each line is a **folder-boundary "starts with"** match. `templates` excludes `te
 trailing slashes and back-slashes are normalised, blanks and duplicates dropped. Editing the list
 rebuilds the index automatically.
 
-Suggested entries: your template folder, and ZettelFlow's own scaffolding (`_ZettelFlow`,
-`_ZettelFlowMdTemplates`) if you don't consider those notes part of your slip-box. Nothing is
-excluded by default — you opt in.
+Suggested entries: your template folder, and any other tooling you don't consider part of your
+slip-box.
+
+## System folders are excluded automatically
+
+ZettelFlow's **own machinery** is never part of your thinking, so it is excluded **automatically** —
+you don't have to list it. That covers the flows folder (`foldersFlowsPath`, default
+`_ZettelFlow/folders`), the hook-flow folder (`hooks.folderFlowPath`, default `_ZettelFlow/hooks`)
+and the `zf` JS library folder (`jsLibraryFolderPath`). Their step notes and scripts therefore never
+get indexed, cultivated, or counted anywhere. Your manual list is merged on top of these.
 
 ## Notes
 
@@ -39,6 +46,7 @@ excluded by default — you opt in.
 ## Architecture
 
 The pure predicate lives in `architecture/knowledge/scope/knowledgeScope.ts`
-(`isPathExcluded` / `normalizeExcludedPaths`), applied at the single boundary in
-`KnowledgeIndex` (`build` / `upsert` / `enrichInlineRelations` / `onRename`). Settings:
-`ZettelFlowSettings.excludedPaths`.
+(`isPathExcluded` / `normalizeExcludedPaths`), with `scopeExcludedPaths(settings)` merging the user's
+`excludedPaths` with the auto-excluded system folders. It is applied at the single boundary in
+`KnowledgeIndex.inScope` (`build` / `upsert` / `enrichInlineRelations` / `onRename`). Settings:
+`ZettelFlowSettings.excludedPaths` (+ `foldersFlowsPath`, `hooks.folderFlowPath`, `jsLibraryFolderPath`).

--- a/src/architecture/components/core/resurface/resurfaceInputs.ts
+++ b/src/architecture/components/core/resurface/resurfaceInputs.ts
@@ -1,5 +1,6 @@
 import { App, CachedMetadata, TFile, getAllTags } from "obsidian";
 import { ActiveNoteSignals, ResurfaceCandidate } from "application/notes/resurfaceRanking";
+import { KnowledgeIndex } from "architecture/knowledge";
 
 /**
  * Impure gathering for connection resurfacing — turns Obsidian's metadata cache into the pure
@@ -66,14 +67,19 @@ function buildResurfaceInputsUncached(app: App): ResurfaceInputs {
     const backlinkIndex = buildBacklinkIndex(resolved);
     const cache = app.metadataCache;
 
-    const candidates: ResurfaceCandidate[] = app.vault.getMarkdownFiles().map((file) => ({
-        path: file.path,
-        basename: file.basename,
-        tags: fileTags(cache.getFileCache(file)),
-        outgoingLinks: Object.keys(resolved[file.path] ?? {}),
-        backlinks: backlinkIndex.get(file.path) ?? [],
-        lastOpenedOrModified: file.stat.mtime,
-    }));
+    // Honour knowledge scope (#311): excluded/system notes must never be resurfaced as "forgotten".
+    const index = KnowledgeIndex.getInstance();
+    const candidates: ResurfaceCandidate[] = app.vault
+        .getMarkdownFiles()
+        .filter((file) => index.inScope(file.path))
+        .map((file) => ({
+            path: file.path,
+            basename: file.basename,
+            tags: fileTags(cache.getFileCache(file)),
+            outgoingLinks: Object.keys(resolved[file.path] ?? {}),
+            backlinks: backlinkIndex.get(file.path) ?? [],
+            lastOpenedOrModified: file.stat.mtime,
+        }));
 
     const buildActiveSignals = (file: TFile): ActiveNoteSignals => ({
         path: file.path,

--- a/src/architecture/knowledge/KnowledgeIndex.ts
+++ b/src/architecture/knowledge/KnowledgeIndex.ts
@@ -8,7 +8,7 @@ import { parseInlineFields } from "./parse/inlineFields";
 import { extractWikilinks, isSemanticRelationType } from "./relations";
 import { isClaimOrSourceKey, isSourceKey } from "./claims";
 import { detectDevelopmentEvents } from "./journal/developmentEvents";
-import { isPathExcluded } from "./scope/knowledgeScope";
+import { isPathExcluded, scopeExcludedPaths, type ScopeSettings } from "./scope/knowledgeScope";
 import { DevelopmentJournal } from "architecture/plugin/journal/DevelopmentJournal";
 import { ConceptualTimeline } from "architecture/plugin/timeline/ConceptualTimeline";
 
@@ -62,16 +62,21 @@ export class KnowledgeIndex {
         this.schemas = { ...this.schemas, ...schemas };
     }
 
-    /** The configured out-of-scope path prefixes (#311) — notes here are not part of the thinking system. */
+    /**
+     * The out-of-scope path prefixes (#311, extended): the user's `excludedPaths` **plus** ZettelFlow's
+     * own managed system folders (flows, hook flows, JS library), which are auto-excluded so system notes
+     * are never treated as knowledge.
+     */
     private excludedPaths(): readonly string[] {
         try {
-            return ObsidianApi.getOwnPlugin()?.settings?.excludedPaths ?? [];
+            const settings = ObsidianApi.getOwnPlugin()?.settings as ScopeSettings | undefined;
+            return settings ? scopeExcludedPaths(settings) : [];
         } catch {
             return []; // before settings are wired (or in tests), nothing is excluded
         }
     }
 
-    /** Whether a note counts as knowledge (#311): everything except the configured excluded paths. */
+    /** Whether a note counts as knowledge (#311): everything except the excluded (user + system) paths. */
     public inScope(path: string): boolean {
         return !isPathExcluded(path, this.excludedPaths());
     }

--- a/src/architecture/knowledge/scope/knowledgeScope.ts
+++ b/src/architecture/knowledge/scope/knowledgeScope.ts
@@ -33,6 +33,34 @@ export function isPathExcluded(path: string, prefixes: readonly string[]): boole
     return false;
 }
 
+/**
+ * The scope-relevant slice of the plugin settings (kept minimal so this module stays config-free). The
+ * folders here are ZettelFlow's own machinery — flow canvases and their step notes, hook flow scripts, the
+ * JS library — never the user's own thinking, so they are excluded automatically.
+ */
+export interface ScopeSettings {
+    excludedPaths?: readonly string[];
+    /** Folder where folder-automation flow canvases (and their step notes) live. */
+    foldersFlowsPath?: string;
+    /** Folder holding the user's `zf` JS library. */
+    jsLibraryFolderPath?: string;
+    /** Folder for hook-triggered flow canvases. */
+    hooks?: { folderFlowPath?: string };
+}
+
+/**
+ * Every excluded prefix that defines the thinking system's scope (#311, extended): the user's own
+ * excluded paths **plus** ZettelFlow's managed system folders, which are auto-excluded so system notes
+ * are never indexed, cultivated, or counted anywhere. Deterministic and normalised.
+ */
+export function scopeExcludedPaths(settings: ScopeSettings): string[] {
+    const system = [settings.foldersFlowsPath, settings.jsLibraryFolderPath, settings.hooks?.folderFlowPath];
+    return normalizeExcludedPaths([
+        ...(settings.excludedPaths ?? []),
+        ...system.filter((p): p is string => typeof p === "string"),
+    ]);
+}
+
 /** Split a textarea value (one prefix per line) into a normalised prefix list. */
 export function parseExcludedPathsInput(text: string): string[] {
     return normalizeExcludedPaths(text.split(/\r?\n/));

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -728,7 +728,7 @@ export default {
     settings_scope_heading: 'Knowledge scope',
     settings_scope_intro: 'Keep config, templates and other vault tooling out of the thinking system. Notes under an excluded path never enter the index, so they drop out of every mechanism at once — graph, health, discovery, cultivate and home.',
     settings_excluded_paths_name: 'Excluded paths',
-    settings_excluded_paths_desc: 'One folder path per line. Every note whose path starts with it is excluded (folder-boundary match), e.g. templates or _ZettelFlow.',
+    settings_excluded_paths_desc: 'One folder path per line. Every note whose path starts with it is excluded (folder-boundary match), e.g. templates or _ZettelFlow. ZettelFlow\'s own system folders (flows, hooks, JS library) are always excluded automatically.',
     settings_excluded_paths_placeholder: 'templates\n_ZettelFlow',
     settings_lifecycle_heading: 'Knowledge lifecycle',
     settings_lifecycle_intro: 'Classify notes by lifecycle state and change their phase with a validated command. The state lives in plain, configurable frontmatter — no lock-in.',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -728,7 +728,7 @@ export default {
     settings_scope_heading: 'Ámbito del conocimiento',
     settings_scope_intro: 'Mantén la configuración, plantillas y otras herramientas del vault fuera del sistema de pensamiento. Las notas bajo una ruta excluida no entran en el índice, así que desaparecen de todos los mecanismos a la vez: grafo, salud, descubrimiento, cultivar e inicio.',
     settings_excluded_paths_name: 'Rutas excluidas',
-    settings_excluded_paths_desc: 'Una ruta de carpeta por línea. Se excluye toda nota cuya ruta empiece por ella (coincidencia a nivel de carpeta), p. ej. templates o _ZettelFlow.',
+    settings_excluded_paths_desc: 'Una ruta de carpeta por línea. Se excluye toda nota cuya ruta empiece por ella (coincidencia a nivel de carpeta), p. ej. templates o _ZettelFlow. Las carpetas propias de ZettelFlow (flujos, hooks, librería JS) se excluyen siempre de forma automática.',
     settings_excluded_paths_placeholder: 'templates\n_ZettelFlow',
     settings_lifecycle_heading: 'Ciclo de vida del conocimiento',
     settings_lifecycle_intro: 'Clasifica las notas por su estado del ciclo de vida y cambia su fase con un comando validado. El estado vive en frontmatter plano y configurable, sin lock-in.',

--- a/test/architecture/knowledge/scope/knowledgeScope.test.ts
+++ b/test/architecture/knowledge/scope/knowledgeScope.test.ts
@@ -4,9 +4,29 @@ import {
     isPathExcluded,
     parseExcludedPathsInput,
     excludedPathsToText,
+    scopeExcludedPaths,
 } from "architecture/knowledge/scope/knowledgeScope";
 
 describe("knowledgeScope (#311)", () => {
+    it("scopeExcludedPaths auto-excludes ZettelFlow's system folders alongside the user list", () => {
+        const paths = scopeExcludedPaths({
+            excludedPaths: ["templates"],
+            foldersFlowsPath: "_ZettelFlow/folders",
+            jsLibraryFolderPath: "_ZettelFlow/scripts",
+            hooks: { folderFlowPath: "_ZettelFlow/hooks" },
+        });
+        expect(paths).toEqual(["templates", "_ZettelFlow/folders", "_ZettelFlow/scripts", "_ZettelFlow/hooks"]);
+        // A flow step note and a hook script are out of scope even though the user never listed them.
+        expect(isPathExcluded("_ZettelFlow/folders/step.md", paths)).toBe(true);
+        expect(isPathExcluded("_ZettelFlow/hooks/on-create.canvas", paths)).toBe(true);
+        expect(isPathExcluded("ideas/real-note.md", paths)).toBe(false);
+    });
+
+    it("scopeExcludedPaths tolerates missing/blank system settings", () => {
+        expect(scopeExcludedPaths({})).toEqual([]);
+        expect(scopeExcludedPaths({ excludedPaths: ["a"], foldersFlowsPath: "", jsLibraryFolderPath: undefined })).toEqual(["a"]);
+    });
+
     it("normalises prefixes (slashes, trim, dedupe, drop empty)", () => {
         expect(normalizeExcludedPaths(["  templates/ ", "\\config\\", "templates", "", "  "])).toEqual([
             "templates",


### PR DESCRIPTION
## Knowledge scope: auto-exclude ZettelFlow's system folders + fix the resurface leak

A user noted that Cultivate (and everything) was still considering **system notes**. Two changes:

### 1. Auto-exclude ZettelFlow's own system folders
`scopeExcludedPaths(settings)` now merges the user's `excludedPaths` with ZettelFlow's managed folders —
`foldersFlowsPath` (`_ZettelFlow/folders`), `hooks.folderFlowPath` (`_ZettelFlow/hooks`) and
`jsLibraryFolderPath`. `KnowledgeIndex.inScope` uses it, so flow step notes and hook scripts are **never
indexed, cultivated, or counted** anywhere — no manual listing required. Because the filter runs at the
single index boundary, every model-reading feature (Cultivate, Home, Health, Discovery, graph, journal,
timeline) honours it at once.

### 2. Fix the "Forgotten"/resurface leak (the extra case the user asked me to look for)
`buildResurfaceInputs` built candidates from **all** markdown files, bypassing scope — so excluded/system
notes could be resurfaced as "forgotten". It now filters by `KnowledgeIndex.inScope`.

### Docs / UX / tests
- Settings hint + `docs/development/knowledge-scope.md` document the automatic system-folder exclusion.
- `knowledgeScope.test.ts` covers `scopeExcludedPaths` (merge + missing/blank fields); resurface + scope
  suites green.
- `npm run verify` green; production build OK; en/es parity kept.
