### PR TITLE
docs(manifesto): cognitive agency as the meta-principle + constitution §XII

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ each step's **actions**. It's a monorepo:
   **fully static**: `docs/main_template.json` + `docs/systems/*.zftemplate` served over GitHub raw
   (no backend — #294).
 
-Current version: `2.12.0`, `minAppVersion 1.13.1`, desktop **and** mobile (`isDesktopOnly:false`).
+Current version: `3.1.0`, `minAppVersion 1.13.1`, desktop **and** mobile (`isDesktopOnly:false`).
 
 ## Architecture in 60 seconds
 
@@ -103,7 +103,7 @@ release, run the **`obsidian-plugin-quality`** skill; for PRs, use the
 ## Known gaps (don't be surprised)
 
 - **`versions.json` and `version-bump.mjs` are present** — `npm version <x.y.z>` bumps
-  `manifest.json` and records the `version → minAppVersion` map. Current release line: `2.12.0`.
+  `manifest.json` and records the `version → minAppVersion` map. Current release line: `3.1.0`.
 - **Tests are only seeded** — a jest + TDD harness now exists (pure-logic suites); breadth must
   grow (tracked by issues).
 - `eslint-plugin-obsidianmd` is **clean and blocking** (was a 475-problem baseline; #85). All
@@ -163,6 +163,12 @@ This harness is committed (only `.claude/settings.local.json` is git-ignored). I
 
 ## Working agreements
 
+- **Cognitive agency (the meta-principle — see the [manifesto](docs/manifesto.md)).** ZettelFlow removes
+  *mechanical* work and protects *cognitive* work. Mechanical output (a gathered list, a derived metric)
+  writes freely; **interpretive** output (a conclusion, counterargument, synthesis, proposed connection —
+  AI or heuristic) reaches the vault **only through an explicit human accept/modify/reject**, and the
+  verdict is recorded. This is [constitution §XII](docs/development/constitution.md) and it is a review
+  gate, not a preference.
 - **Design by subtraction (a core principle — see the [manifesto](docs/manifesto.md)).** Prefer
   removing or centralizing over adding. If a new capability overlaps an existing one, **empower one**
   instead of shipping both; keep the product minimal and comprehensible. An addition must earn its

--- a/docs/development/constitution.md
+++ b/docs/development/constitution.md
@@ -91,3 +91,26 @@ Three invariants make this enforceable, not aspirational:
   future `knowledge/` home) **never imports `obsidian`** and makes no network/AI call. Derived
   metrics are **queries over the model, not invented dashboard features** — *metrics are
   consequences, not inventions*.
+
+## XII. Never write a judgement the user did not make
+
+The manifesto's meta-principle is **cognitive agency**: ZettelFlow removes *mechanical* work and
+protects *cognitive* work. **Mechanical** output — a gathered list, a derived metric, a structural
+projection — may be written freely. **Interpretive** output — an interpretation, conclusion,
+counterargument, synthesis or proposed connection, whether produced by AI or by a heuristic — reaches
+the vault **only through an explicit human verdict** (accept / modify / reject). Machine text is
+*proposed*, never *committed*.
+
+Two consequences a reviewer can check on a diff:
+
+- **No silent interpretive write.** An action that produces interpretive output and writes it with no
+  decision point is rejected — inside a wizard build *and* inside an automation. The AI gate (#301)
+  bounds cost and automation; it does not grant agency.
+- **The verdict is data, not just an effect.** A human decision is recorded (the judgement record), so
+  *cognitive agency* stays a **consequence of the model** like every other metric (§XI) — never an
+  invented score.
+
+**Deliberate friction** — asking for the user's reading before revealing the system's — is a design
+tool, not a tax: applied only where judgement is genuinely at stake, never as a generic confirmation
+dialog. It is the opposite of the *operational* friction removed by the
+[friction audit](friction-audit.md); §XI still applies, so a friction step must not add net surface.

--- a/docs/development/friction-audit.md
+++ b/docs/development/friction-audit.md
@@ -9,6 +9,13 @@
 > it; almost nothing is deleted."* Nothing below is a proposal to delete a capability — only to expose
 > one obvious path and tuck duplicates out of the way.
 
+>
+> **Two different "frictions" — do not confuse them.** This page is about **operational friction**:
+> duplicated paths, unclear entry points, steps that cost the user effort for no thinking in return. That
+> kind is removed. **Deliberate (cognitive) friction** — asking for your reading before the system reveals
+> its own — is the opposite: it is *added* on purpose where judgement is at stake
+> ([constitution §XII](constitution.md), [manifesto](../manifesto.md)).
+
 ## Method
 
 Counted from source on `main`: `addCommand` ids, `registerView` names, the community catalog types,

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -24,6 +24,51 @@ life:
 CAPTURE → CLASSIFY → PROCESS → CONNECT → DEVELOP → REVIEW → CONSOLIDATE
 ```
 
+## Cognitive agency (the meta-principle)
+
+The four pillars below say **what** ZettelFlow builds. This says **why** it exists.
+
+Every tool that touches knowledge work now offers the same bargain: hand over the thinking, keep the
+output. Take it often enough and something erodes quietly — not your notes, your **judgement**.
+Delegating a *mechanical* task is strategic and good; the loss begins when the tool takes over the
+**evaluation** and you stop exercising the metacognitive agency that made the knowledge yours. That is
+**cognitive surrender**, and it is the failure mode ZettelFlow is built against.
+
+> **ZettelFlow removes mechanical work. It protects cognitive work.**
+
+This is not an anti-AI stance, and not a demand that you do everything by hand. Automating *"gather
+every idea that contradicts this one"* is pure gain. Automating *"and here is what you should conclude"*
+is the loss. The line is exact:
+
+| ZettelFlow does this | ZettelFlow never does this |
+|---|---|
+| Gathers the evidence | Decides what the evidence means |
+| Surfaces the contradiction | Resolves it for you |
+| Notices the missing source | Invents the justification |
+| Proposes a connection | Commits it without your verdict |
+| Shows you the argument you built | Writes the argument you didn't |
+
+The mechanism is **deliberate friction**: at the moments where judgement is actually at stake, the
+system asks for *your* reading before it reveals its own. Not to slow you down — to keep the reasoning
+yours. And because judgement is the scarce resource, it is the thing worth measuring: **cognitive
+agency** is a consequence of the model like every other metric, the answer to *"has my understanding
+changed, or has my vault just grown?"*
+
+```
+                         COGNITIVE AGENCY
+             keep the human intellectually in the loop
+                                │
+            ┌───────────────────┼───────────────────┐
+            ↓                   ↓                   ↓
+        Lifecycle             Graph             Discovery
+            └───────────────────┼───────────────────┘
+                                ↓
+                             Health
+```
+
+> **Obsidian stores your thoughts. ZettelFlow connects them, challenges them and makes them evolve —
+> but it never thinks for you.**
+
 ## The four pillars (the soul)
 
 - 🌱 **Knowledge Lifecycle** — every idea has a state (fleeting → literature → permanent → developing
@@ -43,6 +88,8 @@ Knowledge debt is a natural byproduct of doing the work — never an arbitrary n
 
 - **"Obsidian + AI"** — competing with a thousand tools. **AI is one Action, never the product.** The
   system works fully — every pillar, every dashboard — for a user who never enables AI.
+- **An answer machine.** A tool that hands you conclusions trains you to stop reaching them. ZettelFlow
+  gathers, proposes and challenges — the verdict is always yours.
 - **"Another plugin to create Zettelkasten notes."** That ceiling is too low.
 - A generic manager that pleases everyone and marks no one.
 
@@ -90,8 +137,10 @@ abandon*. Minimalism here is not a lack of ambition; it is the ambition.
 
 The best tools meet you where you are. A newcomer should be productive in **five minutes** — install a
 system, create a note, watch it land already connected, cross-checked and scored — without reading a
-manual. That is the **on-ramp**: ZettelFlow does the thinking-work *for* you until you're ready to do it
-yourself.
+manual. That is the **on-ramp**: ZettelFlow does the *mechanical* work for you from the first minute —
+the scaffolding, the gathering, the cross-checking — so that what is left for you is the judgement. It
+never does the judgement work for you, at any level: a beginner is not a user who thinks less, only a
+user with more scaffolding.
 
 And there should always be another level. Compose your own workflows, program conditions and events,
 author and share systems, ask your own knowledge graph questions — the ceiling rises as far as your


### PR DESCRIPTION
Opens the 3.2 chapter (epic #335) at the only place it can start: the identity documents.

## What changes

- **`docs/manifesto.md`** — a new **Cognitive agency** section above the four pillars. The pillars say
  *what* ZettelFlow builds; nothing said *why* it exists. It names the failure mode the product is
  built against (**cognitive surrender**) and draws the line exactly: mechanical work is removed,
  cognitive work is protected — with a does/never table so the line is usable at review time.
- **`docs/manifesto.md`** — resolves the **contradiction this creates**. *Easy to use, hard to master*
  said: *"ZettelFlow does the thinking-work for you until you're ready to do it yourself."* That is
  cognitive surrender written as a promise. The on-ramp now does the *mechanical* work from minute one
  and never the judgement work: a beginner is not a user who thinks less, only one with more
  scaffolding.
- **`docs/manifesto.md`** — *an answer machine* joins **what we will not become**.
- **`docs/development/constitution.md`** — **§XII: never write a judgement the user did not make.**
  Interpretive output (a conclusion, counterargument, synthesis, proposed connection — AI or heuristic)
  reaches the vault only through an explicit accept / modify / reject, and the verdict is *recorded*,
  so agency stays a consequence of the model (§XI) instead of an invented score. Two checks a reviewer
  can run on a diff.
- **`docs/development/friction-audit.md`** — disambiguates the two frictions: **operational** friction
  is removed (that page's job), **deliberate cognitive** friction is added on purpose where judgement
  is at stake.
- **`CLAUDE.md`** — carries the meta-principle into the working agreements so it binds future changes,
  and refreshes a stale version line (`2.12.0` → `3.1.0`).

## Why a principle, not a feature

Everything in this repo is enforced (blocking lint, guardrail tests, the §XI gate). A principle with no
mechanism becomes marketing — so it ships as a constitution article with binary, checkable
consequences, and epic #335 implements it in dependency order: judgement record → agency-aware AI →
deliberate friction → agency as a consequence.

Docs-only; no behaviour, no public surface, no score impact. `npm run lint` green via the pre-commit
hook.

Refs #335, #336, #337, #338, #339.
