### PR TITLE
fix(quality): clear the Obsidian automated-review findings for 3.1.0 (#340)

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,6 +7,10 @@ on:
 
 permissions:
   contents: write
+  # Provenance attestations for the three release artifacts (#340): the Community-hub scan
+  # flags their absence, and the build is already byte-for-byte reproducible.
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -36,6 +40,14 @@ jobs:
             echo "::error::Tag '$tag' does not equal manifest.version '$version'. Tag with the manifest version."
             exit 1
           fi
+
+      - name: Attest build provenance for the release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/main.js
+            dist/styles.css
+            manifest.json
 
       - name: Create GitHub release with the three artifacts
         env:

--- a/README.md
+++ b/README.md
@@ -250,8 +250,10 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 ZettelFlow collects **no telemetry** and sends **no personal data or vault contents** anywhere. The plugin uses these capabilities:
 
 - **File system (vault).** Reads canvas flow files and creates/edits notes (e.g. the **Change note state** command writes a single lifecycle property to the active note). All access goes through Obsidian's `Vault` / `FrontmatterService` API — never a hardcoded path. Works on desktop and mobile.
-- **Network — optional, community feature only.** If (and only if) you open the community templates browser, ZettelFlow fetches example flows from the ZettelFlow community source. Nothing is sent unless you use this feature.
-- **Script execution.** The Script action and JavaScript step files run **JavaScript you write** as part of a flow. This code runs with the plugin's access to your vault — only run scripts you trust.
+- **Vault enumeration.** ZettelFlow lists every markdown file **path** to build the offline knowledge model that health, discovery, the graph and Cultivate all read. Paths and metadata only, all local — and you can keep folders out of it with the knowledge scope.
+- **Network — two opt-in paths, nothing until you use them.** The **community gallery** does read-only `GET`s of the static catalog on GitHub (no backend, no account, no uploads), and the optional **AI provider** sends length-bounded note content to the single https endpoint *you* configure. Both are off until you open the browser or enable AI.
+- **Dynamic code execution.** The Script action, dynamic selectors, vault hooks and workflow-event conditions run **JavaScript you write**, with the plugin's access to your vault — only run scripts you trust. No remote code is ever fetched or executed, and every runtime function is built in one audited module.
+- **Clipboard — write only.** The “copy” buttons put a step or action configuration on your clipboard as JSON. ZettelFlow never *reads* your clipboard.
 
 See [Capabilities & privacy](https://rafaelgb.github.io/Obsidian-ZettelFlow/development/capabilities-and-privacy/) for full details.
 

--- a/docs/development/capabilities-and-privacy.md
+++ b/docs/development/capabilities-and-privacy.md
@@ -11,8 +11,16 @@ telemetry** and transmits **no personal data or vault contents**.
 | **File system (vault)** | Always | Read your Canvas flow files; create and edit notes as the output of a flow; install community templates into your vault. | Obsidian's `Vault` API and `FileManager` — no hardcoded `.obsidian` paths, path-normalised, desktop **and** mobile. |
 | **Network** | Opt-in | Only the **community templates** browser: read-only `GET`s that fetch example flows/steps/actions/systems and preview images from the static ZettelFlow community catalog on GitHub raw. No backend, no account, no uploads. | `request`/`requestUrl` in `src/application/community/`. No requests are made unless you open the community browser. |
 | **AI provider (external)** | Opt-in, off by default | The optional **🤖 AI action category** (`summarize`, `classify`, `generate-questions`, …). When you enable it and run an AI action, the **(length-bounded) note content** is sent to the single **https** OpenAI-compatible endpoint **you configure** to get a completion back. AI never fires on its own in automations unless you opt in. | `requestUrl` in `src/architecture/ai/OpenAiCompatibleProvider.ts` only. No bundled key, no default endpoint, no other endpoint, no telemetry. Off by default; input/output are capped and the endpoint must be https (or localhost). See [AI provider setup](ai-provider-setup.md). |
-| **Script execution** | Opt-in | The **Script** action and JavaScript step files execute **JavaScript you author** as part of a flow. | The `.js` code editor (`CodeView`) and the script action. Runs with the plugin's vault access — run only scripts you trust. |
-| **Clipboard** | No | — | ZettelFlow does not read or write the system clipboard. |
+| **Clipboard** | On your click | **Writes only, never reads.** The “copy” buttons put a step / action / canvas-node configuration on the clipboard as JSON so you can paste it elsewhere or share it. | `navigator.clipboard.writeText` in the step, action and canvas-node editors. Nothing is ever read from your clipboard, and nothing is copied unless you press a copy button. |
+| **Vault enumeration** | Always | Lists every markdown file **path** in the vault to build the offline knowledge model that every analysis reads (health, discovery, the graph, Cultivate). | `vault.getMarkdownFiles()` via the `ObsidianApi` facade. Paths and metadata only, all local, no network. You can keep folders out of it entirely with the [knowledge scope](knowledge-scope.md). |
+| **Dynamic code execution** | Opt-in | Runs the JavaScript **you** author: the Script action, dynamic selectors, vault hooks and workflow-event conditions. | Built in exactly **one** module, `architecture/api/lib/FnConstructor.ts` (a guardrail test fails the build if a second site appears). No remote code is ever fetched or executed — only code stored in your own vault or settings. |
+
+## What the automated scan sees that is not ours
+
+Obsidian's Community-hub scan reports **runtime base64 encode/decode**. That call does not come from
+ZettelFlow code — there is no `atob`/`btoa` anywhere in `src/`. It comes from the bundled 3D graph
+library (`3d-force-graph`, which vendors three.js loaders) used by the graph view. It decodes assets
+the library ships with; it does not encode anything about your vault, and it makes no request.
 
 ## No telemetry
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc -noEmit -skipLibCheck",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint ./src --fix",
-    "lint:obsidian": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:obsidian": "eslint \"src/**/*.{ts,tsx}\" --max-warnings 0",
     "verify": "npm run typecheck && npm run lint && npm run lint:obsidian && npm test",
     "prepare": "husky",
     "commitlint": "commitlint --edit"

--- a/src/application/community/CommunityMarkdownModal.ts
+++ b/src/application/community/CommunityMarkdownModal.ts
@@ -25,14 +25,13 @@ export class CommunityMarkdownModal extends Modal {
         this.contentEl.empty();
         const mdTemplateFolder = this.plugin.settings.communitySettings.markdownTemplateFolder;
 
-        const span = activeDocument.createElement("span", {});
         // Header with title and subtitle with the mode
         const navbar = this.contentEl.createDiv({ cls: c("modal-navbar") });
 
         navbar.createEl("h2", { text: this.title })
         navbar.createEl("p", { text: this.description });
         // Separator
-        navbar.appendChild(span);
+        navbar.createSpan();
 
         const navbarButtonGroup = navbar.createDiv({ cls: c("navbar-button-group") });
 

--- a/src/application/community/ManageInstalledTemplatesModal.tsx
+++ b/src/application/community/ManageInstalledTemplatesModal.tsx
@@ -26,8 +26,7 @@ export class ManageInstalledTemplatesModal extends Modal {
     navbar.createEl("h2", { text: t("manage_installed_templates_title") });
 
     // Separator
-    const span = activeDocument.createElement("span", {});
-    navbar.appendChild(span);
+    navbar.createSpan();
 
     const navbarButtonGroup = navbar.createDiv({
       cls: c("navbar-button-group"),

--- a/src/application/community/shareSystem.ts
+++ b/src/application/community/shareSystem.ts
@@ -51,9 +51,9 @@ export async function buildActiveCanvasTemplate(plugin: ZettelFlow): Promise<Act
 export function downloadTemplate(name: string, json: string): void {
     const blob = new Blob([json], { type: "application/json" });
     const url = URL.createObjectURL(blob);
-    // Native createElement (detached) — Obsidian's createEl would append to the document and throw.
-    const anchor = activeDocument.createElement("a");
-    anchor.href = url;
+    // Detached on purpose: the global createEl builds a parentless element, unlike
+    // activeDocument.createEl, which appends to the document and throws.
+    const anchor = createEl("a", { href: url });
     anchor.setAttr("download", `${name}.zftemplate`);
     anchor.click();
     URL.revokeObjectURL(url);

--- a/src/architecture/api/lib/FnConstructor.ts
+++ b/src/architecture/api/lib/FnConstructor.ts
@@ -12,10 +12,14 @@ export function errorMessage(error: unknown): string {
 export type AsyncScriptFunction = (...args: unknown[]) => Promise<unknown>;
 
 /**
- * Build an async function from a user-provided script body, the way the note-builder
- * actions and vault hooks run JS. The AsyncFunction constructor isn't exposed on the
- * global scope, so it is reached through the prototype of an async function. Typing it
- * here keeps every call site free of unsafe `any`.
+ * Build an async function from a user-provided script body — the **single** place ZettelFlow
+ * constructs runtime code (#340). The Script action, dynamic selectors, vault hooks and
+ * workflow-event conditions all route through here, so the dynamic-execution capability the
+ * Obsidian scan reports has exactly one home to disclose and one place to audit.
+ *
+ * The AsyncFunction constructor is not exposed globally, so it is reached through the prototype
+ * of an async function. Typing it here keeps every call site free of unsafe `any`.
+ * A guardrail test fails the build if a second site starts building functions on its own.
  */
 export function buildAsyncScriptFunction(argNames: string[], body: string): AsyncScriptFunction {
     const asyncProto = Object.getPrototypeOf(async function () { }) as {

--- a/src/architecture/components/core/search/Search.tsx
+++ b/src/architecture/components/core/search/Search.tsx
@@ -10,10 +10,10 @@ export function Search<T>(props: SearchType<T>) {
   // Refs
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  // Initial detached placeholder. Use native `createElement` here — Obsidian's `createEl` helper appends
-  // the node to its receiver, so building a "ul" on the document appended a second element to the document
-  // and threw "appendChild: Only one element on document allowed", unmounting the React tree (#327).
-  const listRef = useRef<HTMLUListElement>(activeDocument.createElement("ul"));
+  // Initial detached placeholder. The global `createEl` builds a parentless node; the *document*
+  // helper appends to its receiver, which once put a second element on the document and threw
+  // "appendChild: Only one element on document allowed", unmounting the React tree (#327).
+  const listRef = useRef<HTMLUListElement>(createEl("ul"));
   // States
   const [value, setValue] = useState<string>("");
   const [selectedValue, setSelectedValue] = useState<string>("");

--- a/src/architecture/components/settings/navbar.ts
+++ b/src/architecture/components/settings/navbar.ts
@@ -14,14 +14,13 @@ export function navbarAction(
     modal: AbstractStepModal,
     disableNavbar: boolean = false
 ): void {
-    const span = activeDocument.createElement("span", {});
     // Header with title and subtitle with the mode
     const navbar = contentEl.createDiv({ cls: c("modal-navbar") });
 
     navbar.createEl("h2", { text: name })
     navbar.createEl("p", { text: description });
     // Separator
-    navbar.appendChild(span);
+    navbar.createSpan();
 
     if (disableNavbar) return;
 

--- a/src/architecture/plugin/events/WorkflowEventEngine.ts
+++ b/src/architecture/plugin/events/WorkflowEventEngine.ts
@@ -3,7 +3,7 @@ import { CachedMetadata, EventRef, TAbstractFile, TFile } from "obsidian";
 import { log } from "architecture";
 import { canvas } from "architecture/plugin/canvas";
 import { FileService, FILE_EXTENSIONS, VaultStateManager } from "architecture/plugin";
-import { fnsManager } from "architecture/api";
+import { buildAsyncScriptFunction, fnsManager } from "architecture/api";
 import { SelectorMenuModal } from "zettelkasten";
 import { buildBindings, type FlowTriggerSource, type WorkflowBinding } from "./bindings";
 import { deriveFrontmatterEvents } from "./derive";
@@ -178,13 +178,9 @@ export class WorkflowEventEngine {
 
     /** Evaluate a binding condition as a `zf` script (same evaluator as hooks / the Script action). */
     private runScript = async (script: string, ctx: unknown): Promise<unknown> => {
-        const asyncProto = Object.getPrototypeOf(async function () {}) as {
-            constructor: new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
-        };
-        const AsyncFunction = asyncProto.constructor;
         const fnBody = `return (async () => {\n${script}\n})();`;
         const functions = await fnsManager.getFns();
-        const scriptFn = new AsyncFunction("event", "zf", fnBody);
+        const scriptFn = buildAsyncScriptFunction(["event", "zf"], fnBody);
         return await scriptFn(ctx, functions);
     };
 

--- a/src/hooks/VaultHooks.ts
+++ b/src/hooks/VaultHooks.ts
@@ -17,7 +17,7 @@ import {
     Literal,
     VaultStateManager,
 } from "architecture/plugin";
-import { fnsManager } from "architecture/api";
+import { buildAsyncScriptFunction, fnsManager } from "architecture/api";
 import { evaluateBindingCondition } from "architecture/plugin/events/condition";
 
 import { hasFrontmatterMutations, copyFrontmatter, changedHookProperties } from "./utils/CompareUtils";
@@ -44,14 +44,6 @@ export type HookDryRunResult =
     | { status: "skipped" }
     | { status: "no-file" }
     | { status: "error"; message: string };
-
-/** Reach the (otherwise hidden) `AsyncFunction` constructor via an async function's prototype. */
-function asyncFunctionCtor(): new (...args: string[]) => (...args: unknown[]) => Promise<unknown> {
-    const proto = Object.getPrototypeOf(async function () { }) as {
-        constructor: new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
-    };
-    return proto.constructor;
-}
 
 /** Ajustable si ves muchos "changed" por tecleo. */
 const METADATA_DEBOUNCE_MS = 60;
@@ -86,12 +78,11 @@ export class VaultHooks {
         const newValue = frontmatter[property];
         try {
             const zf = await fnsManager.getFns();
-            const AsyncFunction = asyncFunctionCtor();
 
             const condition = settings.condition?.trim();
             if (condition) {
                 const ctx = { event: "property.changed", notePath: file.path, property, oldValue: undefined, newValue };
-                const condFn = new AsyncFunction("event", "zf", `return (${condition});`);
+                const condFn = buildAsyncScriptFunction(["event", "zf"], `return (${condition});`);
                 const passes = await condFn(ctx, zf);
                 if (!passes) return { status: "skipped" };
             }
@@ -101,7 +92,7 @@ export class VaultHooks {
                 request: { oldValue: undefined, newValue, property, frontmatter },
                 response: { frontmatter: {}, removeProperties: [] },
             };
-            const scriptFn = new AsyncFunction("event", "zf", `return (async () => {\n${settings.script}\n return event;\n})(event, zf);`);
+            const scriptFn = buildAsyncScriptFunction(["event", "zf"], `return (async () => {\n${settings.script}\n return event;\n})(event, zf);`);
             const result = (await scriptFn(event, zf)) as HookEvent;
             return { status: "ran", response: result.response };
         } catch (error) {
@@ -487,31 +478,21 @@ export class VaultHooks {
      */
     private evaluateHookCondition(condition: string | undefined, ctx: unknown): Promise<boolean> {
         return evaluateBindingCondition(condition, ctx, async (script, context) => {
-            const asyncProto = Object.getPrototypeOf(async function () { }) as {
-                constructor: new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
-            };
-            const AsyncFunction = asyncProto.constructor;
             const zf = await fnsManager.getFns();
-            const fn = new AsyncFunction("event", "zf", `return (${script});`);
+            const fn = buildAsyncScriptFunction(["event", "zf"], `return (${script});`);
             return fn(context, zf);
         });
     }
 
     private async executeHook(script: string, event: HookEvent): Promise<HookEvent> {
         try {
-            // The AsyncFunction constructor isn't exposed on the global scope; reach it via
-            // the prototype of an async function. Type it so the built function is callable.
-            const asyncProto = Object.getPrototypeOf(async function () { }) as {
-                constructor: new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
-            };
-            const AsyncFunction = asyncProto.constructor;
             const fnBody = `return (async () => {
         ${script}
         return event;
       })(event, zf);`;
 
             const functions = await fnsManager.getFns();
-            const scriptFn = new AsyncFunction("event", "zf", fnBody);
+            const scriptFn = buildAsyncScriptFunction(["event", "zf"], fnBody);
 
             return (await scriptFn(event, functions)) as HookEvent;
         } catch (error: unknown) {

--- a/src/starters/zcomponents/TemplateExportComponent.ts
+++ b/src/starters/zcomponents/TemplateExportComponent.ts
@@ -6,6 +6,7 @@ import { FileService } from "architecture/plugin";
 import { FolderSuggest } from "architecture/settings";
 import { ConfirmModal } from "architecture/components/settings";
 import { buildTemplate, parseTemplate, ZfTemplate } from "application/template/zfTemplate";
+import { downloadTemplate } from "application/community/shareSystem";
 
 export class TemplateExportComponent extends PluginComponent {
     constructor(plugin: ZettelFlow) {
@@ -76,22 +77,13 @@ export class TemplateExportComponent extends PluginComponent {
         const name = canvasFile.basename;
         const template = buildTemplate(name, "", "", { filename: canvasFile.name, content: canvasContent }, steps);
 
-        const json = JSON.stringify(template, null, 2);
-        const blob = new Blob([json], { type: "application/json" });
-        const url = URL.createObjectURL(blob);
-        // Native createElement (detached) — Obsidian's createEl would append to the document and throw.
-        const anchor = activeDocument.createElement("a");
-        anchor.href = url;
-        anchor.setAttr("download", `${name}.zftemplate`);
-        anchor.click();
-        URL.revokeObjectURL(url);
+        downloadTemplate(name, JSON.stringify(template, null, 2));
         new Notice(t("export_template_success"));
     }
 
     private pickAndImport(): void {
-        const input = activeDocument.createElement("input");
-        input.type = "file";
-        input.accept = ".zftemplate";
+        // Detached on purpose (see downloadTemplate): the global helper adds no parent.
+        const input = createEl("input", { type: "file", attr: { accept: ".zftemplate" } });
         input.addEventListener("change", () => {
             const file = input.files?.[0];
             if (!file) return;

--- a/src/zettelkasten/modals/InstalledActionEditorModal.ts
+++ b/src/zettelkasten/modals/InstalledActionEditorModal.ts
@@ -36,7 +36,6 @@ export class InstalledActionEditorModal extends AbstractStepModal {
     private renderContent() {
         // Clear the previous content
         this.contentEl.empty();
-        const span = activeDocument.createElement("span", {});
         this.modalEl.addClass(c("modal"));
         // Header with title and subtitle with the mode
         const navbar = this.contentEl.createDiv({ cls: c("modal-navbar") });
@@ -44,7 +43,7 @@ export class InstalledActionEditorModal extends AbstractStepModal {
         navbar.createEl("h2", { text: t("installed_action_editor_title") })
 
         // Separator
-        navbar.appendChild(span);
+        navbar.createSpan();
 
         const navbarButtonGroup = navbar.createDiv({ cls: c("navbar-button-group") });
         // Add Uninstall button

--- a/src/zettelkasten/modals/InstalledStepEditorModal.ts
+++ b/src/zettelkasten/modals/InstalledStepEditorModal.ts
@@ -38,7 +38,6 @@ export class InstalledStepEditorModal extends AbstractStepModal {
     }
 
     onOpen(): void {
-        const span = activeDocument.createElement("span", {});
         this.modalEl.addClass(c("modal"));
         // Header with title and subtitle with the mode
         const navbar = this.info.contentEl.createDiv({ cls: c("modal-navbar") });
@@ -46,7 +45,7 @@ export class InstalledStepEditorModal extends AbstractStepModal {
         navbar.createEl("h2", { text: t("installed_step_editor_title") })
 
         // Separator
-        navbar.appendChild(span);
+        navbar.createSpan();
         const navbarButtonGroup = navbar.createDiv({ cls: c("navbar-button-group") });
 
         // Add Uninstall button

--- a/src/zettelkasten/modals/StepBuilderModal.ts
+++ b/src/zettelkasten/modals/StepBuilderModal.ts
@@ -48,7 +48,6 @@ export class StepBuilderModal extends AbstractStepModal {
 
     onOpen(): void {
         VaultStateManager.INSTANCE.freeze();
-        const span = activeDocument.createElement("span", {});
         this.modalEl.addClass(c("modal"));
         // Header with title and subtitle with the mode
         const navbar = this.info.contentEl.createDiv({ cls: c("modal-navbar") });
@@ -56,7 +55,7 @@ export class StepBuilderModal extends AbstractStepModal {
         navbar.createEl("h2", { text: t("step_builder_title") })
 
         // Separator
-        navbar.appendChild(span);
+        navbar.createSpan();
 
         const navbarButtonGroup = navbar.createDiv({ cls: c("navbar-button-group") });
 

--- a/test/architecture/api/lib/asyncFunctionIsCentralized.test.ts
+++ b/test/architecture/api/lib/asyncFunctionIsCentralized.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "@jest/globals";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative, sep } from "path";
+
+// test/architecture/api/lib → 4 ups → repo root
+const SRC = join(__dirname, "..", "..", "..", "..", "src");
+const FN_CONSTRUCTOR = join("architecture", "api", "lib", "FnConstructor.ts");
+
+/**
+ * The Obsidian Community-hub scan flags **dynamic code execution** (#340). It is a real, headline
+ * capability here — the Script action, dynamic selectors, vault hooks and workflow-event conditions
+ * all run user JS — so it cannot be removed. What it *can* be is **stated precisely**: exactly one
+ * module reaches the hidden `AsyncFunction` constructor, so the disclosure names one place and a
+ * reviewer has one place to audit (constitution §VII, and §XI: one home per job).
+ */
+function sourceFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+        else if (/\.tsx?$/.test(entry)) out.push(full);
+    }
+    return out;
+}
+
+describe("AsyncFunction construction is centralized (#340)", () => {
+    const files = sourceFiles(SRC);
+
+    it("finds the source tree", () => {
+        expect(files.length).toBeGreaterThan(100);
+    });
+
+    it("reaches the AsyncFunction constructor in FnConstructor only", () => {
+        const offenders = files
+            .filter((file) => /Object\.getPrototypeOf\(\s*async function/.test(readFileSync(file, "utf8")))
+            .map((file) => relative(SRC, file).split(sep).join("/"));
+
+        expect(offenders).toEqual([FN_CONSTRUCTOR.split(sep).join("/")]);
+    });
+
+    it("builds runtime scripts through buildAsyncScriptFunction only", () => {
+        const offenders = files
+            .filter((file) => !file.endsWith(FN_CONSTRUCTOR))
+            .filter((file) => /new AsyncFunction\(/.test(readFileSync(file, "utf8")))
+            .map((file) => relative(SRC, file).split(sep).join("/"));
+
+        expect(offenders).toEqual([]);
+    });
+});


### PR DESCRIPTION
Clears the score-blocking findings from the Obsidian automated review of `3.1.0` (#340).

## The root cause of the warnings

`obsidianmd/prefer-create-el` ships in the recommended set at **`"warn"`**, so `npm run lint:obsidian`
exited 0 while the Community-hub scan counted the same 4 findings against us. The lint was reporting
them all along — nothing was ever configured to fail on them.

`lint:obsidian` now runs with **`--max-warnings 0`**, which makes that rule *and the ~20 others that
ship at warn level* blocking, in `verify`, the pre-push hook and CI. One flag instead of a rule-by-rule
severity table.

## What changed

| Finding | Fix |
|---|---|
| 4 × `document.createElement` (warnings) | Zero `createElement` call sites remain in `src/`. |
| Missing artifact attestations (×2) | `actions/attest-build-provenance` over the three release artifacts. |
| Dynamic code execution | Not removed — it is the Script action. **Centralised** into one audited module. |
| Vault enumeration / clipboard / network | Disclosed accurately (one of them was disclosed *wrongly*). |
| Runtime base64 | Traced to the bundled dependency and documented; not our code. |

Notes worth flagging for review:

- **`activeWindow.createEl` — the rule's own autofix — does not typecheck.** The Obsidian typings
  declare `createEl` on `Node` and as a global function, never on `Window`. The three detached
  elements (download anchor, import file input, Search placeholder `<ul>`) use the **global**
  `createEl`, which builds a parentless element; that is the API-correct form for a detached node.
- The 6 separator spans were `activeDocument.createElement("span", {})` followed by a manual
  `appendChild` — that second argument was silently ignored. They are now `navbar.createSpan()`.
- `TemplateExportComponent` carried an inline copy of `downloadTemplate`; it now calls the shared one
  (§XI, and one fewer call site to fix).
- **The clipboard disclosure was false.** `capabilities-and-privacy.md` claimed *"Clipboard: No —
  ZettelFlow does not read or write the system clipboard"* while five copy buttons call
  `navigator.clipboard.writeText`. Corrected to write-only, on your click, with the sites named
  (constitution §VII). The README's network bullet also said "community feature only" and omitted the
  AI provider entirely.
- Dynamic execution was copy-pasted in **four** places besides the canonical helper. Every site now
  routes through `buildAsyncScriptFunction`, and a source-scanning guardrail test (the house
  `pure-is-obsidian-free` pattern) fails the build if a fifth appears. No behaviour change.

## Not in this PR: the 3D graph

AC-5 is [measured and posted on the issue](https://github.com/RafaelGB/Obsidian-ZettelFlow/issues/340#issuecomment-5477112309):
the 3D-graph stack is **1,458 kB — 58.6% of the 2,489 kB bundle** (`three` alone is 53.4%; all of
ZettelFlow is 24.6%). But it is a **product** decision, not a score fix — base64 is a *disclosure*,
not a warning — and the Graph surface is 3D-only since #280, so dropping the renderer would remove one
of the four manifesto surfaces. **Decided: keep it** — see the decision comment on the issue.

`npm run verify` green: 204 suites, 1057 tests, 0 lint warnings.

Closes #340.
