### PR TITLE
fix(config): make the judgement record actually turnable off (#336)

### DIFF
--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -906,6 +906,11 @@ export default {
     settings_journal_enable_name: 'Record development events',
     settings_journal_enable_desc: 'Keep a per-day count of ideas developed (state advanced, source or connection added). On by default.',
     settings_journal_disclosure: 'Stored locally as day → count only — no note names, no content, no network.',
+    settings_judgements_heading: 'Judgement record',
+    settings_judgements_intro: 'ZettelFlow remembers the decisions you make on your own ideas, so it can tell an idea that grew from one you actually reasoned about.',
+    settings_judgements_enable_name: 'Record my decisions',
+    settings_judgements_enable_desc: 'On by default. Turning it off stops new records; nothing else changes.',
+    settings_judgements_disclosure: 'Local only: a bounded log of a note path, a short label, and whether you accepted, edited, rejected, confirmed or challenged. Never note content, never AI output, never networked.',
     // Evolution timeline settings (#168)
     settings_timeline_heading: 'Evolution timeline',
     settings_timeline_intro: 'ZettelFlow keeps a per-note history of how an idea evolved — its lifecycle state and claim texts over time.',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -906,6 +906,11 @@ export default {
     settings_journal_enable_name: 'Registrar eventos de desarrollo',
     settings_journal_enable_desc: 'Lleva un recuento diario de ideas desarrolladas (estado avanzado, fuente o conexión añadida). Activado por defecto.',
     settings_journal_disclosure: 'Se guarda en local solo como día → recuento — sin nombres de notas, sin contenido, sin red.',
+    settings_judgements_heading: 'Registro de decisiones',
+    settings_judgements_intro: 'ZettelFlow recuerda las decisiones que tomas sobre tus propias ideas, para poder distinguir una idea que ha crecido de una sobre la que de verdad has razonado.',
+    settings_judgements_enable_name: 'Registrar mis decisiones',
+    settings_judgements_enable_desc: 'Activado por defecto. Al desactivarlo dejan de guardarse registros nuevos; no cambia nada más.',
+    settings_judgements_disclosure: 'Solo local: un registro acotado con la ruta de la nota, una etiqueta corta y si aceptaste, editaste, rechazaste, confirmaste o desafiaste. Nunca el contenido de la nota, nunca la salida de la IA, nunca por red.',
     // Ajustes de la línea temporal de evolución (#168)
     settings_timeline_heading: 'Línea temporal de evolución',
     settings_timeline_intro: 'ZettelFlow guarda por nota un historial de cómo evolucionó una idea — su estado de ciclo de vida y los textos de sus afirmaciones a lo largo del tiempo.',

--- a/src/config/modals/ZettelFlowSettingsTab.tsx
+++ b/src/config/modals/ZettelFlowSettingsTab.tsx
@@ -27,6 +27,7 @@ import { PropertyHooksManager } from "./handlers/hooks/components/PropertyHooksM
 import { HookErrorBoundary } from "./handlers/hooks/components/HookErrorBoundary";
 import { aiSettingsGroup } from "./handlers/aiSettingsGroup";
 import { journalSettingsGroup } from "./handlers/journalSettingsGroup";
+import { judgementSettingsGroup } from "./handlers/judgementSettingsGroup";
 import { timelineSettingsGroup } from "./handlers/timelineSettingsGroup";
 import { patternsSettingsGroup } from "./handlers/patternsSettingsGroup";
 
@@ -530,6 +531,7 @@ export class ZettelFlowSettingsTab extends PluginSettingTab {
             aiSettingsGroup(plugin),
             // ── Thinking journal (#162) ───────────────────────────────────────
             journalSettingsGroup(plugin),
+            judgementSettingsGroup(plugin),
             timelineSettingsGroup(plugin),
             // ── Knowledge patterns (#200) ─────────────────────────────────────
             patternsSettingsGroup(plugin),

--- a/src/config/modals/handlers/judgementSettingsGroup.ts
+++ b/src/config/modals/handlers/judgementSettingsGroup.ts
@@ -1,0 +1,44 @@
+import { SettingDefinitionItem } from "obsidian";
+import ZettelFlow from "main";
+import { c } from "architecture";
+import { t } from "architecture/lang";
+
+/**
+ * Declarative "Judgement record" settings group (#336, epic #335): an enable toggle for the
+ * cognitive-agency record (on by default) plus a data-disclosure note — a local, bounded log of
+ * locale-free descriptors, never note content and never model output. Mirrors the #162 journal group.
+ */
+export function judgementSettingsGroup(plugin: ZettelFlow): SettingDefinitionItem {
+    return {
+        type: "group",
+        heading: t("settings_judgements_heading"),
+        items: [
+            {
+                name: t("settings_judgements_intro"),
+                render: (setting) => {
+                    setting.setClass(c("readable-setting-item"));
+                },
+            },
+            {
+                name: t("settings_judgements_enable_name"),
+                desc: t("settings_judgements_enable_desc"),
+                render: (setting) => {
+                    setting.addToggle((toggle) =>
+                        toggle
+                            .setValue(plugin.settings.judgements.enabled)
+                            .onChange(async (value) => {
+                                plugin.settings.judgements = { ...plugin.settings.judgements, enabled: value };
+                                await plugin.saveSettings();
+                            })
+                    );
+                },
+            },
+            {
+                name: t("settings_judgements_disclosure"),
+                render: (setting) => {
+                    setting.setClass(c("readable-setting-item"));
+                },
+            },
+        ],
+    };
+}

--- a/test/config/judgementSettingsGroup.test.ts
+++ b/test/config/judgementSettingsGroup.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+import en from "architecture/lang/locale/en";
+import es from "architecture/lang/locale/es";
+
+// test/config → 2 ups → repo root
+const ROOT = join(__dirname, "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+const KEYS = [
+    "settings_judgements_heading",
+    "settings_judgements_intro",
+    "settings_judgements_enable_name",
+    "settings_judgements_enable_desc",
+    "settings_judgements_disclosure",
+];
+
+/**
+ * `capabilities-and-privacy.md` tells the user the judgement record "can be turned off". A setting the
+ * docs promise and the UI does not offer is the same class of defect as the clipboard row corrected in
+ * #340 — so the promise is pinned by a test.
+ */
+describe("the judgement record can actually be turned off (#336)", () => {
+    it("ships a settings group with an enable toggle", () => {
+        const group = read("src/config/modals/handlers/judgementSettingsGroup.ts");
+        expect(group).toContain("plugin.settings.judgements.enabled");
+        expect(group).toContain("settings_judgements_enable_name");
+    });
+
+    it("is wired into the settings tab beside the other data toggles", () => {
+        const tab = read("src/config/modals/ZettelFlowSettingsTab.tsx");
+        expect(tab).toContain("judgementSettingsGroup(plugin)");
+    });
+
+    it("speaks both languages", () => {
+        for (const locale of [en, es] as unknown as Record<string, string>[]) {
+            for (const key of KEYS) {
+                expect(typeof locale[key]).toBe("string");
+                expect(locale[key].length).toBeGreaterThan(0);
+            }
+        }
+    });
+});


### PR DESCRIPTION
Follow-up to #336, found while auditing what was left of epic #335.

`capabilities-and-privacy.md` tells users the judgement record "can be turned off", and
`settings.judgements.enabled` exists and is honoured by `JudgementLog` — but **no settings UI ever
exposed it**. The setting was reachable only by hand-editing `data.json`.

That is the same class of defect as the clipboard row corrected in #340: the disclosure described a
capability the product did not actually offer. Constitution §VII asks for honest disclosure, so this
closes the gap rather than softening the doc.

Adds the declarative **Judgement record** group beside the thinking journal (mirroring #162): intro,
an enable toggle, and a disclosure naming exactly what is stored — a note path, a short label, and
which of the five verdicts you gave. Never note content, never AI output, never networked.

A test pins the promise: the group exists, it is wired into the tab, and its strings resolve in both
locales.

`npm run verify` green: 214 suites, 1138 tests.

Refs #336, #335.