### PR TITLE
feat(knowledge): D1 — capture verdict rationale and confidence (#361)

### DIFF
--- a/docs/development/cognitive-agency.md
+++ b/docs/development/cognitive-agency.md
@@ -36,10 +36,12 @@ One decision you made about one idea:
 | `subject` | A **short, locale-free descriptor** of what was judged — an action id (`challenge-idea`), a cultivation move (`connect`), a relation (`supports:ideas/atomicity.md`). |
 | `origin` | Where the proposal came from: `ai`, `derived` (a deterministic projection) or `human` (your own initiative). |
 | `verdict` | `accepted` · `modified` · `rejected` · `confirmed` · `challenged`. |
-| `note` | An optional short remark. Omitted when blank. |
+| `note` | An optional short **rationale**, captured at the verdict moment — the reasoning you type on an AI proposal, or the reading you commit on a Cultivate friction move. Omitted when blank. |
+| `confidence` | An optional **how-sure** marker — `low` · `medium` · `high`. Omitted when you did not say (#361). |
 
-Both `origin` and `verdict` are **closed unions**, so a verdict always means one of a fixed set of
-things and the i18n layer maps them to text.
+`origin`, `verdict` and `confidence` are **closed unions**, so each always means one of a fixed set of
+things and the i18n layer maps them to text. `note` and `confidence` are always optional: a bare verdict
+records exactly as it did before them.
 
 ## What it deliberately does not store
 
@@ -58,7 +60,9 @@ accrues judgements either.
 All pure, all offline, all reachable through the Knowledge State barrel:
 
 - `judgementsFor(history, path)` / `lastJudgementFor(history, path)` — the verdicts on one idea.
-- `agencySignals(history, path)` — counts by verdict and by origin, plus when it was last ruled on.
+- `agencySignals(history, path)` — counts by verdict and by origin, when it was last ruled on, whether
+  any verdict carried a rationale (`hasRationale`) and the confidence of the most recent one
+  (`lastConfidence`).
 - `judgementDays(history)` — verdicts per UTC day, reusing the heatmap's own day key so the two
   definitions of "a day" cannot drift.
 
@@ -79,8 +83,10 @@ AI proposals fill the record with `origin: "ai"`. [Cultivate](cultivate.md) fill
 that is a judgement too — `challenged` when you argued against your own idea, `confirmed` when you
 committed a prediction about it.
 
-Skipping the prompt records nothing. Between the two origins, the record can finally distinguish an
-idea that *grew* from one you actually *reasoned about* — which is what #339 projects.
+Skipping the prompt records nothing. The reading you commit is stored as the judgement's `note`, so the
+record keeps not just *that* you reasoned but *what* you reasoned; an optional confidence selector rides
+along on both surfaces (#361). Between the two origins, the record can finally distinguish an idea that
+*grew* from one you actually *reasoned about* — which is what #339 projects.
 
 ## What the record finally lets the system say
 

--- a/src/actions/ai/aiActionCore.ts
+++ b/src/actions/ai/aiActionCore.ts
@@ -8,6 +8,7 @@ import { sanitizeAiText } from "architecture/ai/promptSafety";
 import { ObsidianApi } from "architecture/plugin/ObsidianAPI";
 import { ProposalModal } from "architecture/components/core/proposal/ProposalModal";
 import { JudgementLog, type JudgementEntry } from "architecture/plugin/judgement/JudgementLog";
+import { withReasoning, type JudgementConfidence } from "architecture/knowledge/judgement";
 import type { AiActionElement } from "zettelkasten";
 import { writeKnowledgeResult } from "../knowledge/knowledgeActionCore";
 
@@ -30,11 +31,22 @@ export interface AiActionSpec {
     notice(value: unknown): string;
 }
 
+/** How the user judged a proposal: the verdict, the text to write, and an optional reasoned trace (#361, D1). */
+export interface ReviewedProposal {
+    verdict: "accepted" | "modified" | "rejected";
+    /** The text to write. Empty for a rejection. */
+    text: string;
+    /** Optional short rationale the user gave with the verdict — recorded, never written to the note. */
+    note?: string;
+    /** Optional how-sure marker the user attached to the verdict. */
+    confidence?: JudgementConfidence;
+}
+
 /** Puts a proposal to the user. Resolves `null` when they dismiss it — a dismissal is not a verdict. */
 export type ProposalReview = (proposal: {
     actionId: string;
     text: string;
-}) => Promise<{ verdict: "accepted" | "modified" | "rejected"; text: string } | null>;
+}) => Promise<ReviewedProposal | null>;
 
 /** The two collaborators the write path needs, injectable so the real path is testable offline. */
 export interface AiActionDeps {
@@ -114,7 +126,7 @@ export async function proposeCompletion(
     prompt: string,
     about: ProposalSubject,
     deps: AiActionDeps = defaultDeps
-): Promise<{ verdict: "accepted" | "modified" | "rejected"; text: string } | null> {
+): Promise<ReviewedProposal | null> {
     const service = AiService.getInstance();
     const state = service.gate();
     if (state === "disabled") {
@@ -147,8 +159,15 @@ export async function proposeCompletion(
 
     if (about.path) {
         // `origin: "ai"` records where the *proposal* came from, not who invoked it — a completion
-        // requested from a user's own script is still the model's suggestion, judged by them.
-        deps.record({ path: about.path, subject: about.subject, origin: "ai", verdict: outcome.verdict });
+        // requested from a user's own script is still the model's suggestion, judged by them. The
+        // rationale/confidence ride along only when the user gave them (#361, D1).
+        deps.record(
+            withReasoning(
+                { path: about.path, subject: about.subject, origin: "ai", verdict: outcome.verdict },
+                outcome.note,
+                outcome.confidence
+            )
+        );
     }
     return outcome;
 }

--- a/src/architecture/api/lib/knowledge/knowledgeApi.ts
+++ b/src/architecture/api/lib/knowledge/knowledgeApi.ts
@@ -80,6 +80,7 @@ export const NOT_EXPOSED: Record<string, string> = {
     isJudgement: "type guard, not a projection",
     sanitizeJudgementLog: "persistence concern, owned by JudgementLog",
     recordJudgement: "a write; scripts read the model and write only their own note",
+    withReasoning: "a write helper that attaches rationale/confidence to a judgement, not a projection",
     recordDay: "a write into the journal counts",
     pruneCounts: "internal journal maintenance",
     developmentStreak: "momentum signal owned by the Home/Cultivate surfaces",

--- a/src/architecture/components/core/cultivate/CultivateModeRenderer.ts
+++ b/src/architecture/components/core/cultivate/CultivateModeRenderer.ts
@@ -11,9 +11,12 @@ import {
     selectCultivationTarget,
     cultivationQueue,
     developmentStreak,
+    JUDGEMENT_CONFIDENCES,
+    withReasoning,
     type CultivationMove,
     type CultivationMoveKind,
     type CultivationSession,
+    type JudgementConfidence,
 } from "architecture/knowledge/state";
 
 const DEBOUNCE_MS = 500;
@@ -232,6 +235,21 @@ export class CultivateModeRenderer extends KnowledgeModeRenderer {
         area.placeholder = t("cultivate_friction_placeholder");
         area.value = this.frictionAnswers.get(move.kind) ?? "";
 
+        // Optional how-sure marker on your reading (#361, D1) — an unset value records no confidence.
+        const confidenceRow = body.createDiv({ cls: c("cultivate-friction-confidence") });
+        confidenceRow.createSpan({
+            cls: c("cultivate-friction-confidence-label"),
+            text: t("proposal_confidence_label"),
+        });
+        const confidence = confidenceRow.createEl("select", {
+            cls: c("cultivate-friction-confidence-select"),
+            attr: { "aria-label": t("proposal_confidence_label") },
+        });
+        confidence.createEl("option", { text: t("confidence_unset"), value: "" });
+        for (const level of JUDGEMENT_CONFIDENCES) {
+            confidence.createEl("option", { text: t(`confidence_${level}` as Parameters<typeof t>[0]), value: level });
+        }
+
         const actions = body.createDiv({ cls: c("cultivate-friction-actions") });
         const reveal = actions.createEl("button", {
             cls: c("cultivate-friction-reveal"),
@@ -241,7 +259,13 @@ export class CultivateModeRenderer extends KnowledgeModeRenderer {
         area.addEventListener("input", () => {
             reveal.disabled = area.value.trim().length === 0;
         });
-        reveal.addEventListener("click", () => this.answerFriction(move, area.value.trim()));
+        reveal.addEventListener("click", () =>
+            this.answerFriction(
+                move,
+                area.value.trim(),
+                confidence.value ? (confidence.value as JudgementConfidence) : undefined
+            )
+        );
 
         const skip = actions.createEl("button", {
             cls: c("cultivate-friction-skip"),
@@ -250,17 +274,26 @@ export class CultivateModeRenderer extends KnowledgeModeRenderer {
         skip.addEventListener("click", () => this.skipFriction(move));
     }
 
-    /** Your reading is committed: record it as a judgement (#336) and open the move. */
-    private answerFriction(move: CultivationMove, text: string): void {
+    /**
+     * Your reading is committed: record it as a judgement (#336) — the reading itself is the rationale
+     * and the how-sure marker rides along when given (#361, D1) — and open the move.
+     */
+    private answerFriction(move: CultivationMove, text: string, confidence?: JudgementConfidence): void {
         if (!text || !move.friction) return;
         this.frictionAnswers.set(move.kind, text);
         if (this.session) {
-            JudgementLog.getInstance().record({
-                path: this.session.path,
-                subject: `friction:${move.kind}`,
-                origin: "derived",
-                verdict: move.friction.verdict,
-            });
+            JudgementLog.getInstance().record(
+                withReasoning(
+                    {
+                        path: this.session.path,
+                        subject: `friction:${move.kind}`,
+                        origin: "derived",
+                        verdict: move.friction.verdict,
+                    },
+                    text,
+                    confidence
+                )
+            );
         }
         this.reveal(move.kind);
     }

--- a/src/architecture/components/core/proposal/ProposalModal.ts
+++ b/src/architecture/components/core/proposal/ProposalModal.ts
@@ -1,12 +1,17 @@
 import { App, Modal, Setting } from "obsidian";
 import { t } from "architecture/lang";
 import { c } from "architecture";
+import { JUDGEMENT_CONFIDENCES, withReasoning, type JudgementConfidence } from "architecture/knowledge/state";
 
 /** What the user decided about a proposal. `null` (dismissal) is deliberately not a verdict. */
 export interface ProposalOutcome {
     verdict: "accepted" | "modified" | "rejected";
     /** The text to write. Empty for a rejection. */
     text: string;
+    /** Optional short rationale the user gave with the verdict (#361, D1) — recorded, never written. */
+    note?: string;
+    /** Optional how-sure marker the user attached to the verdict (#361, D1). */
+    confidence?: JudgementConfidence;
 }
 
 /**
@@ -27,6 +32,9 @@ export class ProposalModal extends Modal {
     private outcome: ProposalOutcome | null = null;
     private resolve: ((outcome: ProposalOutcome | null) => void) | null = null;
     private acceptLabel: HTMLElement | null = null;
+    /** Optional reasoning captured at the verdict moment (#361, D1) — both empty by default. */
+    private rationale = "";
+    private confidence: JudgementConfidence | undefined;
 
     constructor(app: App, private readonly title: string, proposed: string) {
         super(app);
@@ -59,6 +67,31 @@ export class ProposalModal extends Modal {
             this.current = textarea.value;
             this.refreshAcceptLabel();
         });
+
+        // Optional: capture *why* you ruled, at the moment you rule (#361, D1). Never required — an
+        // empty rationale and an unset confidence record exactly as a bare verdict did before. Built with
+        // the same plain `createEl` the proposed-text box uses, so the reasoning row reads as one piece.
+        contentEl.createEl("label", { text: t("proposal_rationale_label"), cls: c("proposal-reason-label") });
+        contentEl.createEl("p", { text: t("proposal_rationale_desc"), cls: c("proposal-reason-desc") });
+        const rationale = contentEl.createEl("textarea", {
+            cls: c("proposal-reason-input"),
+            attr: { rows: "2", placeholder: t("proposal_rationale_placeholder"), "aria-label": t("proposal_rationale_label") },
+        });
+        rationale.addEventListener("input", () => (this.rationale = rationale.value));
+
+        const confidenceRow = contentEl.createDiv({ cls: c("proposal-confidence") });
+        confidenceRow.createEl("label", { text: t("proposal_confidence_label"), cls: c("proposal-confidence-label") });
+        const confidence = confidenceRow.createEl("select", {
+            cls: c("proposal-confidence-select"),
+            attr: { "aria-label": t("proposal_confidence_label") },
+        });
+        confidence.createEl("option", { text: t("confidence_unset"), value: "" });
+        for (const level of JUDGEMENT_CONFIDENCES) {
+            confidence.createEl("option", { text: t(`confidence_${level}` as Parameters<typeof t>[0]), value: level });
+        }
+        confidence.addEventListener("change", () =>
+            (this.confidence = confidence.value ? (confidence.value as JudgementConfidence) : undefined)
+        );
 
         new Setting(contentEl)
             .addButton((btn) => {
@@ -99,7 +132,7 @@ export class ProposalModal extends Modal {
     }
 
     private finish(outcome: ProposalOutcome): void {
-        this.outcome = outcome;
+        this.outcome = withReasoning(outcome, this.rationale, this.confidence);
         this.close();
     }
 }

--- a/src/architecture/knowledge/judgement/Judgement.ts
+++ b/src/architecture/knowledge/judgement/Judgement.ts
@@ -22,6 +22,13 @@ export type JudgementOrigin = (typeof JUDGEMENT_ORIGINS)[number];
 export const JUDGEMENT_VERDICTS = ["accepted", "modified", "rejected", "confirmed", "challenged"] as const;
 export type JudgementVerdict = (typeof JUDGEMENT_VERDICTS)[number];
 
+/**
+ * How sure the user was when they ruled (#361, D1). Locale-free — the i18n layer maps these to text.
+ * Optional everywhere: a verdict given without one is the norm, never a gap to fill.
+ */
+export const JUDGEMENT_CONFIDENCES = ["low", "medium", "high"] as const;
+export type JudgementConfidence = (typeof JUDGEMENT_CONFIDENCES)[number];
+
 /** One recorded human decision about one idea. */
 export interface Judgement {
     /** When the verdict was given. */
@@ -38,6 +45,11 @@ export interface Judgement {
     verdict: JudgementVerdict;
     /** Optional short user remark. Omitted when blank. */
     note?: string;
+    /**
+     * Optional how-sure marker (#361, D1). Omitted when the user did not say. This is the only
+     * *interpretation* the record carries about the verdict itself, and it is never required.
+     */
+    confidence?: JudgementConfidence;
 }
 
 /** Keep at most this many judgements (drop oldest on overflow), like every other persisted list. */
@@ -45,6 +57,7 @@ export const DEFAULT_MAX_JUDGEMENTS = 500;
 
 const ORIGINS = new Set<string>(JUDGEMENT_ORIGINS);
 const VERDICTS = new Set<string>(JUDGEMENT_VERDICTS);
+const CONFIDENCES = new Set<string>(JUDGEMENT_CONFIDENCES);
 
 /** Whether an unknown value is a well-formed {@link Judgement}. Never throws. */
 export function isJudgement(value: unknown): value is Judgement {
@@ -61,7 +74,9 @@ export function isJudgement(value: unknown): value is Judgement {
         ORIGINS.has(candidate.origin) &&
         typeof candidate.verdict === "string" &&
         VERDICTS.has(candidate.verdict) &&
-        (candidate.note === undefined || typeof candidate.note === "string")
+        (candidate.note === undefined || typeof candidate.note === "string") &&
+        (candidate.confidence === undefined ||
+            (typeof candidate.confidence === "string" && CONFIDENCES.has(candidate.confidence)))
     );
 }
 
@@ -76,6 +91,7 @@ function normalize(entry: Judgement): Judgement {
         verdict: entry.verdict,
     };
     if (note) clean.note = note;
+    if (entry.confidence) clean.confidence = entry.confidence;
     return clean;
 }
 
@@ -112,6 +128,25 @@ export function recordJudgement(
     const maxLen = opts.maxLen ?? DEFAULT_MAX_JUDGEMENTS;
     const next = [...history, clean];
     return next.length > maxLen ? next.slice(next.length - maxLen) : next;
+}
+
+/**
+ * Attach an optional rationale + confidence to a base record (#361, D1), **omitting each** when the note
+ * is blank or the confidence unset — so a bare verdict stays byte-identical to a pre-D1 one. The one home
+ * for the "reasoning rides along only when the user gave it" rule, shared by the AI proposal path and the
+ * Cultivate friction path so the two cannot drift. Pure; never mutates `base`.
+ */
+export function withReasoning<T extends object>(
+    base: T,
+    note: string | undefined,
+    confidence: JudgementConfidence | undefined
+): T & { note?: string; confidence?: JudgementConfidence } {
+    const trimmed = note?.trim();
+    return {
+        ...base,
+        ...(trimmed ? { note: trimmed } : {}),
+        ...(confidence ? { confidence } : {}),
+    };
 }
 
 /**

--- a/src/architecture/knowledge/judgement/judgementQueries.ts
+++ b/src/architecture/knowledge/judgement/judgementQueries.ts
@@ -3,6 +3,7 @@ import {
     JUDGEMENT_ORIGINS,
     JUDGEMENT_VERDICTS,
     type Judgement,
+    type JudgementConfidence,
     type JudgementOrigin,
     type JudgementVerdict,
 } from "./Judgement";
@@ -41,6 +42,13 @@ export interface AgencySignals {
     byOrigin: Record<JudgementOrigin, number>;
     /** When the idea was last ruled on, or `null` if never. */
     lastAt: number | null;
+    /**
+     * Whether any judgement on this idea carried a written rationale (#361, D1). A *reasoned* verdict is
+     * a richer signal than a bare one — but its absence is still an unknown, never a mark against you.
+     */
+    hasRationale: boolean;
+    /** The confidence attached to the **most recent** judgement, or `null` when it carried none (#361, D1). */
+    lastConfidence: JudgementConfidence | null;
 }
 
 function zeroed<K extends string>(keys: readonly K[]): Record<K, number> {
@@ -61,6 +69,8 @@ export function agencySignals(history: readonly Judgement[], path: string): Agen
         byVerdict: zeroed(JUDGEMENT_VERDICTS),
         byOrigin: zeroed(JUDGEMENT_ORIGINS),
         lastAt: null,
+        hasRationale: false,
+        lastConfidence: null,
     };
 
     for (const entry of history) {
@@ -68,7 +78,11 @@ export function agencySignals(history: readonly Judgement[], path: string): Agen
         signals.total++;
         signals.byVerdict[entry.verdict]++;
         signals.byOrigin[entry.origin]++;
-        if (signals.lastAt === null || entry.at > signals.lastAt) signals.lastAt = entry.at;
+        if (entry.note !== undefined) signals.hasRationale = true;
+        if (signals.lastAt === null || entry.at > signals.lastAt) {
+            signals.lastAt = entry.at;
+            signals.lastConfidence = entry.confidence ?? null;
+        }
     }
     return signals;
 }

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -1140,6 +1140,14 @@ export default {
     proposal_save_edit: 'Save my edit',
     proposal_reject: 'Reject',
     proposal_recorded_hint: 'Nothing is written until you accept. Your verdict is recorded either way.',
+    proposal_rationale_label: 'Why (optional)',
+    proposal_rationale_desc: 'A sentence on your reasoning. Recorded with your verdict — never written to the note.',
+    proposal_rationale_placeholder: 'Your reasoning — a sentence is enough',
+    proposal_confidence_label: 'How sure are you?',
+    confidence_unset: 'Not specified',
+    confidence_low: 'Low',
+    confidence_medium: 'Medium',
+    confidence_high: 'High',
 
     // Action purposes (#187) — the one-line description shown in the action picker card.
     prompt_purpose: 'Add text as property/context/body to the note.',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -1141,6 +1141,14 @@ export default {
     proposal_save_edit: 'Guardar mi versión',
     proposal_reject: 'Rechazar',
     proposal_recorded_hint: 'No se escribe nada hasta que aceptas. Tu decisión queda registrada en cualquier caso.',
+    proposal_rationale_label: 'Por qué (opcional)',
+    proposal_rationale_desc: 'Una frase sobre tu razonamiento. Se registra con tu veredicto — nunca se escribe en la nota.',
+    proposal_rationale_placeholder: 'Tu razonamiento — una frase basta',
+    proposal_confidence_label: '¿Cómo de seguro estás?',
+    confidence_unset: 'Sin especificar',
+    confidence_low: 'Baja',
+    confidence_medium: 'Media',
+    confidence_high: 'Alta',
 
     // Propósitos de las acciones (#187) — la descripción de una línea que se muestra en el selector de acciones.
     prompt_purpose: 'Añade texto como propiedad/contexto/cuerpo a la nota.',

--- a/src/styles/components/cultivate.scss
+++ b/src/styles/components/cultivate.scss
@@ -142,6 +142,19 @@
     font-family: var(--font-text);
 }
 
+// The optional how-sure marker on a friction reading (#361, D1).
+.zettelkasten-flow__cultivate-friction-confidence {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2);
+    margin-block-start: var(--size-4-2);
+}
+
+.zettelkasten-flow__cultivate-friction-confidence-label {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+}
+
 .zettelkasten-flow__cultivate-friction-actions {
     display: flex;
     gap: var(--size-4-2);

--- a/src/styles/components/proposal.scss
+++ b/src/styles/components/proposal.scss
@@ -21,3 +21,36 @@
     font-size: var(--font-ui-smaller);
     margin-block: var(--size-4-2) 0;
 }
+
+// The optional reasoning capture (#361, D1): why you ruled, and how sure — never required.
+.zettelkasten-flow__proposal-reason-label,
+.zettelkasten-flow__proposal-confidence-label {
+    display: block;
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+    margin-block: var(--size-4-3) var(--size-4-1);
+}
+
+.zettelkasten-flow__proposal-reason-desc {
+    color: var(--text-faint);
+    font-size: var(--font-ui-smaller);
+    margin-block: 0 var(--size-4-1);
+}
+
+.zettelkasten-flow__proposal-reason-input {
+    width: 100%;
+    resize: vertical;
+    min-height: 3rem;
+    font-family: var(--font-text);
+}
+
+.zettelkasten-flow__proposal-confidence {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2);
+    margin-block-start: var(--size-4-2);
+
+    .zettelkasten-flow__proposal-confidence-label {
+        margin-block: 0;
+    }
+}

--- a/test/actions/ai/aiVerdict.test.ts
+++ b/test/actions/ai/aiVerdict.test.ts
@@ -58,6 +58,22 @@ describe("agency-aware AI: the model proposes, the user commits (#337, §XII)", 
         ]);
     });
 
+    it("records the user's rationale and confidence when the verdict carries them (#361, D1)", async () => {
+        const { info } = fakeInfo();
+        const { recorded, dep } = deps({ verdict: "accepted", text: "keep", note: "the source is weak", confidence: "high" });
+
+        await runAiActionFromPrompt(info, el, "prompt", spec, dep);
+
+        expect(recorded[0]).toEqual({
+            path: NOTE,
+            subject: "challenge-idea",
+            origin: "ai",
+            verdict: "accepted",
+            note: "the source is weak",
+            confidence: "high",
+        });
+    });
+
     it("writes the completion when it is accepted", async () => {
         const { info, frontmatter } = fakeInfo();
         const { recorded, dep } = deps({ verdict: "accepted", text: "This idea assumes atomicity is always desirable." });

--- a/test/architecture/knowledge/judgement/judgementQueries.test.ts
+++ b/test/architecture/knowledge/judgement/judgementQueries.test.ts
@@ -89,6 +89,35 @@ describe("agencySignals (#336, AC-1 — a well-defined unknown, never a score)",
     });
 });
 
+describe("agencySignals — rationale + confidence (#361, D1)", () => {
+    it("reports hasRationale=false when no judgement carried a note", () => {
+        expect(agencySignals([j()], A).hasRationale).toBe(false);
+    });
+
+    it("reports hasRationale=true when any judgement for that path carried a note", () => {
+        const log = [j({ at: T0 }), j({ at: T0 + 1, note: "because the source is weak" })];
+        expect(agencySignals(log, A).hasRationale).toBe(true);
+    });
+
+    it("a note on another path does not set hasRationale", () => {
+        expect(agencySignals([j({ path: B, note: "elsewhere" })], A).hasRationale).toBe(false);
+    });
+
+    it("lastConfidence is null when the idea was never ruled on", () => {
+        expect(agencySignals([], A).lastConfidence).toBeNull();
+    });
+
+    it("lastConfidence is the confidence of the most recent judgement", () => {
+        const log = [j({ at: T0, confidence: "low" }), j({ at: T0 + DAY, confidence: "high" })];
+        expect(agencySignals(log, A).lastConfidence).toBe("high");
+    });
+
+    it("lastConfidence is null when the most recent judgement omitted confidence", () => {
+        const log = [j({ at: T0, confidence: "high" }), j({ at: T0 + DAY })];
+        expect(agencySignals(log, A).lastConfidence).toBeNull();
+    });
+});
+
 describe("judgementDays (#336, the tally S4 reframes the streak onto)", () => {
     it("is empty for an empty log", () => {
         expect(judgementDays([])).toEqual({});

--- a/test/architecture/knowledge/judgement/recordJudgement.test.ts
+++ b/test/architecture/knowledge/judgement/recordJudgement.test.ts
@@ -3,6 +3,7 @@ import {
     DEFAULT_MAX_JUDGEMENTS,
     recordJudgement,
     sanitizeJudgementLog,
+    withReasoning,
     type Judgement,
 } from "architecture/knowledge/judgement";
 
@@ -97,6 +98,22 @@ describe("recordJudgement (#336, FR-6)", () => {
         const [recorded] = recordJudgement([], entry({ note: "the counterexample stands" }));
         expect(recorded.note).toBe("the counterexample stands");
     });
+
+    it("keeps a valid confidence (#361, D1)", () => {
+        const [recorded] = recordJudgement([], entry({ confidence: "high" }));
+        expect(recorded.confidence).toBe("high");
+    });
+
+    it("omits the confidence field entirely when none is given — a legacy-shaped record (#361, D1)", () => {
+        const [recorded] = recordJudgement([], entry());
+        expect("confidence" in recorded).toBe(false);
+    });
+
+    it("returns the same reference for a confidence outside the closed set (#361, D1)", () => {
+        const history = [entry()];
+        const bogus = entry({ confidence: "certain" as Judgement["confidence"] });
+        expect(recordJudgement(history, bogus)).toBe(history);
+    });
 });
 
 describe("sanitizeJudgementLog (#336, AC-5)", () => {
@@ -112,7 +129,47 @@ describe("sanitizeJudgementLog (#336, AC-5)", () => {
         expect(sanitizeJudgementLog(raw)).toEqual([entry(), entry({ at: T0 + 1, verdict: "accepted" })]);
     });
 
+    it("round-trips a rich record (confidence + note) through record → sanitize unchanged (#361, D1)", () => {
+        const recorded = recordJudgement([], entry({ confidence: "high", note: "the counterexample stands" }));
+        expect(sanitizeJudgementLog(recorded)).toEqual(recorded);
+    });
+
+    it("still validates a legacy entry that has neither note nor confidence (#361, D1)", () => {
+        expect(sanitizeJudgementLog([entry()])).toEqual([entry()]);
+    });
+
     it("never throws", () => {
         expect(() => sanitizeJudgementLog([{ at: "soon" }, Symbol("x")])).not.toThrow();
+    });
+});
+
+describe("withReasoning (#361, D1) — the one home for optional rationale + confidence", () => {
+    const base = { path: "ideas/atomicity.md", subject: "connect", origin: "derived", verdict: "confirmed" } as const;
+
+    it("attaches a trimmed note when it has text", () => {
+        expect(withReasoning(base, "  because the source is weak  ", undefined)).toEqual({
+            ...base,
+            note: "because the source is weak",
+        });
+    });
+
+    it("omits the note when it is blank or undefined", () => {
+        expect(withReasoning(base, "   ", undefined)).toEqual(base);
+        expect(withReasoning(base, undefined, undefined)).toEqual(base);
+    });
+
+    it("attaches confidence when set and omits it when undefined", () => {
+        expect(withReasoning(base, undefined, "high")).toEqual({ ...base, confidence: "high" });
+        expect(withReasoning(base, undefined, undefined)).toEqual(base);
+    });
+
+    it("attaches both together", () => {
+        expect(withReasoning(base, "why", "low")).toEqual({ ...base, note: "why", confidence: "low" });
+    });
+
+    it("never mutates the base record", () => {
+        const copy = { ...base };
+        withReasoning(copy, "x", "high");
+        expect(copy).toEqual(base);
     });
 });

--- a/test/config/localeKeysAreUsed.test.ts
+++ b/test/config/localeKeysAreUsed.test.ts
@@ -16,7 +16,7 @@ const LOCALE_DIR = join("architecture", "lang", "locale");
  *
  * Adding a prefix here is how you *keep* a key; it should be a deliberate, rare act.
  */
-const COMPOSED_PREFIXES = ["condition_op_", "cultivate_move_", "system_difficulty_"];
+const COMPOSED_PREFIXES = ["condition_op_", "cultivate_move_", "system_difficulty_", "confidence_"];
 
 function sourceFiles(dir: string): string[] {
     const out: string[] = [];


### PR DESCRIPTION
Closes #361. D1 of epic #360 (3.3 Knowledge dynamics) — the foundation D2 and D4 read.

## What
Turn the judgement record from a *counter of decisions* into a *memory of reasoning* (constitution §XII):
- `Judgement` gains an optional `confidence` (`low`/`medium`/`high`); `agencySignals` exposes `hasRationale` + `lastConfidence`. Both fields optional — a bare verdict records **byte-identically** to before.
- One pure `withReasoning` helper attaches optional note/confidence to a record — the single home for the "reasoning rides along only when given" rule, shared by the AI proposal path and the Cultivate friction path so the two cannot drift.
- The AI `ProposalModal` offers an optional rationale field + confidence selector; the Cultivate friction **reading is now recorded as the rationale**, with a confidence marker.

## Agency (§XII)
Nothing here writes to a note; it only enriches the recorded verdict. Capture is always optional — friction is not a tax.

## Tests / verify
- Model: confidence round-trip + validation, `agencySignals` rationale/confidence, `withReasoning` (pure). AI wiring: rationale/confidence flow through `proposeCompletion` only when given.
- `npm run verify` green · `lint:obsidian` clean · full suite **1350 tests** · coverage floor met (functions 74.08%).
- i18n en+es (sentence case). Docs: `docs/development/cognitive-agency.md` updated. No README change — this refines the existing cognitive-agency surface, not a new command/view/action.