### PR TITLE
feat(state): D4 — trajectory (advancing / steady / stalled) (#364)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -35,6 +35,7 @@ For what the surfaces are, which variables each one binds, and worked recipes, s
 | `reasoningPaths` | `(start: string, opts?: ReasoningPathsOptions) => Path[]` | Chains of reasoning leading out of an idea. |
 | `recommendations` | `() => KnowledgeRecommendation[]` | What to do next, ranked — the same list the Home surface shows. |
 | `review` | `(now?: number, windowDays?: number) => WeeklyReview` | What changed, stalled and matured over a recent window. |
+| `trajectory` | `(now?: number, opts?: TrajectoryOptions) => IdeaTrajectory[]` | Which important ideas are advancing, steady or stalled by how recently you ruled on them. |
 | `unexamined` | `(opts?: { limit?: number }) => UnexaminedIdea[]` | Ideas that gained structure but carry no judgement of yours. |
 
 ## AI — `zf.ai`

--- a/docs/development/cognitive-agency.md
+++ b/docs/development/cognitive-agency.md
@@ -65,6 +65,10 @@ All pure, all offline, all reachable through the Knowledge State barrel:
   (`lastConfidence`).
 - `judgementDays(history)` — verdicts per UTC day, reusing the heatmap's own day key so the two
   definitions of "a day" cannot drift.
+- `trajectory(model, history, now)` (#364) — every well-connected idea placed on an *advancing / steady
+  / stalled* spectrum by how recently you ruled on it: the read side of *"is this idea moving, or has it
+  stalled?"*. A stalled idea grew but carries no recent verdict; `unexaminedIdeas` (never ruled on) is
+  its `lastMovementAt: null` extreme. Queryable from a script as `zf.knowledge.trajectory()`. Still no score.
 
 ### There is no score
 

--- a/src/architecture/api/lib/knowledge/knowledgeApi.ts
+++ b/src/architecture/api/lib/knowledge/knowledgeApi.ts
@@ -22,6 +22,7 @@ import {
     lastJudgementFor,
     agencySignals,
     unexaminedIdeas,
+    trajectory,
 } from "architecture/knowledge/state";
 
 /**
@@ -219,6 +220,12 @@ export function knowledgeApi(deps: KnowledgeApiDeps): Record<string, KnowledgeMe
             signature: "(path: string) => Judgement | null",
             summary: "The most recent verdict on one idea, or null.",
             call: (path: string) => lastJudgementFor(history(), path),
+        },
+        trajectory: {
+            signature: "(now?: number, opts?: TrajectoryOptions) => IdeaTrajectory[]",
+            summary: "Which important ideas are advancing, steady or stalled by how recently you ruled on them.",
+            call: (now?: number, opts?: Parameters<typeof trajectory>[3]) =>
+                trajectory(model(), history(), now ?? Date.now(), opts),
         },
     };
 }

--- a/src/architecture/knowledge/state/index.ts
+++ b/src/architecture/knowledge/state/index.ts
@@ -44,3 +44,4 @@ export type { Snapshot } from "architecture/knowledge/timeline/recordSnapshot";
 export * from "architecture/knowledge/timeline/timelineEvents";
 export * from "./classifyHealth";
 export * from "./recommendation";
+export * from "./trajectory";

--- a/src/architecture/knowledge/state/trajectory.ts
+++ b/src/architecture/knowledge/state/trajectory.ts
@@ -1,0 +1,75 @@
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import { lastJudgementFor } from "architecture/knowledge/judgement/judgementQueries";
+import { UNEXAMINED_MIN_DEGREE } from "architecture/knowledge/judgement/unexamined";
+import type { Judgement } from "architecture/knowledge/judgement/Judgement";
+
+/**
+ * Idea **trajectory** (#364, D4) — the read side of the manifesto's question *"has my understanding
+ * changed, or has my vault just grown?"*. Lifecycle tells you an idea's *state*; this tells you its
+ * *direction*: is it moving, or has it stalled?
+ *
+ * "Movement" here is **cognitive**, not structural — a recorded verdict (#336), the thing that is scarce.
+ * An idea can accrue links and claims for weeks; that is growth, not thought. So an idea that is
+ * structurally *important* (well connected) but carries no recent judgement is **stalled**, and one you
+ * ruled on lately is **advancing**. Pure, deterministic (inject `now`), offline. It returns **ideas and
+ * a direction** — never a number about you: no score, no ratio, no grade (§XI: metrics are consequences).
+ */
+
+/** Which way an idea is moving, by how recently you exercised judgement over it. */
+export type TrajectoryDirection = "advancing" | "steady" | "stalled";
+
+/** One important idea and its cognitive direction. */
+export interface IdeaTrajectory {
+    path: string;
+    direction: TrajectoryDirection;
+    /** When the idea last received a verdict (cognitive movement), or `null` if it never has. */
+    lastMovementAt: number | null;
+}
+
+export interface TrajectoryOptions {
+    /** Connectivity floor — below it an idea is simply *new*, not stalled (default {@link UNEXAMINED_MIN_DEGREE}). */
+    minDegree?: number;
+    /** A verdict within this many days ⇒ `advancing` (default {@link TRAJECTORY_FRESH_DAYS}). */
+    freshWithinDays?: number;
+    /** No verdict for at least this many days ⇒ `stalled` (default {@link TRAJECTORY_STALE_DAYS}). */
+    staleAfterDays?: number;
+}
+
+const DAY = 86_400_000;
+
+/** A verdict within a week reads as active thinking. */
+export const TRAJECTORY_FRESH_DAYS = 7;
+
+/** A month with no verdict on an otherwise-substantial idea reads as stalled. */
+export const TRAJECTORY_STALE_DAYS = 30;
+
+/**
+ * Classify every **important** idea (degree ≥ `minDegree`) as advancing / steady / stalled by the age of
+ * its most recent verdict. A never-judged important idea is stalled with `lastMovementAt: null` — the same
+ * "grew without your judgement" case {@link unexaminedIdeas} names, now placed on a spectrum. Stalled
+ * ideas sort first (they are where attention is owed), then by path for a stable order. Never throws.
+ */
+export function trajectory(
+    model: KnowledgeModel,
+    history: readonly Judgement[],
+    now: number,
+    opts: TrajectoryOptions = {}
+): IdeaTrajectory[] {
+    const minDegree = opts.minDegree ?? UNEXAMINED_MIN_DEGREE;
+    const freshMs = (opts.freshWithinDays ?? TRAJECTORY_FRESH_DAYS) * DAY;
+    const staleMs = (opts.staleAfterDays ?? TRAJECTORY_STALE_DAYS) * DAY;
+
+    const out: IdeaTrajectory[] = [];
+    for (const idea of model.all()) {
+        if (idea.maturitySignals.degree < minDegree) continue; // just new — not neglected
+        const last = lastJudgementFor(history, idea.path);
+        const lastMovementAt = last ? last.at : null;
+        const age = lastMovementAt === null ? Infinity : now - lastMovementAt;
+        const direction: TrajectoryDirection = age > staleMs ? "stalled" : age <= freshMs ? "advancing" : "steady";
+        out.push({ path: idea.path, direction, lastMovementAt });
+    }
+
+    const rank = (d: TrajectoryDirection) => (d === "stalled" ? 0 : d === "steady" ? 1 : 2);
+    out.sort((a, b) => rank(a.direction) - rank(b.direction) || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+    return out;
+}

--- a/test/architecture/knowledge/state/trajectory.test.ts
+++ b/test/architecture/knowledge/state/trajectory.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "@jest/globals";
+import { trajectory, TRAJECTORY_FRESH_DAYS, TRAJECTORY_STALE_DAYS } from "architecture/knowledge/state/trajectory";
+import type { Judgement } from "architecture/knowledge/judgement";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 8, 7, 12, 0, 0);
+
+// hub.md has degree 4 (important); the leaves have degree 1 (just new, not tracked).
+const model = buildModel([
+    idea("hub.md", "permanent", [{ to: "a.md" }, { to: "b.md" }, { to: "c.md" }, { to: "d.md" }]),
+    ...["a", "b", "c", "d"].map((n) => idea(`${n}.md`, "permanent", [])),
+]);
+const j = (at: number, path = "hub.md"): Judgement => ({ at, path, subject: "connect", origin: "derived", verdict: "confirmed" });
+const hub = (history: Judgement[]) => trajectory(model, history, NOW).find((e) => e.path === "hub.md");
+
+describe("trajectory (#364, D4) — advancing / steady / stalled, never a score", () => {
+    it("marks an important idea judged recently as advancing", () => {
+        expect(hub([j(NOW - 2 * DAY)])?.direction).toBe("advancing");
+    });
+
+    it("marks an important idea judged long ago as stalled", () => {
+        expect(hub([j(NOW - (TRAJECTORY_STALE_DAYS + 5) * DAY)])?.direction).toBe("stalled");
+    });
+
+    it("marks an important idea never judged as stalled, with a null lastMovementAt", () => {
+        const entry = hub([]);
+        expect(entry?.direction).toBe("stalled");
+        expect(entry?.lastMovementAt).toBeNull();
+    });
+
+    it("marks an idea judged between the windows as steady", () => {
+        expect(hub([j(NOW - (TRAJECTORY_FRESH_DAYS + 5) * DAY)])?.direction).toBe("steady");
+    });
+
+    it("does not track ideas below the connectivity floor — new is not stalled", () => {
+        expect(trajectory(model, [], NOW).some((e) => e.path === "a.md")).toBe(false);
+    });
+
+    it("reports the last verdict time as lastMovementAt", () => {
+        const at = NOW - 3 * DAY;
+        expect(hub([j(at)])?.lastMovementAt).toBe(at);
+    });
+
+    it("returns no numeric grade or score — only path, direction, lastMovementAt", () => {
+        const [entry] = trajectory(model, [], NOW);
+        expect(Object.keys(entry).sort()).toEqual(["direction", "lastMovementAt", "path"]);
+    });
+
+    it("orders stalled ideas before advancing ones, then by path (deterministic)", () => {
+        const twoHubs = buildModel([
+            idea("z.md", "permanent", [{ to: "a.md" }, { to: "b.md" }, { to: "c.md" }]),
+            idea("y.md", "permanent", [{ to: "a.md" }, { to: "b.md" }, { to: "c.md" }]),
+            ...["a", "b", "c"].map((n) => idea(`${n}.md`, "permanent", [])),
+        ]);
+        // z judged today (advancing); y never judged (stalled) — stalled must come first.
+        const events = trajectory(twoHubs, [j(NOW - DAY, "z.md")], NOW);
+        expect(events.map((e) => e.path)).toEqual(["y.md", "z.md"]);
+    });
+
+    it("says nothing about an empty model", () => {
+        expect(trajectory(buildModel([]), [], NOW)).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #364. D4 of epic #360.

## What
A pure projection classifying every well-connected idea by how recently you ruled on it — the read side of *"has my understanding changed, or has my vault just grown?"*:
- `trajectory(model, history, now, opts)` → `{ path, direction, lastMovementAt }` for each important idea (degree ≥ 3). **advancing** = ruled on within a week; **stalled** = no verdict for a month (or never — the `unexaminedIdeas` extreme); **steady** in between. Stalled first, then by path. No score, no grade.
- Exposed as `zf.knowledge.trajectory()` — a consequence-of-model query, **not** a new UI surface.

## Why not fold into re-engage
`re-engage` (unexaminedIdeas) is left unchanged on purpose: folding wall-clock recency into it would make the recommendation tests time-fragile. Trajectory is the spectrum; `re-engage` stays the "never ruled on" case.

## Tests / verify
Pure unit tests (advancing/steady/stalled, injected `now`, ordering, no-score shape). Generated API reference + `.d.ts` regenerated. Docs: `cognitive-agency.md`. `npm run verify` green, coverage floor met. No README change (a scripting query, not a new command/view/action).