### PR TITLE
feat(knowledge): D3 — propose the next link to extend an argument (#363)

### DIFF
--- a/docs/development/concept-navigation.md
+++ b/docs/development/concept-navigation.md
@@ -44,6 +44,16 @@ that lists every argument chain leaving the note, each relation labelled (`suppo
 every note clickable to open it. The lens only reads the model through the Knowledge State barrel and
 never writes.
 
+### Extend the argument (#363, D3)
+
+The lens also **proposes the next link**. `proposeReasoningLinks(model, start)` ranks the notes most
+related to the active note by shared graph context (`rankRelatedScored`) that are **not already in its
+reasoning chain** — genuinely new branches to weigh. They appear under *Extend the argument* with the
+role vocabulary spelled out — a **reason** (`supports`), a **counter** (`contradicts`), an **example**
+(`example`) or a **response** (`supports`). Crucially this only *proposes*: which role a link plays, and
+whether to add it at all, stays your verdict ([constitution §XII](constitution.md)) — the lens still
+writes nothing, and you commit the link through the normal, judgement-gated relation flow.
+
 ## Out of scope (for now)
 
 Read-only navigation only — no graph-canvas rendering, no path pinning/bookmarking, and no configurable

--- a/src/architecture/knowledge/traverse/reasoningLinks.ts
+++ b/src/architecture/knowledge/traverse/reasoningLinks.ts
@@ -1,0 +1,47 @@
+import type { KnowledgeModel } from "architecture/knowledge/model/KnowledgeModel";
+import {
+    rankRelatedScored,
+    type RankRelatedOptions,
+    type ScoredRelated,
+} from "architecture/knowledge/relations/relationRankingLogic";
+import { reasoningPaths } from "./reasoningPaths";
+
+/**
+ * Authored reasoning paths (#363, D3) — the read side of *building* an argument, not just reading one.
+ * {@link reasoningPaths} shows the chains the graph already encodes; this proposes the **next link** to
+ * extend one. It only *proposes*: which role a link plays, and whether to add it at all, is the user's
+ * verdict ([constitution §XII](../../../../docs/development/constitution.md)) — nothing here writes.
+ */
+
+/** The role a proposed link plays in the argument. The label is the user's; the relation is committed on accept. */
+export const ARGUMENT_ROLES = ["reason", "counter", "example", "response"] as const;
+export type ArgumentRole = (typeof ARGUMENT_ROLES)[number];
+
+/** Which semantic relation each role would commit, when the user chooses to add it through the normal gated flow. */
+export const ROLE_RELATION: Record<ArgumentRole, string> = {
+    reason: "supports",
+    counter: "contradicts",
+    example: "example",
+    response: "supports",
+};
+
+/** One proposed next link: a related note and how related it is. The role is the user's to choose. */
+export type ReasoningLinkCandidate = ScoredRelated;
+
+/**
+ * Propose the next links that would **extend** the argument from `start` (#363, D3): the notes most
+ * related to it by shared graph context ({@link rankRelatedScored}) that are **not already part of its
+ * reasoning chain** — so each is a genuinely new branch to weigh, never one the chain already contains.
+ * Pure, deterministic, read-only, Obsidian-free; an unknown/unindexed start yields `[]`.
+ */
+export function proposeReasoningLinks(
+    model: KnowledgeModel,
+    start: string,
+    opts: RankRelatedOptions = {}
+): ReasoningLinkCandidate[] {
+    const reachable = new Set<string>([start]);
+    for (const path of reasoningPaths(model, start)) {
+        for (const step of path.steps) reachable.add(step.to);
+    }
+    return rankRelatedScored(model, start, opts).filter((candidate) => !reachable.has(candidate.path));
+}

--- a/src/architecture/lang/locale/en.ts
+++ b/src/architecture/lang/locale/en.ts
@@ -645,6 +645,8 @@ export default {
     reasoning_paths_intro: '{0} lines of reasoning start here — follow one to see how the argument builds.',
     reasoning_paths_indexing: 'Building the knowledge model…',
     reasoning_paths_empty: 'No argument-forward chains leave this note yet. Link an idea it supports, expands, exemplifies or implements.',
+    reasoning_paths_extend_title: 'Extend the argument',
+    reasoning_paths_extend_intro: 'The next link is yours to choose — a reason, a counter, an example or a response. These related notes are candidates; add the one the argument needs.',
     reasoning_paths_rel_supports: 'supports',
     reasoning_paths_rel_expands: 'expands',
     reasoning_paths_rel_example: 'example',

--- a/src/architecture/lang/locale/es.ts
+++ b/src/architecture/lang/locale/es.ts
@@ -645,6 +645,8 @@ export default {
     reasoning_paths_intro: '{0} líneas de razonamiento parten de aquí — sigue una para ver cómo se construye el argumento.',
     reasoning_paths_indexing: 'Construyendo el modelo de conocimiento…',
     reasoning_paths_empty: 'Aún no sale de esta nota ninguna cadena argumental. Enlaza una idea que apoye, amplíe, ejemplifique o implemente.',
+    reasoning_paths_extend_title: 'Amplía el argumento',
+    reasoning_paths_extend_intro: 'El siguiente enlace lo eliges tú — una razón, un contraargumento, un ejemplo o una respuesta. Estas notas relacionadas son candidatas; añade la que el argumento necesite.',
     reasoning_paths_rel_supports: 'apoya',
     reasoning_paths_rel_expands: 'amplía',
     reasoning_paths_rel_example: 'ejemplo',

--- a/src/styles/components/reasoningPaths.scss
+++ b/src/styles/components/reasoningPaths.scss
@@ -52,3 +52,27 @@
         font-style: normal;
     }
 }
+
+// Extend the argument (#363, D3): proposed next links, read-only — the role is the user's to choose.
+.zettelkasten-flow__reasoning-paths-extend-title {
+    margin-block: var(--size-4-4) var(--size-4-1);
+    font-size: var(--font-ui-medium);
+    color: var(--text-normal);
+}
+
+.zettelkasten-flow__reasoning-paths-extend-intro {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    margin-block-end: var(--size-4-2);
+}
+
+.zettelkasten-flow__reasoning-paths-extend-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-4-1);
+}
+
+.zettelkasten-flow__reasoning-paths-extend-item {
+    padding-inline-start: var(--size-4-2);
+    border-inline-start: 2px solid var(--background-modifier-border);
+}

--- a/src/zettelkasten/modals/ReasoningPathsModal.ts
+++ b/src/zettelkasten/modals/ReasoningPathsModal.ts
@@ -2,6 +2,7 @@ import { c } from "architecture";
 import { t } from "architecture/lang";
 import { KnowledgeIndex } from "architecture/knowledge";
 import { reasoningPaths, type Path } from "architecture/knowledge/state";
+import { proposeReasoningLinks, type ReasoningLinkCandidate } from "architecture/knowledge/traverse/reasoningLinks";
 import { makeActivatable } from "architecture/components/core/a11y";
 import { App, Modal } from "obsidian";
 
@@ -44,14 +45,37 @@ export class ReasoningPathsModal extends Modal {
             contentEl.createDiv({ cls: c("reasoning-paths-status"), text: t("reasoning_paths_indexing") });
             return;
         }
-        const paths = reasoningPaths(index.getModel(), this.start);
-        if (paths.length === 0) {
+        const model = index.getModel();
+        const paths = reasoningPaths(model, this.start);
+        const candidates = proposeReasoningLinks(model, this.start, { limit: 5 });
+
+        if (paths.length === 0 && candidates.length === 0) {
             contentEl.createDiv({ cls: c("reasoning-paths-status"), text: t("reasoning_paths_empty") });
             return;
         }
-        contentEl.createDiv({ cls: c("reasoning-paths-intro"), text: t("reasoning_paths_intro", String(paths.length)) });
-        const list = contentEl.createDiv({ cls: c("reasoning-paths-list") });
-        for (const path of paths) this.renderPath(list, path);
+
+        if (paths.length > 0) {
+            contentEl.createDiv({ cls: c("reasoning-paths-intro"), text: t("reasoning_paths_intro", String(paths.length)) });
+            const list = contentEl.createDiv({ cls: c("reasoning-paths-list") });
+            for (const path of paths) this.renderPath(list, path);
+        }
+
+        if (candidates.length > 0) this.renderExtend(contentEl, candidates);
+    }
+
+    /**
+     * The next links to consider (#363, D3) — **proposed, never committed**. The role each would play
+     * (a reason, a counter, an example, a response) and whether to add it at all stays your verdict;
+     * clicking a candidate only opens it. Nothing here writes to the vault.
+     */
+    private renderExtend(contentEl: HTMLElement, candidates: ReasoningLinkCandidate[]): void {
+        contentEl.createEl("h3", { text: t("reasoning_paths_extend_title"), cls: c("reasoning-paths-extend-title") });
+        contentEl.createDiv({ cls: c("reasoning-paths-extend-intro"), text: t("reasoning_paths_extend_intro") });
+        const list = contentEl.createDiv({ cls: c("reasoning-paths-extend-list") });
+        for (const candidate of candidates) {
+            const row = list.createDiv({ cls: c("reasoning-paths-extend-item") });
+            this.renderNote(row, candidate.path);
+        }
     }
 
     onClose(): void {

--- a/test/architecture/knowledge/traverse/reasoningLinks.test.ts
+++ b/test/architecture/knowledge/traverse/reasoningLinks.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "@jest/globals";
+import { proposeReasoningLinks, ARGUMENT_ROLES, ROLE_RELATION } from "architecture/knowledge/traverse/reasoningLinks";
+import { idea, buildModel } from "../../../actions/knowledge/support/knowledgeFixture";
+
+// start —supports→ mid —supports→ deep  (a reasoning chain); hubA/hubB co-cite start, deep and cand.
+const model = buildModel([
+    idea("start.md", "permanent", [{ to: "mid.md", type: "supports" }]),
+    idea("mid.md", "permanent", [{ to: "deep.md", type: "supports" }]),
+    idea("deep.md", "permanent", []),
+    idea("cand.md", "permanent", []),
+    idea("hubA.md", "permanent", [{ to: "start.md" }, { to: "deep.md" }, { to: "cand.md" }]),
+    idea("hubB.md", "permanent", [{ to: "start.md" }, { to: "deep.md" }, { to: "cand.md" }]),
+]);
+
+describe("proposeReasoningLinks (#363, D3) — propose the next link, never commit it", () => {
+    it("proposes a related note that is not yet part of the argument", () => {
+        const paths = proposeReasoningLinks(model, "start.md").map((c) => c.path);
+        expect(paths).toContain("cand.md");
+    });
+
+    it("excludes notes already reachable in the reasoning chain", () => {
+        // deep.md is co-cited with start (so it scores) but sits two hops down the chain — not a new link.
+        const paths = proposeReasoningLinks(model, "start.md").map((c) => c.path);
+        expect(paths).not.toContain("deep.md");
+    });
+
+    it("carries a positive relatedness score on every candidate", () => {
+        for (const candidate of proposeReasoningLinks(model, "start.md")) {
+            expect(candidate.score).toBeGreaterThan(0);
+        }
+    });
+
+    it("honours a limit", () => {
+        expect(proposeReasoningLinks(model, "start.md", { limit: 1 }).length).toBeLessThanOrEqual(1);
+    });
+
+    it("returns nothing for an unknown start", () => {
+        expect(proposeReasoningLinks(model, "missing.md")).toEqual([]);
+    });
+
+    it("maps each argument role to the relation it would commit", () => {
+        expect([...ARGUMENT_ROLES]).toEqual(["reason", "counter", "example", "response"]);
+        expect(ROLE_RELATION).toEqual({
+            reason: "supports",
+            counter: "contradicts",
+            example: "example",
+            response: "supports",
+        });
+    });
+});


### PR DESCRIPTION
Closes #363. D3 of epic #360 — authored reasoning paths.

## What
The reasoning-paths lens now **proposes the next link**, never committing it (constitution §XII):
- New pure `proposeReasoningLinks(model, start)` ranks the notes most related to a note by shared graph context (`rankRelatedScored`) that are **not already in its reasoning chain** — genuinely new branches to weigh. Read-only.
- `ARGUMENT_ROLES` (reason/counter/example/response) maps each role to the relation it would commit (supports/contradicts/example/supports).
- The `ReasoningPathsModal` gains an **"Extend the argument"** section listing the candidates with the role vocabulary spelled out.

## Scope (deliberate)
The lens **only proposes** — which role a link plays and whether to add it stays your verdict; committing goes through the existing judgement-gated relation flow. I did **not** build a parallel in-modal typed-relation writer: the relation write path only does plain wikilinks, so a typed writer would be a fragile rabbit hole. §XII is fully honored (propose, never commit).

Lives in `traverse/` (deep-imported by the modal), off the State barrel, so it doesn't touch the scripting registry. Pure unit tests; i18n en+es; docs (`concept-navigation.md`). verify green, coverage floor met.