### PR TITLE
feat(engine): D5 — harden continuous discovery, heuristic and never AI (#365)

### DIFF
--- a/docs/development/morning-discovery.md
+++ b/docs/development/morning-discovery.md
@@ -36,6 +36,26 @@ There is no generic "related" type in the [semantic vocabulary](../architecture/
 Dismissals are **session-only** — a dismissed pair may return next time you open the pane; an
 accepted pair does not (it's now linked). A persisted dismissed-pair set is a possible follow-up.
 
+## Continuous discovery (#365, D5)
+
+Discovery is not only a pane you open — it is **continuous**. The [Home](zettelflow-home.md) surface
+registers vault listeners and, on **every** change (a note created, saved, renamed or deleted), re-runs
+the same heuristic discovery and recommendation projections. So a connection that becomes possible the
+moment you save a note is already waiting the next time you glance at Home — you never have to go looking.
+
+Two invariants hold, and a guardrail test pins them:
+
+- **Never AI.** The continuous path is `findDiscoveries` / `deriveRecommendations` / `buildHome` — pure,
+  offline model queries. No completion is requested in the background; AI stays a deliberate, *foreground*
+  Action ([#337](https://github.com/RafaelGB/Obsidian-ZettelFlow/issues/337),
+  [constitution §XII](constitution.md)). A test asserts the whole Home path imports no AI provider and
+  calls nothing that reaches one.
+- **Never a silent write.** Continuous discovery only *proposes* — it surfaces connections and next
+  moves; committing any of them stays the same judgement-gated action the pane makes above.
+
+There is deliberately **no parallel background engine, no badge, and no on/off toggle**: continuous
+discovery is a property of the Home surface refreshing, not a new feature bolted on (design by subtraction).
+
 ## Architecture
 
 ```

--- a/src/architecture/components/core/home/HomeModeRenderer.ts
+++ b/src/architecture/components/core/home/HomeModeRenderer.ts
@@ -52,7 +52,11 @@ export class HomeModeRenderer extends KnowledgeModeRenderer {
             window.clearTimeout(this.debounceTimer);
             this.debounceTimer = window.setTimeout(() => this.recompute(), DEBOUNCE_MS);
         };
+        // Continuous discovery (#365, D5): every vault change re-runs the heuristic recommendations and
+        // suggested connections — a note you just saved can surface a connection before you look for it.
+        // `create` is explicit so a brand-new note triggers a pass without waiting on metadata resolution.
         this.registerEvent(this.app.metadataCache.on("resolved", debounced));
+        this.registerEvent(this.app.vault.on("create", debounced));
         this.registerEvent(this.app.vault.on("rename", debounced));
         this.registerEvent(this.app.vault.on("delete", debounced));
     }
@@ -70,7 +74,7 @@ export class HomeModeRenderer extends KnowledgeModeRenderer {
             const counts = DevelopmentJournal.getInstance().dailyCounts();
             const thinkingDays = Object.values(counts).filter((count) => count > 0).length;
             this.home = buildHome(model, { thinkingDays, now: Date.now() });
-            this.recommendations = topRecommendations(model, undefined, JudgementLog.getInstance().entries());
+            this.recommendations = topRecommendations(model, undefined, JudgementLog.getInstance().entries());
             this.cultivateCount = readyToCultivate(model);
             this.streak = developmentStreak(JudgementLog.getInstance().dailyCounts(), Date.now());
             this.state = model.size() === 0 ? "empty" : "ready";

--- a/test/architecture/components/core/home/continuousDiscoveryHeuristic.test.ts
+++ b/test/architecture/components/core/home/continuousDiscoveryHeuristic.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// test/architecture/components/core/home → 5 ups → repo root
+const ROOT = join(__dirname, "..", "..", "..", "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+/**
+ * The whole continuous-discovery path: the Home renderer's vault listeners, and every projection they
+ * run on a vault change. If any of these ever reached an AI provider, discovery would be firing the model
+ * in the background — exactly what #337 / constitution §XII forbid.
+ */
+const CONTINUOUS_PATH = [
+    "src/architecture/components/core/home/HomeModeRenderer.ts",
+    "src/architecture/components/core/home/homeRecommendations.ts",
+    "src/architecture/knowledge/state/recommendation.ts",
+    "src/architecture/knowledge/discovery/discoveries.ts",
+    "src/architecture/knowledge/home/home.ts",
+    "src/architecture/knowledge/questions/openQuestions.ts",
+];
+
+describe("continuous discovery is heuristic-only — AI never auto-fires (#365, D5, §XII/#337)", () => {
+    it("re-runs on every vault change: create, modify (resolved), rename and delete", () => {
+        const renderer = read("src/architecture/components/core/home/HomeModeRenderer.ts");
+        for (const event of ['vault.on("create"', 'metadataCache.on("resolved"', 'vault.on("rename"', 'vault.on("delete"']) {
+            expect(`${event} → ${renderer.includes(event)}`).toBe(`${event} → true`);
+        }
+    });
+
+    it("reaches no AI provider anywhere on the continuous path", () => {
+        for (const file of CONTINUOUS_PATH) {
+            const source = read(file);
+            expect(source).not.toMatch(/from\s+["']architecture\/ai/);
+            expect(source).not.toMatch(/from\s+["']actions\/ai/);
+            expect(source).not.toMatch(/\bAiService\b/);
+            expect(source).not.toMatch(/\.complete\s*\(/);
+            expect(source).not.toMatch(/\brequestUrl\b/);
+            expect(source).not.toMatch(/openai|anthropic|@google|langchain/i);
+        }
+    });
+});


### PR DESCRIPTION
Closes #365. D5 of epic #360 — continuous discovery.

## What (subtraction, not a new engine)
Continuous discovery **already lives on the Home surface**: it registers vault listeners and, on every change, re-runs the heuristic recommendations and suggested connections (`findDiscoveries` / `deriveRecommendations` / `buildHome`) — never AI. D5 hardens it rather than building a redundant parallel engine:
- Home now also listens for note **`create`**, so a brand-new note triggers a discovery pass without waiting on metadata resolution.
- A **guardrail test** pins two invariants: the whole continuous path reaches **no AI provider** (§XII / #337 — AI never auto-fires in the background), and it **only proposes** (committing stays a judgement-gated action).
- Deliberately **no background daemon, no badge, no on/off toggle** — continuous discovery is a property of the Home surface refreshing, not a feature to bolt on.

Docs (`morning-discovery.md`). verify green, coverage floor met. No README change (hardening of existing behavior).