### PR TITLE
fix(scope): read excluded paths from the injected plugin, not the global lookup (#374)

### DIFF
--- a/src/architecture/knowledge/KnowledgeIndex.ts
+++ b/src/architecture/knowledge/KnowledgeIndex.ts
@@ -36,6 +36,13 @@ export class KnowledgeIndex {
     private readonly model = new KnowledgeModel();
     private schemas: KnowledgeSchemas = {};
     private currentStatus: KnowledgeIndexStatus = "idle";
+    /**
+     * The live settings host, injected at {@link bootstrap} (#374). Scope is read from **here** rather
+     * than `ObsidianApi.getOwnPlugin()`, because `app.plugins.getPlugin(id)` can return `undefined` while
+     * the plugin is still enabling/reloading — which made `excludedPaths()` silently return `[]` and every
+     * exclusion a no-op (notes from excluded folders kept showing up in Cultivate and everywhere else).
+     */
+    private settingsHost: { settings: ScopeSettings } | null = null;
 
     private constructor() {
         // singleton
@@ -67,9 +74,19 @@ export class KnowledgeIndex {
      * own managed system folders (flows, hook flows, JS library), which are auto-excluded so system notes
      * are never treated as knowledge.
      */
+    /**
+     * Inject the settings host (#374). Called by {@link bootstrap} with the live plugin; also lets scope
+     * be exercised in a unit test without a running app.
+     */
+    public useSettingsHost(host: { settings: ScopeSettings } | null): void {
+        this.settingsHost = host;
+    }
+
     private excludedPaths(): readonly string[] {
         try {
-            const settings = ObsidianApi.getOwnPlugin()?.settings as ScopeSettings | undefined;
+            // Prefer the injected host; fall back to the global lookup only when the index was never
+            // bootstrapped (e.g. an isolated test). The injected reference is what makes this reliable.
+            const settings: ScopeSettings | undefined = this.settingsHost?.settings ?? ObsidianApi.getOwnPlugin()?.settings;
             return settings ? scopeExcludedPaths(settings) : [];
         } catch {
             return []; // before settings are wired (or in tests), nothing is excluded
@@ -132,6 +149,8 @@ export class KnowledgeIndex {
      * registered through `plugin.registerEvent`, so they are removed automatically on unload.
      */
     public bootstrap(plugin: Plugin, opts: KnowledgeIndexBootstrapOptions = {}): void {
+        // Read scope from the plugin we are handed, not a global registry lookup that isn't ready yet (#374).
+        this.useSettingsHost(plugin as unknown as { settings: ScopeSettings });
         const vault = ObsidianApi.vault();
         plugin.registerEvent(vault.on("create", (file) => this.onCreate(file)));
         plugin.registerEvent(vault.on("modify", (file) => this.onModify(file)));

--- a/test/architecture/knowledge/KnowledgeIndex.test.ts
+++ b/test/architecture/knowledge/KnowledgeIndex.test.ts
@@ -146,6 +146,25 @@ describe("KnowledgeIndex service", () => {
         __setMockObsidianApi({ ownPlugin: { registerEvent: () => undefined, register: () => undefined } });
     });
 
+    it("reads scope from the injected host even when the global plugin lookup is empty (#374)", () => {
+        // The runtime bug: during enable/reload, app.plugins.getPlugin(id) returns a plugin with no scope
+        // settings, so excludedPaths() used to fall back to [] and nothing was excluded. The host wired at
+        // bootstrap fixes it — here getOwnPlugin has no excludedPaths, but the injected host does.
+        wire([file("ideas/a.md"), file("🧮 Bases/x.md")]);
+        __setMockObsidianApi({
+            ownPlugin: { registerEvent: () => undefined, register: () => undefined, settings: {} },
+        });
+        const index = KnowledgeIndex.getInstance();
+        index.useSettingsHost({ settings: { excludedPaths: ["🧮 Bases"] } });
+        index.build();
+
+        expect(index.getModel().get("ideas/a.md")).toBeDefined();
+        expect(index.getModel().get("🧮 Bases/x.md")).toBeUndefined();
+
+        index.useSettingsHost(null);
+        __setMockObsidianApi({ ownPlugin: { registerEvent: () => undefined, register: () => undefined } });
+    });
+
     it("ignores non-markdown files", () => {
         wire([]);
         const index = KnowledgeIndex.getInstance();


### PR DESCRIPTION
Closes #374. The runtime completion of the excluded-paths fix (follow-up to #375, which fixed the *values* — CRUD folder-picker + NFC — but not the *delivery*).

## Root cause (found by instrumenting the reporting vault)
`KnowledgeIndex.excludedPaths()` read scope via `ObsidianApi.getOwnPlugin()` — i.e. `app.plugins.getPlugin('zettelflow')` — which returns **undefined while the plugin is still enabling/reloading**. So `excludedPaths()` fell back to `[]`, the build indexed **every** note, and excluded folders kept appearing in Cultivate, Home, discovery — everywhere.

The stored values were never the problem: a dump from the live vault showed the saved `excludedPaths` matched the disk folder names **exactly** and `isPathExcluded` returned `true`; the settings simply weren't reaching the build.

## Fix
The index now reads scope from the **plugin reference `bootstrap()` already receives** (like every other service that gets `this` injected), not the global registry lookup. `getOwnPlugin()` stays only as a test-time fallback.

**Verified live:** with the fix, the same vault reports `total 905 · inScope 421 · excluded 484` — the four excluded folders (emoji + number-prefixed names) are correctly out of the model, so Cultivate can no longer surface them.

## Test
`KnowledgeIndex` build excludes an emoji folder using the **injected host even when `getOwnPlugin()` has no scope settings** (reproduces the enable/reload timing). `npm run verify` + `lint:obsidian` green; coverage floor met.