### PR TITLE
feat(state): ask-your-graph — incoming: and folder: predicates (#323)

### DIFF
--- a/docs/development/ask-your-graph.md
+++ b/docs/development/ask-your-graph.md
@@ -19,6 +19,8 @@ A blank query matches nothing — the surface asks for intent.
 | `state:<value>` | notes in a lifecycle state, e.g. `state:permanent` |
 | `relation:<type>` | notes with an outgoing typed edge, e.g. `relation:contradicts` |
 | `relation:<type>:<target>` | …pointing at a note whose name/path contains `<target>`, e.g. `relation:supports:decisionA` |
+| `incoming:<type>[:<source>]` | notes with an **incoming** typed edge — the mirror of `relation:`, e.g. `incoming:contradicts` (notes *something contradicts*) |
+| `folder:<path>` | notes under a folder, e.g. `folder:Projects` (folder-boundary match, case- and Unicode-tolerant) |
 | `degree>=<n>` | connectivity — also `<=`, `>`, `<`, `=` (e.g. `degree>=5`) |
 | `hub` | a well-connected note (degree ≥ 5) |
 | `orphan` | nothing links to it (no incoming edges) |
@@ -46,7 +48,7 @@ A useful query can be **saved** (persisted in settings) and re-run from the *Sav
 ```
 runGraphQuery(model, source, now)                    (pure, Obsidian-free, unit-tested)
   → { matches: Idea[], error? }                       DNF of predicate terms; deterministic sort
-  parses: state / relation[:target] / degree cmp / hub / orphan / leaf / unsourced / older-/newer-than / about / !neg
+  parses: state / relation[:target] / incoming[:source] / folder / degree cmp / hub / orphan / leaf / unsourced / older-/newer-than / about / !neg
 
 AskGraphModal (command: ask-your-graph)
   reads the KnowledgeIndex model → runGraphQuery(query)

--- a/src/architecture/knowledge/query/graphQuery.ts
+++ b/src/architecture/knowledge/query/graphQuery.ts
@@ -1,5 +1,6 @@
 import type { Idea } from "../model/Idea";
 import type { KnowledgeModel } from "../model/KnowledgeModel";
+import { incomingRelations } from "./queries";
 
 /**
  * **Ask your graph** (#318 S3) — a composable, *deterministic* query over the semantic graph and the
@@ -37,6 +38,7 @@ export const GRAPH_QUERY_EXAMPLES: readonly GraphQueryExample[] = [
     { label: "Hubs that contradict something", query: "hub AND relation:contradicts" },
     { label: "Ideas that support one note but contradict another", query: "relation:supports AND relation:contradicts" },
     { label: "Fleeting or still-unsourced ideas", query: "state:fleeting OR unsourced" },
+    { label: "Notes something contradicts", query: "incoming:contradicts" },
 ];
 
 /** A predicate token and what it selects — the referenceable vocabulary for the builder + the docs. */
@@ -48,6 +50,8 @@ export interface GraphQueryPredicate {
 export const GRAPH_QUERY_PREDICATES: readonly GraphQueryPredicate[] = [
     { token: "state:<value>", note: "notes in a lifecycle state, e.g. state:permanent" },
     { token: "relation:<type>[:<target>]", note: "notes with an outgoing typed edge, e.g. relation:supports or relation:contradicts:ideaA" },
+    { token: "incoming:<type>[:<source>]", note: "notes with an incoming typed edge — the mirror of relation:, e.g. incoming:contradicts (notes something contradicts)" },
+    { token: "folder:<path>", note: "notes under a folder, e.g. folder:Projects (folder-boundary match)" },
     { token: "degree>=<n>", note: "connectivity — also <=, >, <, = (e.g. degree>=5)" },
     { token: "hub", note: "a well-connected note (degree ≥ 5)" },
     { token: "orphan", note: "nothing links to it (no incoming edges)" },
@@ -130,6 +134,27 @@ function parseTerm(raw: string): { predicate?: Predicate; error?: string } {
             const n = Number(arg);
             if (!Number.isFinite(n)) return { error: "newer-than: needs a number of days" };
             return negate(negated, (idea, _m, now) => idea.created > 0 && now - idea.created <= n * DAY_MS);
+        }
+        case "incoming": {
+            if (!arg) return { error: "incoming: needs a type" };
+            const sep = arg.indexOf(":");
+            const type = (sep === -1 ? arg : arg.slice(0, sep)).toLowerCase();
+            const source = (sep === -1 ? "" : arg.slice(sep + 1).trim()).toLowerCase();
+            return negate(negated, (idea, model) =>
+                incomingRelations(model, idea.path).some(
+                    (r) =>
+                        r.type.toLowerCase() === type &&
+                        (source === "" || basename(r.from).toLowerCase().includes(source) || r.from.toLowerCase().includes(source))
+                )
+            );
+        }
+        case "folder": {
+            if (!arg) return { error: "folder: needs a path" };
+            const folder = arg.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "").normalize("NFC").toLowerCase();
+            if (folder === "") return { error: "folder: needs a path" };
+            return negate(negated, (idea) =>
+                idea.path.replace(/\\/g, "/").normalize("NFC").toLowerCase().startsWith(`${folder}/`)
+            );
         }
         case "unsourced":
             return negate(negated, (idea) => idea.claims.length > 0 && !idea.maturitySignals.hasSources);

--- a/test/architecture/knowledge/query/graphQuery.test.ts
+++ b/test/architecture/knowledge/query/graphQuery.test.ts
@@ -51,6 +51,31 @@ describe("runGraphQuery (#318 S3)", () => {
         expect(notOrphan).not.toContain("alpha.md"); // alpha is an orphan
     });
 
+    it("queries by incoming typed relation — the mirror of relation: (#323)", () => {
+        expect(paths("incoming:supports")).toEqual(["beta.md"]); // alpha supports beta
+        expect(paths("incoming:contradicts")).toEqual(["gamma.md"]); // alpha contradicts gamma
+        expect(paths("incoming:contradicts:alpha")).toEqual(["gamma.md"]);
+        expect(paths("incoming:contradicts:nope")).toEqual([]);
+        expect(runGraphQuery(model, "incoming:", NOW).error).toBeTruthy();
+    });
+
+    it("queries by folder, folder-boundary aware and Unicode/case tolerant (#323)", () => {
+        const m = buildModel([
+            idea("Projects/a.md", "permanent", []),
+            idea("Projects/sub/b.md", "permanent", []),
+            idea("Projects.md", "permanent", []), // a note named like the folder — NOT under it
+            idea("Projects-other/c.md", "permanent", []), // sibling sharing the prefix — NOT matched
+            idea("ideas/d.md", "permanent", []),
+            idea("🧮 Bases/e.md", "permanent", []),
+        ]);
+        const p = (q: string) => runGraphQuery(m, q, NOW).matches.map((x) => x.path).sort();
+        expect(p("folder:Projects")).toEqual(["Projects/a.md", "Projects/sub/b.md"]);
+        expect(p("folder:projects")).toEqual(["Projects/a.md", "Projects/sub/b.md"]); // case-insensitive
+        expect(p("folder:ideas")).toEqual(["ideas/d.md"]);
+        expect(p("folder:🧮 Bases")).toEqual(["🧮 Bases/e.md"]); // emoji/space folder
+        expect(runGraphQuery(m, "folder:", NOW).error).toBeTruthy();
+    });
+
     it("a blank query matches nothing (the surface asks for intent)", () => {
         expect(runGraphQuery(model, "   ", NOW)).toEqual({ matches: [] });
     });


### PR DESCRIPTION
First story of epic #323 (Ask your graph → first-class). References #323 (does not close it).

## What
Two new predicates on the deterministic graph-query engine (extend `graphQuery.ts`, never fork it — subtraction):
- **`incoming:<type>[:<source>]`** — the *mirror* of `relation:`, so you can ask *"notes something contradicts"* / *"notes supported by X"*, which the outgoing `relation:` cannot express.
- **`folder:<path>`** — notes under a folder (folder-boundary match, case- and Unicode/NFC-tolerant, so emoji/spaced folders work). The folder bridge that lets a structure query supersede a Dataview slice.

## Tests / verify
Fixture tests for both (incoming with/without source; folder boundary + case + emoji). The predicate vocabulary + an example are updated (feed the modal help, the future guided builder and the docs). Docs: `ask-your-graph.md`. `npm run verify` + `lint:obsidian` green, coverage floor met.

## Next in #323
G2 surface mode (the "first-class" promotion) · G3 lenses · G4 richer saved queries · G5 guided builder.