### PR TITLE
feat(graph): A1 — immersive Knowledge Galaxy environment (#384)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ canvas wizard, it ships a set of tools that grow and maintain your slip-box:
   neighbours (in **and** out), click one to re-focus — Learning → Memory → Spacing effect → Anki,
   no folders. Ships with headless **reasoning paths** that read the graph as an argument
   (supports → expands → example → implements). Read-only, offline.
-- **🌌 3D knowledge graph** — *see the shape of your thinking.* Fly through a 3D force-directed graph
-  of your slip-box: notes sized by connectivity, coloured by cluster, links coloured by relation type;
-  search-to-focus, filter by state, and a **discovery lens** that lights up orphans, dead-ends and
-  contradictions in space. Click a node to open it. Read-only, offline; degrades to the 2D map on
-  mobile. (Graph surface → 3D mode.)
+- **🌌 3D knowledge graph** — *see the shape of your thinking.* Fly through an immersive **Knowledge
+  Galaxy**: your slip-box as a 3D force-directed graph over a starfield, notes sized by connectivity,
+  cluster-hued glow halos, links coloured by relation type; search-to-focus, filter by state, and a
+  **discovery lens** that lights up orphans, dead-ends and contradictions in space. Click a node to
+  open it. Read-only, offline; respects reduced-motion, and degrades to the 2D map on mobile.
+  (Graph surface → 3D mode.)
 - **❓ Open questions** — every unanswered question in your vault, made first-class: each `question::`
   with no answer yet, its asker(s), and the note most likely to answer it (ranked by shared graph
   context). Read-only, offline — a live thread instead of a dead end.
@@ -226,7 +227,7 @@ Stuck? Read the [Getting started guide](https://rafaelgb.github.io/Obsidian-Zett
 | **Living knowledge map** | A read-only sidebar that detects your hubs and the notes clustering around them, regenerating as the vault changes. |
 | **Concept navigation** | Walk your vault by typed relation (in + out) — focus a note, click a neighbour to re-focus, no folders. A **Trace reasoning paths** command opens a read-only lens of the argument chains leaving a note (`supports → expands → example → implements`), each note clickable. Offline. |
 | **Ask your graph** | A deterministic query surface over your slip-box's *meaning and structure* (not frontmatter/tags like Dataview, and never AI): compose predicates — `state:`, `relation:supports/contradicts`, `incoming:`, `folder:`, `degree>=`, `orphan`, `unsourced`, `older-than:` … — with `AND`/`OR` to answer *"orphaned permanents older than 30 days that contradict X"*. Results open on click as a list or table; compose terms from menus with the guided builder; save a query to **name / reorder / pin it to Home**. Read-only, offline. |
-| **3D knowledge graph** | An interactive 3D force-directed graph of your slip-box (Graph surface → 3D): nodes sized by connectivity and coloured by cluster, links coloured by relation type; search-to-focus, state filter, and a discovery lens for orphans · dead-ends · contradictions. Read-only, offline; 2D-map fallback on mobile. |
+| **3D knowledge graph** | An immersive **Knowledge Galaxy** — an interactive 3D force-directed graph of your slip-box over a starfield (Graph surface → 3D): nodes sized by connectivity and coloured by cluster with cluster-hued glow halos, links coloured by relation type; search-to-focus, state filter, and a discovery lens for orphans · dead-ends · contradictions. Read-only, offline; respects reduced-motion and Lite mode; 2D-map fallback on mobile. |
 | **Open questions** | A vault-wide list of every unanswered `question::`, its askers, and candidate answering notes ranked by shared graph context. Read-only, offline. |
 | **Evolution timeline** | The conceptual history of an idea — a per-note sequence of its lifecycle state + claim texts, captured only on meaningful change, oldest to newest. Local, bounded, opt-in. |
 | **Evidence map** *(experimental)* | Compound thinking — a grounded synthesis of a note from your own graph (supports · contradicts · evidence · gaps), every row linked to its source note. No invented content, no AI. |

--- a/docs/development/graph-3d.md
+++ b/docs/development/graph-3d.md
@@ -23,7 +23,12 @@ Open the **Graph** surface and pick the **3D** mode (next to Map and Navigate). 
 - Each cluster sits inside a faint translucent **hull** so its grouping reads at a glance.
 - Notes are **marked by kind** — `?` for open **questions**, `◆` for **sourced** notes — so types stand
   out (see the legend).
-- Nodes and links **glow** (bloom) against a dark space — an immersive look, not a flat diagram.
+- An immersive **"Knowledge Galaxy" environment** (#384): a subtle **starfield** backdrop with a depth
+  vignette, **cluster-hued glow halos** on hubs *and* other well-connected notes, and best-effort
+  **selective bloom** so the graph reads as a living space, not a flat diagram. The environment is
+  purely additive — it never blocks the base render, and a post-processing failure degrades to lit
+  spheres rather than a blank canvas. It follows the **Lite** control and OS **reduced-motion**, and is
+  absent on mobile / no-WebGL (which use the navigable-list fallback).
 - Data comes purely from the offline `KnowledgeModel` via the Knowledge State surface
   (`build3DGraph`), so the WebGL view is a thin shell over tested data.
 
@@ -73,12 +78,18 @@ sourced from the model — click a chip to toggle it:
   responsive layout; a hint notes when the view is capped.
 - On **mobile** or when **WebGL is unavailable**, the mode degrades to a message with a button that
   opens the 2D **Map** instead of failing.
+- The immersive **environment** (starfield, non-hub halos, selective bloom) is disabled under
+  **Lite** mode and OS **reduced-motion**, and never runs on mobile / no-WebGL — Lite stays the
+  guaranteed FPS escape hatch. Selective bloom loads lazily and best-effort; a failure never blanks
+  the graph.
 
 ## Where it lives
 
 - Pure projection: `architecture/knowledge/map/graph3d.ts` (`build3DGraph`, `filterGraph3D`,
   `capGraph3D`, `graph3dStats`, `buildAdjacency`, `OVERLAY_SPECS`, `STATE_COLOR_VARS`,
   `RELATION_COLOR_VARS`) — Obsidian-free, unit-tested.
+- Pure environment math: `architecture/components/core/graph3d/graph3dEnvironment.ts`
+  (`environmentEnabled`, `starfieldPositions`, `haloSpec`) — Obsidian-free, unit-tested (#384).
 - View: `architecture/components/core/graph3d/Graph3DRenderer.ts`, mounted by `GraphSurfaceView` for
   the `3d` mode; the deep-link handoff is `graph3dFocus.ts`.
 - Styles: `styles/components/graph3d.scss` — legend/toolbar colours share Obsidian's `--color-*`

--- a/src/architecture/components/core/graph3d/Graph3DRenderer.ts
+++ b/src/architecture/components/core/graph3d/Graph3DRenderer.ts
@@ -24,6 +24,7 @@ import {
 } from "architecture/knowledge/state";
 import { KnowledgeModeRenderer } from "architecture/components/core/surface/KnowledgeModeRenderer";
 import { consumeGraph3DFocus } from "./graph3dFocus";
+import { environmentEnabled, starfieldPositions, haloSpec } from "./graph3dEnvironment";
 // Type-only imports — erased at compile time, so the WebGL libraries load lazily in mountGraph().
 import type { ForceGraph3DInstance } from "3d-force-graph";
 import type * as THREE from "three";
@@ -33,6 +34,10 @@ const DIM_NODE = "rgba(120, 124, 135, 0.10)";
 const DIM_LINK = "rgba(120, 124, 135, 0.04)";
 const TIMELAPSE_MS = 9000;
 const TIMELAPSE_STEPS = 48;
+// A1 (#384) — the immersive starfield: a single Points cloud on a shell wrapping the graph.
+const STAR_COUNT = 1400;
+const STAR_INNER_RADIUS = 320;
+const STAR_OUTER_RADIUS = 900;
 type ViewState = "indexing" | "ready" | "empty" | "error";
 type ColorMode = "state" | "cluster";
 type LiveNode = { id?: string; x?: number; y?: number; z?: number; vx?: number; vy?: number; vz?: number };
@@ -96,6 +101,9 @@ export class Graph3DRenderer extends KnowledgeModeRenderer {
     private spread = 35;
     private three: typeof THREE | null = null;
     private glowTexture: THREE.CanvasTexture | null = null;
+    private starfield: THREE.Points | null = null;
+    private bloomPass: { enabled: boolean; dispose?(): void } | null = null;
+    private reducedMotion = false;
     private hullMeshes: THREE.Mesh[] = [];
     private spriteTextCtor: (new (t?: string, h?: number, c?: string) => LabelSprite) | null = null;
     private readonly proximityLabels = new Map<string, LabelSprite>();
@@ -218,6 +226,7 @@ export class Graph3DRenderer extends KnowledgeModeRenderer {
             this.buildBottomBar(this.wrapperEl);
 
             const reduced = prefersReducedMotion();
+            this.reducedMotion = reduced;
             const graph = new ForceGraph3D(this.graphEl)
                 .backgroundColor("#0b0e14")
                 .nodeLabel("name")
@@ -247,10 +256,15 @@ export class Graph3DRenderer extends KnowledgeModeRenderer {
                 .onEngineStop(() => this.onEngineSettled());
             this.graph = graph;
             this.spriteTextCtor = SpriteText;
-            if (SpriteText) this.attachNodeDecorations(graph, SpriteText);
+            if (SpriteText) this.attachNodeDecorations(graph);
             this.tightenLayout(graph);
             this.applyGraphData();
             this.applySize();
+            // A1 (#384): the immersive environment is purely additive and follows the env gate — it
+            // never blocks or blanks the base render above.
+            this.buildEnvironment();
+            void this.applyBloom();
+            this.wrapperEl?.toggleClass(c("graph3d--immersive"), this.envEnabled());
             if (SpriteText && this.three) {
                 this.proximityTimer = window.setInterval(() => this.updateProximityLabels(), 300);
             }
@@ -319,46 +333,127 @@ export class Graph3DRenderer extends KnowledgeModeRenderer {
         }
     }
 
-    /** Node decorations: hub **glow** + **label** on the most-connected notes, and a **type icon**
-     *  (`?` question, `◆` source) so kinds of note read at a glance. */
-    private attachNodeDecorations(graph: ForceGraph3DInstance, SpriteText: new (t?: string, h?: number, c?: string) => LabelSprite): void {
-        graph.nodeThreeObjectExtend(true).nodeThreeObject(((node: unknown) => {
-            const gn = node as Graph3DNode & LiveNode;
-            const isHub = this.hubIds.has(gn.id ?? "");
-            const icon = gn.kind === "question" ? "?" : gn.kind === "source" ? "◆" : "";
-            if (!isHub && !icon) return undefined;
-            const three = this.three;
-            if (!three) {
-                if (isHub) {
-                    const label = new SpriteText(gn.name, 6, "#e8eaed");
-                    label.position.set(0, Math.sqrt(gn.val) * 4 + 8, 0);
-                    return label;
-                }
-                return undefined;
-            }
-            const group = new three.Group();
-            if (isHub && this.glowTexture) {
-                const material = new three.SpriteMaterial({ map: this.glowTexture, transparent: true, depthWrite: false, blending: three.AdditiveBlending });
-                material.opacity = 0.5;
-                material.color.set(this.clusterHue(gn.group));
-                const glow = new three.Sprite(material);
-                const size = Math.sqrt(gn.val) * 7 + 16;
-                glow.scale.set(size, size, 1);
-                group.add(glow);
-            }
+    /** Node decorations: a cluster-hued **glow halo** (hubs always; other meaningful nodes only in the
+     *  immersive environment, #384), a **label** on hubs, and a **type icon** (`?` question, `◆`
+     *  source). The per-node builder is reused by {@link refreshDecorations} when Lite toggles. */
+    private attachNodeDecorations(graph: ForceGraph3DInstance): void {
+        graph.nodeThreeObjectExtend(true).nodeThreeObject(((node: unknown) => this.buildNodeObject(node)) as never);
+    }
+
+    /** Re-evaluate every node's decorations (e.g. after Lite toggles the non-hub halos on/off). */
+    private refreshDecorations(): void {
+        if (this.graph && this.spriteTextCtor) {
+            this.graph.nodeThreeObject(((node: unknown) => this.buildNodeObject(node)) as never);
+        }
+    }
+
+    /** Build the three.js decoration object for one node (glow halo + hub label + kind icon). */
+    private buildNodeObject(node: unknown): THREE.Object3D | undefined {
+        const SpriteText = this.spriteTextCtor;
+        if (!SpriteText) return undefined;
+        const gn = node as Graph3DNode & LiveNode;
+        const isHub = this.hubIds.has(gn.id ?? "");
+        const icon = gn.kind === "question" ? "?" : gn.kind === "source" ? "◆" : "";
+        const three = this.three;
+        // Hubs always glow; non-hub halos appear only in the immersive environment (dropped in Lite).
+        const halo = three && this.glowTexture && (isHub || this.envEnabled()) ? haloSpec(gn.val, isHub) : null;
+        if (!isHub && !icon && !halo) return undefined;
+        if (!three) {
             if (isHub) {
                 const label = new SpriteText(gn.name, 6, "#e8eaed");
                 label.position.set(0, Math.sqrt(gn.val) * 4 + 8, 0);
-                group.add(label);
+                return label;
             }
-            if (icon) {
-                const offset = Math.sqrt(gn.val) * 3 + 5;
-                const iconSprite = new SpriteText(icon, 6, gn.kind === "question" ? "#fbbf24" : "#22d3ee");
-                iconSprite.position.set(offset, offset, 0);
-                group.add(iconSprite);
+            return undefined;
+        }
+        const group = new three.Group();
+        if (halo && this.glowTexture) {
+            const material = new three.SpriteMaterial({ map: this.glowTexture, transparent: true, depthWrite: false, blending: three.AdditiveBlending });
+            material.opacity = halo.opacity;
+            material.color.set(this.clusterHue(gn.group));
+            const glow = new three.Sprite(material);
+            glow.scale.set(halo.scale, halo.scale, 1);
+            group.add(glow);
+        }
+        if (isHub) {
+            const label = new SpriteText(gn.name, 6, "#e8eaed");
+            label.position.set(0, Math.sqrt(gn.val) * 4 + 8, 0);
+            group.add(label);
+        }
+        if (icon) {
+            const offset = Math.sqrt(gn.val) * 3 + 5;
+            const iconSprite = new SpriteText(icon, 6, gn.kind === "question" ? "#fbbf24" : "#22d3ee");
+            iconSprite.position.set(offset, offset, 0);
+            group.add(iconSprite);
+        }
+        return group;
+    }
+
+    // ── A1 (#384): the immersive "Knowledge Galaxy" environment ─────────────────
+    /** Whether the additive environment (starfield + non-hub halos + bloom) should run right now. */
+    private envEnabled(): boolean {
+        return environmentEnabled({ reduced: this.reducedMotion, lite: this.lite, webgl: true, mobile: Platform.isMobile });
+    }
+
+    /** Build the additive starfield backdrop — one `Points` draw call. Best-effort; never blanks the graph. */
+    private buildEnvironment(): void {
+        const three = this.three;
+        if (!three || !this.graph || this.starfield || !this.envEnabled()) return;
+        try {
+            const positions = starfieldPositions(STAR_COUNT, STAR_INNER_RADIUS, STAR_OUTER_RADIUS, Math.random);
+            const geometry = new three.BufferGeometry();
+            geometry.setAttribute("position", new three.BufferAttribute(positions, 3));
+            const material = new three.PointsMaterial({
+                size: 1.6,
+                color: new three.Color("#cbd5e1"),
+                transparent: true,
+                opacity: 0.65,
+                sizeAttenuation: true,
+                depthWrite: false,
+                blending: three.AdditiveBlending,
+            });
+            const points = new three.Points(geometry, material);
+            this.starfield = points;
+            this.graph.scene().add(points);
+        } catch (error) {
+            log.warn("[Graph3D] starfield unavailable", error);
+        }
+    }
+
+    /** Selective bloom via the library's post-processing composer — best-effort and defensive across
+     *  library updates. A failure degrades to lit spheres (the base render already ran), never a blank. */
+    private async applyBloom(): Promise<void> {
+        const three = this.three;
+        if (!three || !this.graph || this.bloomPass || !this.envEnabled()) return;
+        try {
+            const { UnrealBloomPass } = await import("three/examples/jsm/postprocessing/UnrealBloomPass.js");
+            if (this.disposed || !this.graph) return;
+            const composer = (this.graph as unknown as {
+                postProcessingComposer?: () => { addPass(pass: unknown): void } | undefined;
+            }).postProcessingComposer?.();
+            if (!composer) return;
+            const width = this.wrapperEl?.clientWidth || 400;
+            const height = this.wrapperEl?.clientHeight || 400;
+            // Conservative strength/radius/threshold so bloom accents hubs without washing out light themes.
+            const pass = new UnrealBloomPass(new three.Vector2(width, height), 0.7, 0.6, 0.65);
+            composer.addPass(pass);
+            this.bloomPass = pass; // UnrealBloomPass structurally satisfies { enabled; dispose? }
+        } catch (error) {
+            log.warn("[Graph3D] selective bloom unavailable", error);
+        }
+    }
+
+    private disposeStarfield(): void {
+        if (this.starfield && this.graph && this.three) {
+            try {
+                this.graph.scene().remove(this.starfield);
+                this.starfield.geometry.dispose();
+                this.starfield.material.dispose();
+            } catch (error) {
+                log.warn("[Graph3D] error disposing starfield", error);
             }
-            return group;
-        }) as never);
+        }
+        this.starfield = null;
     }
 
     /** A soft radial-gradient texture used for the additive hub glow. */
@@ -562,9 +657,18 @@ export class Graph3DRenderer extends KnowledgeModeRenderer {
                 try { this.disposeHulls(this.graph.scene()); } catch (error) { log.warn("[Graph3D] hull dispose", error); }
             }
             this.clearProximityLabels();
+            // A1 (#384): drop the immersive environment for maximum FPS.
+            this.disposeStarfield();
+            if (this.bloomPass) this.bloomPass.enabled = false;
         } else {
             this.rebuildHulls();
+            // A1 (#384): bring the immersive environment back (idempotent + env-gated).
+            this.buildEnvironment();
+            if (this.bloomPass) this.bloomPass.enabled = true;
+            else void this.applyBloom();
         }
+        this.wrapperEl?.toggleClass(c("graph3d--immersive"), this.envEnabled());
+        this.refreshDecorations(); // re-evaluate non-hub halos for the new Lite state
         this.refreshPaint();
         this.updateStatus();
     }
@@ -1043,10 +1147,13 @@ export class Graph3DRenderer extends KnowledgeModeRenderer {
             try {
                 this.clearProximityLabels();
                 this.disposeHulls(this.graph.scene());
+                this.disposeStarfield();
             } catch (error) {
                 log.warn("[Graph3D] error disposing graph decorations", error);
             }
         }
+        this.starfield = null;
+        this.bloomPass = null; // the pass is destroyed with the graph's composer in _destructor()
         this.spriteTextCtor = null;
         this.glowTexture = null;
         this.three = null;

--- a/src/architecture/components/core/graph3d/graph3dEnvironment.ts
+++ b/src/architecture/components/core/graph3d/graph3dEnvironment.ts
@@ -1,0 +1,70 @@
+// Pure, Obsidian-free math + gating for the immersive "Knowledge Galaxy" environment (A1, #384).
+// Kept out of Graph3DRenderer so the geometry and the gate are unit-testable without a WebGL/DOM
+// mock — the same pure/shell split the codebase already uses between `knowledge/map/graph3d.ts`
+// (pure) and the renderer (WebGL shell).
+
+/** The inputs that decide whether the immersive environment (starfield + halos + bloom) should run. */
+export interface EnvironmentGate {
+    /** The OS "reduce motion" preference is on. */
+    reduced: boolean;
+    /** The renderer's Lite mode (per-frame effects dropped for maximum FPS). */
+    lite: boolean;
+    /** WebGL is available. */
+    webgl: boolean;
+    /** Running on mobile (which uses the navigable-list fallback, not the WebGL graph). */
+    mobile: boolean;
+}
+
+/**
+ * The environment is purely additive eye-candy, so it only runs when it is both wanted and cheap:
+ * never under reduced-motion, never in Lite, only with WebGL, and never on mobile. Lite stays the
+ * guaranteed performance escape hatch (#384 AC).
+ */
+export function environmentEnabled(gate: EnvironmentGate): boolean {
+    return !gate.reduced && !gate.lite && gate.webgl && !gate.mobile;
+}
+
+/**
+ * `count` star positions scattered on a spherical shell with radius in `[inner, outer]`, as a flat
+ * `[x,y,z, …]` `Float32Array` ready for a `THREE.BufferAttribute`. A shell (not a cube) reads as
+ * depth-cued space wrapping the graph. Pure: all randomness comes from the injected `rng`
+ * (`() => number` in `[0,1)`), so a seeded rng makes the field deterministic and testable.
+ */
+export function starfieldPositions(count: number, inner: number, outer: number, rng: () => number): Float32Array {
+    const n = Math.max(0, Math.floor(count));
+    const positions = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) {
+        // A uniform direction on the unit sphere, then a radius within the shell.
+        const theta = 2 * Math.PI * rng();
+        const cosPhi = 2 * rng() - 1;
+        const sinPhi = Math.sqrt(Math.max(0, 1 - cosPhi * cosPhi));
+        const radius = inner + (outer - inner) * rng();
+        const o = i * 3;
+        positions[o] = radius * sinPhi * Math.cos(theta);
+        positions[o + 1] = radius * sinPhi * Math.sin(theta);
+        positions[o + 2] = radius * cosPhi;
+    }
+    return positions;
+}
+
+/** The halo sprite spec (relative scale + opacity) for a node, or `null` when it earns no halo. */
+export interface HaloSpec {
+    scale: number;
+    opacity: number;
+}
+
+/** Below this degree a non-hub node gets no halo — halos concentrate on meaningful nodes (FPS, #384). */
+export const HALO_MIN_DEGREE = 2;
+
+/**
+ * Halo geometry for a node given its degree (`val`) and whether it is a hub. Extends the glow beyond
+ * hubs-only (FR2) while keeping hubs visually dominant (bigger, brighter). A non-hub node below
+ * {@link HALO_MIN_DEGREE} returns `null` so large graphs never pay a draw call per trivial node.
+ */
+export function haloSpec(val: number, isHub: boolean): HaloSpec | null {
+    if (!isHub && val < HALO_MIN_DEGREE) return null;
+    const degree = Math.sqrt(Math.max(1, val));
+    const scale = isHub ? degree * 7 + 16 : degree * 4 + 8;
+    const opacity = isHub ? 0.5 : 0.28;
+    return { scale, opacity };
+}

--- a/src/architecture/typing/three-graph3d.d.ts
+++ b/src/architecture/typing/three-graph3d.d.ts
@@ -61,4 +61,45 @@ declare module "three" {
         geometry: SphereGeometry;
     }
     export class Scene extends Object3D { }
+
+    // A1 (#384) — the immersive starfield backdrop is a single `Points` object (one draw call).
+    export class Vector2 {
+        constructor(x?: number, y?: number);
+        x: number;
+        y: number;
+    }
+    export class BufferAttribute {
+        constructor(array: ArrayLike<number>, itemSize: number);
+    }
+    export class BufferGeometry {
+        setAttribute(name: string, attribute: BufferAttribute): this;
+        dispose(): void;
+    }
+    export class PointsMaterial {
+        constructor(params?: Record<string, unknown>);
+        color: Color;
+        opacity: number;
+        size: number;
+        dispose(): void;
+    }
+    export class Points extends Object3D {
+        constructor(geometry?: BufferGeometry, material?: PointsMaterial);
+        geometry: BufferGeometry;
+        material: PointsMaterial;
+    }
+}
+
+// A1 (#384) — best-effort selective bloom. `three` ships no resolvable types for the examples/jsm
+// post-processing passes; we load this one lazily via `import(...)` inside a try/catch, so only the
+// surface we touch is declared. A load/wire failure degrades to lit spheres, never a blank graph.
+declare module "three/examples/jsm/postprocessing/UnrealBloomPass.js" {
+    import type { Vector2 } from "three";
+    export class UnrealBloomPass {
+        constructor(resolution: Vector2, strength: number, radius: number, threshold: number);
+        enabled: boolean;
+        strength: number;
+        radius: number;
+        threshold: number;
+        dispose?(): void;
+    }
 }

--- a/src/styles/components/graph3d.scss
+++ b/src/styles/components/graph3d.scss
@@ -24,6 +24,25 @@
     z-index: 0;
 }
 
+// Immersive "Knowledge Galaxy" environment (#384): a radial depth vignette so the starfield recedes
+// into space around the graph. Pure CSS gradient (no inline styles); the class is only present when the
+// environment is enabled (never under reduced-motion, Lite, or on mobile/no-WebGL). The media query is
+// belt-and-suspenders since the class is already gated off under reduced motion.
+.zettelkasten-flow__graph3d--immersive .zettelkasten-flow__graph3d-canvas::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    background: radial-gradient(ellipse at center, rgba(11, 14, 20, 0) 55%, rgba(5, 7, 12, 0.55) 100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .zettelkasten-flow__graph3d--immersive .zettelkasten-flow__graph3d-canvas::after {
+        background: none;
+    }
+}
+
 // The 3D canvas is always a fixed dark "space", so floating controls are styled light-on-dark
 // (independent of the Obsidian theme) — otherwise theme greys blend into the background and vanish.
 %graph3d-control {

--- a/test/architecture/components/core/graph3d/graph3dEnvironment.test.ts
+++ b/test/architecture/components/core/graph3d/graph3dEnvironment.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    environmentEnabled,
+    starfieldPositions,
+    haloSpec,
+} from "architecture/components/core/graph3d/graph3dEnvironment";
+
+/**
+ * A1 (#384) — the immersive "Knowledge Galaxy" environment. The renderer body is WebGL/GPU and
+ * manual-verify, so every testable decision lives in this pure helper: the gate, the starfield
+ * geometry, and the halo spec.
+ */
+describe("graph3dEnvironment — immersive Knowledge Galaxy (A1, #384)", () => {
+    describe("environmentEnabled (the FR4 gate)", () => {
+        const on = { reduced: false, lite: false, webgl: true, mobile: false };
+        it("is enabled only when not reduced, not lite, WebGL present and not mobile", () => {
+            expect(environmentEnabled(on)).toBe(true);
+        });
+        it("is disabled under prefers-reduced-motion", () => {
+            expect(environmentEnabled({ ...on, reduced: true })).toBe(false);
+        });
+        it("is disabled in lite mode (the FPS escape hatch)", () => {
+            expect(environmentEnabled({ ...on, lite: true })).toBe(false);
+        });
+        it("is disabled without WebGL", () => {
+            expect(environmentEnabled({ ...on, webgl: false })).toBe(false);
+        });
+        it("is disabled on mobile (the navigable-list fallback is used instead)", () => {
+            expect(environmentEnabled({ ...on, mobile: true })).toBe(false);
+        });
+    });
+
+    describe("starfieldPositions", () => {
+        it("returns count*3 flat coordinates", () => {
+            expect(starfieldPositions(100, 200, 400, Math.random).length).toBe(300);
+        });
+        it("places every star on a shell within [inner, outer] (depth-cued, not a cube)", () => {
+            const inner = 200, outer = 400;
+            const pts = starfieldPositions(500, inner, outer, Math.random);
+            for (let i = 0; i < pts.length; i += 3) {
+                const r = Math.hypot(pts[i], pts[i + 1], pts[i + 2]);
+                expect(r).toBeGreaterThanOrEqual(inner - 1e-3);
+                expect(r).toBeLessThanOrEqual(outer + 1e-3);
+            }
+        });
+        it("is deterministic for a seeded rng (pure, no hidden state)", () => {
+            const seeded = () => 0.42;
+            const a = starfieldPositions(10, 100, 200, seeded);
+            const b = starfieldPositions(10, 100, 200, seeded);
+            expect(Array.from(a)).toEqual(Array.from(b));
+        });
+        it("returns an empty array for a non-positive count", () => {
+            expect(starfieldPositions(0, 100, 200, Math.random).length).toBe(0);
+        });
+    });
+
+    describe("haloSpec", () => {
+        it("gives a hub a larger halo than a non-hub of equal degree, but both glow", () => {
+            const hub = haloSpec(9, true);
+            const plain = haloSpec(9, false);
+            expect(hub).not.toBeNull();
+            expect(plain).not.toBeNull();
+            expect(hub!.scale).toBeGreaterThan(plain!.scale);
+        });
+        it("keeps opacity within (0, 1]", () => {
+            for (const spec of [haloSpec(9, true), haloSpec(9, false)]) {
+                expect(spec!.opacity).toBeGreaterThan(0);
+                expect(spec!.opacity).toBeLessThanOrEqual(1);
+            }
+        });
+        it("grows the halo monotonically with degree", () => {
+            expect(haloSpec(16, true)!.scale).toBeGreaterThan(haloSpec(4, true)!.scale);
+        });
+        it("returns null for a low-degree non-hub (halos concentrate on meaningful nodes)", () => {
+            expect(haloSpec(1, false)).toBeNull();
+        });
+    });
+});

--- a/test/architecture/components/core/graph3d/graph3dWiring.test.ts
+++ b/test/architecture/components/core/graph3d/graph3dWiring.test.ts
@@ -33,3 +33,36 @@ describe("Graph 3D mode wiring (#280 S1)", () => {
         expect(src).not.toMatch(/^import\s+\{[^}]*\}\s+from\s+["']3d-force-graph["']/m); // (value) named import
     });
 });
+
+/**
+ * A1 (#384) — the immersive "Knowledge Galaxy" environment is additive, gated, and best-effort: it is
+ * built behind `environmentEnabled()`, bloom loads lazily, and a bloom failure never blanks the graph.
+ */
+describe("Graph 3D immersive environment (A1, #384)", () => {
+    const src = readCore("graph3d/Graph3DRenderer.ts");
+
+    it("gates the environment behind environmentEnabled()", () => {
+        expect(src).toMatch(/environmentEnabled\(/);
+    });
+
+    it("loads selective bloom lazily (dynamic import), never as a static import", () => {
+        expect(src).toMatch(/import\(\s*["'][^"']*UnrealBloomPass[^"']*["']\s*\)/);
+        expect(src).not.toMatch(/^import\s+.*UnrealBloomPass/m);
+    });
+
+    it("makes selective bloom best-effort — a failed bloom load is caught and logged, not thrown", () => {
+        expect(src).toMatch(/import\([^)]*UnrealBloomPass[^)]*\)/); // the lazy load
+        expect(src).toMatch(/selective bloom unavailable/); // the catch-block log.warn — proves it degrades
+    });
+
+    it("keeps the base render path independent of the environment (applyGraphData before env)", () => {
+        // applyGraphData()/applySize() drive the visible graph and run before buildEnvironment()/applyBloom(),
+        // so a starfield/bloom failure can never blank the nodes and links.
+        expect(src).toMatch(/this\.applyGraphData\(\);\s*this\.applySize\(\);/);
+        expect(src).toMatch(/this\.applyGraphData\(\);[\s\S]*this\.buildEnvironment\(\);/);
+    });
+
+    it("disposes the starfield on teardown (no GPU leak)", () => {
+        expect(src).toMatch(/disposeStarfield\(\)/);
+    });
+});


### PR DESCRIPTION
## A1 — immersive "Knowledge Galaxy" environment

Closes #384. Part of epic #383 (workstream A — Knowledge Galaxy).

Extends the existing 3D graph (`Graph3DRenderer`) in place — **no parallel renderer** — with an
immersive environment so the view reads as a living space, not a flat diagram:

- **Starfield backdrop** — a single `THREE.Points` cloud on a spherical shell (one draw call) plus a
  CSS radial depth vignette.
- **Glow halos** widened from hubs-only to hubs **and** other well-connected notes, cluster-hued.
- **Best-effort selective bloom** via the library's `postProcessingComposer()` and a lazy
  `import(UnrealBloomPass)` in a `try/catch` — mirrors the existing `three` / `three-spritetext`
  degradation.

### Design-by-subtraction note (§ constitution)
This consciously **revives the "3D environment" track that #360 deliberately subtracted** — justified
here by *identity/adoption*, not new capability. It stays cheap and optional: it follows the existing
**Lite** control and OS **reduced-motion**, and is absent on mobile / no-WebGL (the navigable-list
fallback is untouched). No new toggle, command, setting, or user-facing string.

### Safety / degradation
- The base render (`applyGraphData()` → `applySize()`) runs **before** `buildEnvironment()` /
  `applyBloom()`, so a starfield or bloom failure degrades to lit spheres — **never a blank graph**
  (enforced by a structural guardrail test).
- Starfield + bloom are disposed/reset in `teardownGraph()` and toggled off in Lite (no GPU leak).

### Tests & guardrails
- New pure unit tests `graph3dEnvironment.test.ts` (13 assertions): the gate, starfield-on-shell +
  determinism, halo spec.
- Extended `graph3dWiring.test.ts`: env is gated behind `environmentEnabled()`, bloom is lazy-only,
  a bloom failure is caught+logged, the base render is independent of the env, starfield is disposed.
- `npm run verify` green (typecheck + oxlint + **eslint obsidian 0** + jest 1431). Production
  `npm run release` build verified — `UnrealBloomPass` bundles cleanly.

### Manual verification (not automatable in-repo)
- [ ] Starfield + halos + bloom render on desktop; look good on light **and** dark themes.
- [ ] ~60 FPS at ~300 nodes on a mid-range machine (no in-repo FPS harness — manual per the AC).
- [ ] Lite drops the environment; reduced-motion disables it; mobile still shows the list fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
