### PR TITLE
fix(graph): show relations during the time-lapse, not just nodes (#394)

### DIFF
--- a/src/architecture/knowledge/map/graph3d.ts
+++ b/src/architecture/knowledge/map/graph3d.ts
@@ -61,6 +61,16 @@ function basename(path: string): string {
 const byStr = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
 
 /**
+ * A link endpoint's id. Links are built with string `source`/`target`, but the force layout
+ * (`d3-force` via `3d-force-graph`) mutates them **in place** into the resolved node objects. These
+ * pure filters run on that same live data during the time-lapse, so read the id either way — otherwise
+ * `kept.has(link.source)` compares a Set of ids against a node object and drops every link (#394).
+ */
+function linkEndId(end: unknown): string {
+    return typeof end === "object" && end !== null ? (end as { id?: string }).id ?? "" : String(end);
+}
+
+/**
  * Pure projection of the {@link KnowledgeModel} into a `{ nodes, links }` shape for the 3D graph view
  * (#280 S1/S2). Nodes are ideas (id = path, name = basename, `val` = degree, `group` = cluster index
  * from {@link buildKnowledgeMap} for coloring, `state`); links are the model's typed relations,
@@ -293,7 +303,7 @@ export function filterGraph3D(data: Graph3DData, filter: Graph3DFilter): Graph3D
         return true;
     });
     const kept = new Set(nodes.map((node) => node.id));
-    const links = data.links.filter((link) => kept.has(link.source) && kept.has(link.target));
+    const links = data.links.filter((link) => kept.has(linkEndId(link.source)) && kept.has(linkEndId(link.target)));
 
     return { nodes, links };
 }
@@ -327,7 +337,7 @@ export function graph3dTimeRange(data: Graph3DData): { min: number; max: number 
 export function graph3dUpToTime(data: Graph3DData, cursor: number): Graph3DData {
     const nodes = data.nodes.filter((node) => node.created === 0 || node.created <= cursor);
     const kept = new Set(nodes.map((node) => node.id));
-    const links = data.links.filter((link) => kept.has(link.source) && kept.has(link.target));
+    const links = data.links.filter((link) => kept.has(linkEndId(link.source)) && kept.has(linkEndId(link.target)));
     return { nodes, links };
 }
 

--- a/test/architecture/knowledge/map/graph3d.test.ts
+++ b/test/architecture/knowledge/map/graph3d.test.ts
@@ -294,3 +294,43 @@ describe("tourStops (#385)", () => {
         expect(tourStops(data(nodes), { maxStops: 5 })).toHaveLength(5);
     });
 });
+
+/**
+ * #394 — the force layout (`d3-force`) mutates link endpoints in place, turning `source`/`target`
+ * string ids into the resolved node objects. The pure filters run on that live data during the
+ * time-lapse, so they must read the id from either shape or every relation disappears (only dots show).
+ */
+describe("link filters survive d3-force endpoint mutation (#394)", () => {
+    const node = (id: string, created: number): Graph3DNode => ({
+        id, name: id, val: 2, group: -1, state: "seed", orphan: false, deadEnd: false, contradiction: false, created, kind: "note",
+    });
+
+    it("graph3dUpToTime keeps links whose endpoints are node objects, not id strings", () => {
+        const a = node("A.md", 10), b = node("B.md", 20);
+        // Simulate the in-place mutation: link.source/target are the node objects.
+        const mutated: Graph3DData = {
+            nodes: [a, b],
+            links: [{ source: a as unknown as string, target: b as unknown as string, type: "supports" }],
+        };
+        expect(graph3dUpToTime(mutated, 100).links).toHaveLength(1);
+    });
+
+    it("filterGraph3D keeps links whose endpoints are node objects", () => {
+        const a = node("A.md", 10), b = node("B.md", 20);
+        const mutated: Graph3DData = {
+            nodes: [a, b],
+            links: [{ source: a as unknown as string, target: b as unknown as string, type: "link" }],
+        };
+        expect(filterGraph3D(mutated, {}).links).toHaveLength(1);
+    });
+
+    it("still drops a link when one mutated endpoint falls outside the time cursor", () => {
+        const a = node("A.md", 10), b = node("B.md", 5000);
+        const mutated: Graph3DData = {
+            nodes: [a, b],
+            links: [{ source: a as unknown as string, target: b as unknown as string, type: "link" }],
+        };
+        // Cursor before B was created → B is filtered out → the link goes with it.
+        expect(graph3dUpToTime(mutated, 100).links).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Fix: time-lapse dropped all relations, showing only nodes

Closes #394. Reported by the user; also fixes A3's time-lapse WebM clip (epic #383).

### Root cause
`d3-force` (via `3d-force-graph`) mutates link objects **in place**, replacing the string
`source`/`target` ids with the resolved **node objects** during layout. The pure filters
`graph3dUpToTime` and `filterGraph3D` tested `kept.has(link.source)` assuming a string — so after the
first render `link.source` is a node object, `kept.has(object)` is always `false`, and **every relation
is filtered out** on subsequent `applyGraphData` calls (time-lapse scrubbing, and returning to 100%).
The graph collapsed to bare dots.

### Fix
Resolve the endpoint id from either shape (string id or mutated node object) via a small `linkEndId()`
helper, used in both pure filters. Minimal, and keeps the first-render path (string ids) unchanged.

### Tests
- `graph3d.test.ts`: 3 regression tests with object-shaped endpoints — `graph3dUpToTime` and
  `filterGraph3D` keep the link; a link whose mutated endpoint falls outside the time cursor is still
  dropped.
- `npm run verify` green (typecheck + oxlint + eslint obsidian **0** + jest 1455).

### Docs
No change — the docs already describe the time-lapse showing the graph grow; this restores that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
