### PR TITLE
feat(agency): C5 — cognitive agency index + AI accept/modify/reject rate (#388)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -14,6 +14,7 @@ For what the surfaces are, which variables each one binds, and worked recipes, s
 | Member | Signature | What it answers |
 |---|---|---|
 | `agency` | `(path: string) => AgencySignals` | Counts of the verdicts you have given on one idea. Never a score. |
+| `agencyIndex` | `(opts?: AgencyMetricsOptions) => AgencyIndex` | How much you shaped interpretive output vs accepted it as-is. A description, never a score. |
 | `balance` | `() => KnowledgeBalance` | How the vault is composed across fleeting, literature and permanent ideas. |
 | `cultivationQueue` | `(exclude?: string[], limit?: number) => string[]` | Ideas most worth thinking about next. |
 | `dashboard` | `() => DashboardModel` | The headline metrics of the whole vault. |
@@ -37,6 +38,7 @@ For what the surfaces are, which variables each one binds, and worked recipes, s
 | `review` | `(now?: number, windowDays?: number) => WeeklyReview` | What changed, stalled and matured over a recent window. |
 | `trajectory` | `(now?: number, opts?: TrajectoryOptions) => IdeaTrajectory[]` | Which important ideas are advancing, steady or stalled by how recently you ruled on them. |
 | `unexamined` | `(opts?: { limit?: number }) => UnexaminedIdea[]` | Ideas that gained structure but carry no judgement of yours. |
+| `verdictBreakdown` | `(opts?: AgencyMetricsOptions) => VerdictBreakdown` | Counts of the verdicts you gave, optionally scoped to AI/derived output. |
 
 ## AI — `zf.ai`
 

--- a/docs/development/cognitive-agency.md
+++ b/docs/development/cognitive-agency.md
@@ -69,12 +69,24 @@ All pure, all offline, all reachable through the Knowledge State barrel:
   / stalled* spectrum by how recently you ruled on it: the read side of *"is this idea moving, or has it
   stalled?"*. A stalled idea grew but carries no recent verdict; `unexaminedIdeas` (never ruled on) is
   its `lastMovementAt: null` extreme. Queryable from a script as `zf.knowledge.trajectory()`. Still no score.
+- `verdictBreakdown(history, opts?)` (#388) — a vault-wide tally of your verdicts, optionally scoped to
+  certain origins. Pass `INTERPRETIVE_ORIGINS` for the **AI accept/modify/reject rate**. Counts only.
+- `agencyIndex(history, opts?)` (#388) — of the interpretive (AI/derived) proposals you ruled on, the
+  share you **shaped** (modified/rejected/challenged) rather than accepted as-is. `index` is `null` when
+  there is nothing to describe. Both are queryable as `zf.knowledge.verdictBreakdown()` /
+  `zf.knowledge.agencyIndex()`, computed **only** from the log — local, never transmitted.
 
 ### There is no score
 
 `agencySignals` exposes counts and a timestamp — **no score, no ratio, no grade**, and a test asserts
 those keys are absent. An idea nobody has ruled on reads as a well-defined **unknown**, not a failing
 mark. The signal names an *idea* and proposes a *move*; it never grades **you**.
+
+`agencyIndex` (#388) does return a ratio, and the distinction matters: it is a **description of your
+verdict mix, not a score of you**. A low value can simply mean the proposals were good — it is never a
+"cognitive surrender score". `index` is `null` (an *unknown*) when there is nothing to describe, and the
+metric is local to your vault and never transmitted. It measures the *gate* (how interpretive output was
+handled), not the person.
 
 This is not a technicality. A "cognitive surrender score" would be exactly the moralising,
 gamified thing epic #335 exists to avoid — the right question is never *"how much did the user do?"*

--- a/src/architecture/api/lib/knowledge/knowledgeApi.ts
+++ b/src/architecture/api/lib/knowledge/knowledgeApi.ts
@@ -21,6 +21,8 @@ import {
     judgementsFor,
     lastJudgementFor,
     agencySignals,
+    agencyIndex,
+    verdictBreakdown,
     unexaminedIdeas,
     trajectory,
 } from "architecture/knowledge/state";
@@ -211,6 +213,16 @@ export function knowledgeApi(deps: KnowledgeApiDeps): Record<string, KnowledgeMe
             signature: "(path: string) => AgencySignals",
             summary: "Counts of the verdicts you have given on one idea. Never a score.",
             call: (path: string) => agencySignals(history(), path),
+        },
+        agencyIndex: {
+            signature: "(opts?: AgencyMetricsOptions) => AgencyIndex",
+            summary: "How much you shaped interpretive output vs accepted it as-is. A description, never a score.",
+            call: (opts?: Parameters<typeof agencyIndex>[1]) => agencyIndex(history(), opts),
+        },
+        verdictBreakdown: {
+            signature: "(opts?: AgencyMetricsOptions) => VerdictBreakdown",
+            summary: "Counts of the verdicts you gave, optionally scoped to AI/derived output.",
+            call: (opts?: Parameters<typeof verdictBreakdown>[1]) => verdictBreakdown(history(), opts),
         },
         judgements: {
             signature: "(path: string) => Judgement[]",

--- a/src/architecture/knowledge/judgement/judgementQueries.ts
+++ b/src/architecture/knowledge/judgement/judgementQueries.ts
@@ -100,3 +100,81 @@ export function judgementDays(history: readonly Judgement[]): Record<string, num
     }
     return days;
 }
+
+// ── Agency metrics (#388, C5) ────────────────────────────────────────────────
+// Local, vault-wide descriptions of your verdict mix. Never transmitted, never a score.
+
+/**
+ * The origins whose output is **interpretive** — a conclusion, a proposed connection — and so must pass
+ * the §XII accept/modify/reject gate before it can reach a note. `human` output is your own and is not
+ * gated, so it is excluded from the agency signal.
+ */
+export const INTERPRETIVE_ORIGINS: readonly JudgementOrigin[] = ["ai", "derived"];
+
+/** Verdicts where you **shaped** the proposal (changed or refused it) instead of taking it as-is. */
+const SHAPING_VERDICTS: readonly JudgementVerdict[] = ["modified", "rejected", "challenged"];
+
+/** Options shared by the agency metrics. */
+export interface AgencyMetricsOptions {
+    /** Restrict the tally to these origins. Omitted = all origins (for {@link verdictBreakdown}). */
+    origins?: readonly JudgementOrigin[];
+}
+
+/** A pure tally of the verdicts recorded, optionally scoped to certain origins (e.g. AI). */
+export interface VerdictBreakdown {
+    /** How many verdicts the tally covers. */
+    total: number;
+    /** Count per verdict — every verdict starts at 0, so a caller never reads `undefined`. */
+    byVerdict: Record<JudgementVerdict, number>;
+}
+
+/**
+ * The **AI accept/modify/reject rate** (#388) as raw counts, not a grade. With no `origins` it tallies
+ * every verdict; pass `INTERPRETIVE_ORIGINS` for the AI/derived rate. Pure and vault-local; an empty log
+ * yields a fully-zeroed shape, never `undefined`.
+ */
+export function verdictBreakdown(history: readonly Judgement[], opts: AgencyMetricsOptions = {}): VerdictBreakdown {
+    const origins = opts.origins ? new Set<JudgementOrigin>(opts.origins) : null;
+    const byVerdict = zeroed(JUDGEMENT_VERDICTS);
+    let total = 0;
+    for (const entry of history) {
+        if (origins && !origins.has(entry.origin)) continue;
+        byVerdict[entry.verdict]++;
+        total++;
+    }
+    return { total, byVerdict };
+}
+
+/** The **cognitive agency signal** (#388) — a description of your engagement, never a score. */
+export interface AgencyIndex {
+    /** Interpretive (AI/derived) verdicts recorded. `0` ⇒ nothing to describe yet. */
+    interpretive: number;
+    /** Of those, how many you **shaped** — modified, rejected or challenged — rather than accepted as-is. */
+    shaped: number;
+    /**
+     * `shaped / interpretive` in `[0, 1]`, or `null` when there is nothing to describe. This is a
+     * **description of your verdict mix, never a score of you**: a low value can simply mean the
+     * proposals were good, not that you were passive (§XI/§XII — a consequence of the log, not an
+     * invented grade). The Experience layer must read it as *unknown* when `null`, not as zero.
+     */
+    index: number | null;
+}
+
+/**
+ * How engaged you were with interpretive output (#388): of the AI/derived proposals you ruled on, the
+ * share you shaped (modified/rejected/challenged) rather than accepted wholesale. Computed **only** from
+ * the {@link Judgement} log — no new state, nothing transmitted. Deliberately **not** a user grade
+ * (§XII); `index` is `null` when there is nothing to describe.
+ */
+export function agencyIndex(history: readonly Judgement[], opts: AgencyMetricsOptions = {}): AgencyIndex {
+    const origins = new Set<JudgementOrigin>(opts.origins ?? INTERPRETIVE_ORIGINS);
+    const shaping = new Set<JudgementVerdict>(SHAPING_VERDICTS);
+    let interpretive = 0;
+    let shaped = 0;
+    for (const entry of history) {
+        if (!origins.has(entry.origin)) continue;
+        interpretive++;
+        if (shaping.has(entry.verdict)) shaped++;
+    }
+    return { interpretive, shaped, index: interpretive === 0 ? null : shaped / interpretive };
+}

--- a/test/architecture/knowledge/judgement/agencyMetrics.test.ts
+++ b/test/architecture/knowledge/judgement/agencyMetrics.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+    agencyIndex,
+    verdictBreakdown,
+    INTERPRETIVE_ORIGINS,
+    type Judgement,
+} from "architecture/knowledge/judgement";
+
+const T0 = Date.UTC(2026, 8, 1, 10, 0, 0);
+const A = "ideas/atomicity.md";
+
+function j(over: Partial<Judgement> = {}): Judgement {
+    return { at: T0, path: A, subject: "connect", origin: "ai", verdict: "accepted", ...over };
+}
+
+/**
+ * C5 (#388) — local, vault-wide agency metrics over the JudgementLog. They must be pure, neutral on an
+ * empty log (never a crash, never a zero-grade), and computed only from recorded verdicts (§XII).
+ */
+describe("verdictBreakdown (#388)", () => {
+    it("returns a fully-zeroed shape for an empty log (never undefined)", () => {
+        const out = verdictBreakdown([]);
+        expect(out.total).toBe(0);
+        expect(out.byVerdict.accepted).toBe(0);
+        expect(out.byVerdict.rejected).toBe(0);
+    });
+
+    it("tallies every verdict when no origins filter is given", () => {
+        const log = [j({ verdict: "accepted" }), j({ verdict: "modified" }), j({ verdict: "rejected", origin: "human" })];
+        const out = verdictBreakdown(log);
+        expect(out.total).toBe(3);
+        expect(out.byVerdict.accepted).toBe(1);
+        expect(out.byVerdict.modified).toBe(1);
+        expect(out.byVerdict.rejected).toBe(1);
+    });
+
+    it("scopes the tally to the given origins (the AI accept/modify/reject rate)", () => {
+        const log = [j({ origin: "ai", verdict: "accepted" }), j({ origin: "human", verdict: "rejected" })];
+        const out = verdictBreakdown(log, { origins: INTERPRETIVE_ORIGINS });
+        expect(out.total).toBe(1); // the human verdict is excluded
+        expect(out.byVerdict.accepted).toBe(1);
+        expect(out.byVerdict.rejected).toBe(0);
+    });
+});
+
+describe("agencyIndex (#388)", () => {
+    it("is neutral (null index) on an empty log — an unknown, not a zero grade", () => {
+        expect(agencyIndex([])).toEqual({ interpretive: 0, shaped: 0, index: null });
+    });
+
+    it("is 0 when every interpretive proposal was accepted as-is", () => {
+        const log = [j({ verdict: "accepted" }), j({ verdict: "accepted", origin: "derived" })];
+        const out = agencyIndex(log);
+        expect(out.interpretive).toBe(2);
+        expect(out.shaped).toBe(0);
+        expect(out.index).toBe(0);
+    });
+
+    it("is 1 when every interpretive proposal was shaped (modified/rejected/challenged)", () => {
+        const log = [j({ verdict: "modified" }), j({ verdict: "rejected" }), j({ verdict: "challenged" })];
+        const out = agencyIndex(log);
+        expect(out.interpretive).toBe(3);
+        expect(out.shaped).toBe(3);
+        expect(out.index).toBe(1);
+    });
+
+    it("counts a mix and excludes your own (human) verdicts from the interpretive signal", () => {
+        const log = [
+            j({ verdict: "accepted" }),           // ai, not shaped
+            j({ verdict: "modified", origin: "derived" }), // interpretive, shaped
+            j({ verdict: "rejected", origin: "human" }),   // your own → excluded
+        ];
+        const out = agencyIndex(log);
+        expect(out.interpretive).toBe(2);
+        expect(out.shaped).toBe(1);
+        expect(out.index).toBe(0.5);
+    });
+
+    it("honours an explicit origins option", () => {
+        const log = [j({ origin: "human", verdict: "modified" })];
+        expect(agencyIndex(log, { origins: ["human"] })).toEqual({ interpretive: 1, shaped: 1, index: 1 });
+    });
+});


### PR DESCRIPTION
## C5 — cognitive agency index + AI accept/modify/reject rate

Closes #388. Part of epic #383 (workstream C — honest agency). Foundation for C6 (#389).

Two pure, **vault-local** metrics over the `JudgementLog`, exposed on `zf.knowledge`:

- **`verdictBreakdown(history, opts?)`** — a tally of your verdicts, optionally scoped to origins.
  Pass `INTERPRETIVE_ORIGINS` for the **AI accept/modify/reject rate**.
- **`agencyIndex(history, opts?)`** — of the interpretive (AI/derived) proposals you ruled on, the share
  you **shaped** (modified/rejected/challenged) rather than accepted as-is. `index` is `null` when there
  is nothing to describe.

### §XII compliance (the planner's flag)
A literal "control ratio" collides with the layer's emphatic *no score / no grade* stance. So
`agencyIndex` is documented and framed as a **description of your verdict mix, not a score of you** — a
low value can simply mean the proposals were good; it measures the **gate**, not the person. `null` reads
as *unknown*. Everything is computed **only** from the recorded log — no new state, nothing transmitted
(**not** telemetry).

### Tests & guardrails
- New `agencyMetrics.test.ts`: empty-log neutrality (`index: null`, never a crash), all-accepted ⇒ 0,
  all-shaped ⇒ 1, mixed ⇒ 0.5, human verdicts excluded from the interpretive signal, origins option.
- Exposed on `zf.knowledge` (anti-drift barrel guard passes); `docs/api/reference.md` regenerated;
  `cognitive-agency.md` updated. No UI (that's C6).
- `npm run verify` green (typecheck + oxlint + eslint obsidian **0** + jest 1463).

🤖 Generated with [Claude Code](https://claude.com/claude-code)