### PR TITLE
docs(adoption): D7 — showcase the living graph + offline/AI-off angle (#390)

### DIFF
--- a/docs/development/cognitive-agency.md
+++ b/docs/development/cognitive-agency.md
@@ -5,6 +5,8 @@
 > [manifesto](../manifesto.md)'s meta-principle: *ZettelFlow removes mechanical work and protects
 > cognitive work.*
 
+> See the agency review in action → the [Showcase](../showcase.md).
+
 ## The problem this solves
 
 ZettelFlow could already tell you a great deal about how your knowledge **grew**. The

--- a/docs/development/graph-3d.md
+++ b/docs/development/graph-3d.md
@@ -7,6 +7,8 @@
 Open the **Graph** surface and pick the **3D** mode (next to Map and Navigate). Everything is
 **read-only and offline** — clicking a node opens its note; the graph never writes.
 
+> See it in motion → the [Showcase](../showcase.md).
+
 ## What it shows
 
 - **Nodes** are your notes, **sized by degree** (how connected they are). Colour has two modes,

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,11 @@ Canvas file          ZettelFlow wizard          Note in your vault
 
 | Feature | Docs |
 |---|---|
+| Immersive **Knowledge Galaxy** 3D graph | [Showcase →](showcase.md) · [3D graph →](development/graph-3d.md) |
+| Cinematic guided tour | [Showcase →](showcase.md) |
+| Share your universe (graph export) | [Showcase →](showcase.md) |
+| Before/after idea card | [Showcase →](showcase.md) · [Evolution timeline →](development/evolution-timeline.md) |
+| Agency review & index | [Showcase →](showcase.md) · [Cognitive agency →](development/cognitive-agency.md) |
 | Guided first-run with example flow | [Getting started →](development/getting-started.md) |
 | Systems Gallery (one-click) | [Systems gallery →](how-to-contribute/systems-gallery.md) |
 | Built-in actions (form + knowledge) | [Actions →](actions/Prompt.md) |

--- a/docs/resources/showcase/agency-review.svg
+++ b/docs/resources/showcase/agency-review.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Agency review (placeholder)">
+  <rect width="1200" height="630" fill="#0b0e14"/>
+  <rect x="24" y="24" width="1152" height="582" rx="18" fill="none" stroke="#2a3346" stroke-width="2"/>
+  <text x="600" y="296" fill="#e8eaed" font-family="sans-serif" font-size="46" font-weight="700" text-anchor="middle">Agency review</text>
+  <text x="600" y="352" fill="#8b93a7" font-family="sans-serif" font-size="22" text-anchor="middle">Placeholder — replace with a real capture before the 3.2.0 release</text>
+</svg>

--- a/docs/resources/showcase/export.svg
+++ b/docs/resources/showcase/export.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Share your universe (export) (placeholder)">
+  <rect width="1200" height="630" fill="#0b0e14"/>
+  <rect x="24" y="24" width="1152" height="582" rx="18" fill="none" stroke="#2a3346" stroke-width="2"/>
+  <text x="600" y="296" fill="#e8eaed" font-family="sans-serif" font-size="46" font-weight="700" text-anchor="middle">Share your universe (export)</text>
+  <text x="600" y="352" fill="#8b93a7" font-family="sans-serif" font-size="22" text-anchor="middle">Placeholder — replace with a real capture before the 3.2.0 release</text>
+</svg>

--- a/docs/resources/showcase/galaxy.svg
+++ b/docs/resources/showcase/galaxy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Knowledge Galaxy (3D graph) (placeholder)">
+  <rect width="1200" height="630" fill="#0b0e14"/>
+  <rect x="24" y="24" width="1152" height="582" rx="18" fill="none" stroke="#2a3346" stroke-width="2"/>
+  <text x="600" y="296" fill="#e8eaed" font-family="sans-serif" font-size="46" font-weight="700" text-anchor="middle">Knowledge Galaxy (3D graph)</text>
+  <text x="600" y="352" fill="#8b93a7" font-family="sans-serif" font-size="22" text-anchor="middle">Placeholder — replace with a real capture before the 3.2.0 release</text>
+</svg>

--- a/docs/resources/showcase/idea-card.svg
+++ b/docs/resources/showcase/idea-card.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Before / after idea card (placeholder)">
+  <rect width="1200" height="630" fill="#0b0e14"/>
+  <rect x="24" y="24" width="1152" height="582" rx="18" fill="none" stroke="#2a3346" stroke-width="2"/>
+  <text x="600" y="296" fill="#e8eaed" font-family="sans-serif" font-size="46" font-weight="700" text-anchor="middle">Before / after idea card</text>
+  <text x="600" y="352" fill="#8b93a7" font-family="sans-serif" font-size="22" text-anchor="middle">Placeholder — replace with a real capture before the 3.2.0 release</text>
+</svg>

--- a/docs/resources/showcase/tour.svg
+++ b/docs/resources/showcase/tour.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Cinematic guided tour (placeholder)">
+  <rect width="1200" height="630" fill="#0b0e14"/>
+  <rect x="24" y="24" width="1152" height="582" rx="18" fill="none" stroke="#2a3346" stroke-width="2"/>
+  <text x="600" y="296" fill="#e8eaed" font-family="sans-serif" font-size="46" font-weight="700" text-anchor="middle">Cinematic guided tour</text>
+  <text x="600" y="352" fill="#8b93a7" font-family="sans-serif" font-size="22" text-anchor="middle">Placeholder — replace with a real capture before the 3.2.0 release</text>
+</svg>

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,73 @@
+# Showcase — the living graph
+
+ZettelFlow doesn't just *store* your notes; it makes your knowledge **evolve**, and lets you *see* it.
+This page is the tour: the immersive graph, the cinematic fly-through, and the ways to share what your
+thinking looks like — all **offline**, and all **without AI** if you want.
+
+> The captures below are placeholders while the 3.2.0 features settle; they're replaced with real
+> screenshots/GIFs before release.
+
+## Knowledge Galaxy — see the shape of your thinking
+
+The 3D graph (**Graph surface → 3D**) renders your slip-box as an immersive **Knowledge Galaxy**: a
+starfield backdrop, notes sized by connectivity with cluster-hued glow halos, links coloured by relation
+type, and a discovery lens that lights up orphans, dead-ends and contradictions in space. It respects
+reduced-motion and Lite mode, and falls back to a navigable list on mobile.
+
+![The Knowledge Galaxy 3D graph](resources/showcase/galaxy.svg)
+
+→ Details: [3D knowledge graph](development/graph-3d.md).
+
+## Cinematic tour — sit back and watch
+
+One click flies the camera on a **cinematic tour** through your hubs and most-recent notes — a graph
+*showcase*, perfect for a demo or a video. Any drag, click or key cancels it; it honours reduced-motion.
+
+![The cinematic guided tour](resources/showcase/tour.svg)
+
+## Share your universe — export the graph
+
+**Share your universe** captures the current view as a **PNG**, or records the time-lapse growth as a
+short **WebM** clip — saved to your vault through the Vault API. No server, no upload.
+
+![Exporting the graph to an image](resources/showcase/export.svg)
+
+## Before / after — how an idea grew
+
+From the Evolution timeline, **Share this idea** paints a **before→after image** of a note — first vs
+current state, claims gained, links, decisions and days — built only from already-recorded data.
+
+![A before/after idea card](resources/showcase/idea-card.svg)
+
+## Agency review — see how much you're still deciding
+
+The **Health → Agency** tab lists your recorded decisions newest-first with a compact header: the
+cognitive agency index and the accept/modify/reject breakdown, plus a one-line plain-language reading.
+It's a description of your verdict mix — **never a grade** — computed locally and never transmitted.
+
+![The agency review tab](resources/showcase/agency-review.svg)
+
+→ Details: [Cognitive agency](development/cognitive-agency.md).
+
+## Works offline, works with AI off
+
+ZettelFlow is built to keep working — and keep your notes yours — with no server and no account:
+
+- **No telemetry, no backend, no uploads.** The plugin transmits no personal data or vault contents.
+- **AI is optional and off by default.** The graph, the tour, export, the idea card, health, discovery
+  and Cultivate are all **fully offline, deterministic, and never need AI**. When you *do* enable AI, only
+  length-bounded note content goes to the single **https** endpoint *you* configure — and nothing the
+  model writes reaches a note until you **accept** it (every completion is a proposal you accept, edit or
+  reject).
+- **The only network paths are opt-in:** the AI provider above, and the read-only **community browser**
+  (GitHub-raw `GET`s when you open it). Both are off until you choose them.
+
+Full detail: [Capabilities & privacy](development/capabilities-and-privacy.md) and the
+[manifesto](manifesto.md).
+
+## Share your system
+
+Built a workflow you love? The community gallery is **fully static** — no backend, no account. Share your
+`.zftemplate` system through GitHub and it appears in everyone's in-app browser.
+
+→ [Systems gallery](how-to-contribute/systems-gallery.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ extra:
 
 nav:
   - Home: index.md
+  - Showcase: showcase.md
   - Get started:
       - Getting started: development/getting-started.md
       - AI provider setup: development/ai-provider-setup.md


### PR DESCRIPTION
## D7 — showcase & adoption layer

Part of epic #383 (workstream D). **Docs-only** — no product code.

- **`docs/showcase.md`** — a central page telling the *living graph + works-offline* story: Knowledge
  Galaxy, cinematic tour, share/export, before/after idea card, agency review — each with a media slot —
  plus an accurate **"works offline, works with AI off"** privacy panel (mirrors capabilities-and-privacy:
  no telemetry/backend/uploads; the only network paths are the **opt-in** AI provider and the read-only
  community browser) and a **share-your-system** CTA to the static gallery.
- **`mkdocs.yml`** — a top-level **Showcase** nav entry under Home.
- **`docs/index.md`** — feature-overview rows for the new capabilities.
- One-line **Showcase** cross-links from `graph-3d.md` and `cognitive-agency.md`.
- SVG **placeholders** under `docs/resources/showcase/` so every asset resolves now.

### Phase 2 (before the 3.2.0 tag) — #390 stays open
Real screenshots/GIFs replace the placeholders (needs a running vault to capture). Leaving #390 open to
track that swap; the docs infrastructure is complete.

### Guardrails
- Docs-only: no `src/` touched, so `eslint-plugin-obsidianmd` and `npm run verify` are unaffected.
- Every referenced asset + internal link resolves (verified by file check; mkdocs isn't on PATH here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)