### PR TITLE
docs(manifesto): establish knowledge with purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ transform knowledge*. It stands on **four pillars**:
 - 🔭 **Knowledge Discovery** — surface the unexpected: connections you didn't know you'd made, ideas worth challenging, a book outline hiding in a folder.
 - 🩺 **Knowledge Health** — measure balance and richness, not volume: maturity, knowledge debt, a weekly review, a heatmap of ideas *developed*.
 
-**AI is one Action, never the product** — every pillar works fully with AI disabled, and when it is on it **proposes, never commits**: you accept, edit or reject every suggestion. And **nothing is
-removed, only repositioned**: the canvas wizard you know is the engine's front end.
+**AI is one Action, never the product** — every pillar works fully with AI disabled, and when it is on
+it **proposes, never commits without your verdict**: you accept, edit or reject every suggestion.
+**Preserve people's work; simplify the paths:** the canvas wizard you know remains the engine's
+front end while overlapping interfaces are consolidated with compatible access.
+
+**Our direction: useful from the first idea, deeper as your practice grows.** You choose what deserves
+attention; recorded activity is not a measure of your understanding. The proposed
+[Knowledge with purpose epic](https://github.com/RafaelGB/Obsidian-ZettelFlow/issues/401) develops that
+direction through purpose-led Cultivate and first value on your own material — **planned, not shipped**.
 
 > Read the **[manifesto →](https://rafaelgb.github.io/Obsidian-ZettelFlow/manifesto/)** · **[full documentation →](https://rafaelgb.github.io/Obsidian-ZettelFlow/)**
 

--- a/docs/architecture/reposition-map.md
+++ b/docs/architecture/reposition-map.md
@@ -6,8 +6,10 @@ architecture it now stands for — the **five layers** of the Knowledge OS (epic
 
 **Knowledge Model · Workflow Engine · Knowledge State · Experience · Community Gallery** (+ Foundation).
 
-> **The rule: keep every feature, reposition it — nothing is deleted or renamed.** This is a *map*,
-> not a move. Every `src/` area below appears **exactly once**. The actual folder moves land as small,
+> **Mapping scope: no features are deleted or renamed by this map.** The
+> [manifesto](../manifesto.md) preserves people's work and compatible workflows, not every redundant
+> interface forever. This is a *map*, not a move. Every `src/` area below appears **exactly once**.
+> The actual folder moves land as small,
 > `verify`-green follow-up PRs (see the roadmap at the end); the *target layer* column is the home a
 > capability belongs to, not a path that exists today.
 

--- a/docs/development/friction-audit.md
+++ b/docs/development/friction-audit.md
@@ -5,9 +5,10 @@
 > [*"one obvious path"* epic (#231)](https://github.com/RafaelGB/Obsidian-ZettelFlow/issues/231); every
 > later phase should cite a row here.
 >
-> **Stance: consolidate & hide.** Per the [manifesto](../manifesto.md), *"keep every feature — reposition
-> it; almost nothing is deleted."* Nothing below is a proposal to delete a capability — only to expose
-> one obvious path and tuck duplicates out of the way.
+> **Stance: consolidate & hide.** The [manifesto](../manifesto.md) asks us to preserve people's work and
+> compatible workflows, not every redundant interface. This audit retains capabilities while exposing
+> one obvious path and moving duplicates out of the way; it does not authorize deleting user work or
+> breaking established workflows.
 
 >
 > **Two different "frictions" — do not confuse them.** This page is about **operational friction**:

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -24,35 +24,61 @@ life:
 CAPTURE → CLASSIFY → PROCESS → CONNECT → DEVELOP → REVIEW → CONSOLIDATE
 ```
 
+## Begin with what matters to you
+
+A well-organized vault is a means, not the destination. The destination might be a question you want
+to understand, a decision you need to make, or an argument you want to develop. Exploration without a
+fixed goal matters too. The system serves your purpose; it does not assign you one.
+
+> **You choose what deserves attention — not just which suggestions to accept.**
+
+This is a direction for the whole product, not a fifth pillar or another project manager. Start with
+your own idea, use what you already know, inspect what challenges it, and decide what to do next.
+Recommendations should explain their basis and scope. A highly connected note is not automatically
+the most important thing for *you* to work on.
+
+Progress can be a sharper question, a useful connection, a changed position, or an honest
+*"I do not have enough evidence yet."* A supporting link does not settle a question; a dense graph
+does not make a claim true. **Evidence found, a proposed interpretation, and a conclusion you endorse
+are different things.** You decide when a response is sufficient for now, and you can reopen it.
+
+Unfinished thinking deserves continuity, not a demand to finish. Preserve the purpose, the reasoning
+and the remaining uncertainty so returning is easier than starting over. Pausing, changing direction
+or deliberately stopping can be the right next move — none requires improving a score first.
+
 ## Cognitive agency (the meta-principle)
 
 The four pillars below say **what** ZettelFlow builds. This says **why** it exists.
 
-Every tool that touches knowledge work now offers the same bargain: hand over the thinking, keep the
-output. Take it often enough and something erodes quietly — not your notes, your **judgement**.
-Delegating a *mechanical* task is strategic and good; the loss begins when the tool takes over the
-**evaluation** and you stop exercising the metacognitive agency that made the knowledge yours. That is
-**cognitive surrender**, and it is the failure mode ZettelFlow is built against.
+Knowledge tools increasingly offer a tempting bargain: hand over the thinking, keep the output.
+The risk is not receiving help; it is letting the output stand in for your **judgement**. Delegating
+a *mechanical* task is strategic and good. Considering a suggested interpretation can be useful too.
+**Cognitive surrender** begins when a system's evaluation is treated as your conclusion without your
+own decision. That is a design failure ZettelFlow works against, not a label to attach to its users.
 
 > **ZettelFlow removes mechanical work. It protects cognitive work.**
 
 This is not an anti-AI stance, and not a demand that you do everything by hand. Automating *"gather
-every idea that contradicts this one"* is pure gain. Automating *"and here is what you should conclude"*
-is the loss. The line is exact:
+the recorded objections in this scope"* removes mechanical work. Showing a possible reading can help
+you examine them. Silently adopting that reading as yours crosses the line:
 
 | ZettelFlow does this | ZettelFlow never does this |
 |---|---|
-| Gathers the evidence | Decides what the evidence means |
-| Surfaces the contradiction | Resolves it for you |
+| Gathers recorded evidence and shows its sources | Treats a citation or a graph link as proof |
+| Surfaces recorded objections and uncertainty | Declares a question settled because support appeared |
 | Notices the missing source | Invents the justification |
-| Proposes a connection | Commits it without your verdict |
-| Shows you the argument you built | Writes the argument you didn't |
+| Proposes an interpretation or connection | Adopts it as your conclusion without your verdict |
+| Helps you inspect and develop your argument | Attributes reasoning to you that you did not author or approve |
 
-The mechanism is **deliberate friction**: at the moments where judgement is actually at stake, the
-system asks for *your* reading before it reveals its own. Not to slow you down — to keep the reasoning
-yours. And because judgement is the scarce resource, it is the thing worth measuring: **cognitive
-agency** is a consequence of the model like every other metric, the answer to *"has my understanding
-changed, or has my vault just grown?"*
+The boundary is explicit: mechanical gathering and structural projections can be automated;
+interpretive output reaches your notes only through your **accept / modify / reject** decision,
+whether the proposal came from AI or a heuristic. The verdict is recorded, and a proposal must remain
+distinguishable from your own authored or approved position. Automation cannot bypass that boundary.
+
+**Deliberate friction** is one design tool: where judgement is genuinely at stake, invite *your*
+reading before revealing the system's. It is not a reflection tax on every click. Skipping a prompt is
+not a verdict; accepting a good suggestion is a legitimate decision. Remove operational effort, and
+test whether the remaining pause helps people reason instead of merely slowing them down.
 
 ```
                          COGNITIVE AGENCY
@@ -67,7 +93,7 @@ changed, or has my vault just grown?"*
 ```
 
 > **Obsidian stores your thoughts. ZettelFlow connects them, challenges them and makes them evolve —
-> but it never thinks for you.**
+> it can propose interpretations, but it never adopts them as your conclusions without your decision.**
 
 ## The four pillars (the soul)
 
@@ -80,23 +106,46 @@ changed, or has my vault just grown?"*
 - 🩺 **Knowledge Health** — measure *balance and richness*, not volume: maturity, knowledge debt, a
   weekly review, composition, a heatmap of the ideas you actually **developed**.
 
-Metrics are **consequences, not inventions**. When a workflow runs *find related* and gets nothing,
-the note is unconnected. When *find contradiction* returns empty, the idea has no opposing view.
-Knowledge debt is a natural byproduct of doing the work — never an arbitrary number.
+### Honest signals, not a measure of your mind
+
+Metrics are **consequences, not inventions**: they must have an inspectable definition grounded in
+recorded data. Their scope and limitations matter. No result from *find related* means no candidate
+was found by that method in that scope. No recorded contradiction does not mean no opposing view
+exists. Connectivity, maturity and debt describe aspects of the recorded system — not truth,
+source quality or the worth of an idea.
+
+> **Signals describe what was recorded; they do not certify understanding. Absence of a record is
+> not absence of thought.**
+
+A decision log can show which proposals you accepted, changed or rejected. It cannot tell whether you
+understood them, thought elsewhere, or should have disagreed more. Confidence is yours to express,
+not something inferred from links or clicks. **"Has my understanding changed, or has my vault just
+grown?" is a question the tool helps you examine, not a score it can answer for you.**
+
+Health should invite a useful next move, not turn every gap into an obligation. More notes, longer
+streaks, more rejections or more time in the plugin are not ends in themselves. No daily quota, no
+guilt for leaving an idea alone: the measure of usefulness is progress you recognize toward what
+matters to you.
 
 ## What we will not become
 
 - **"Obsidian + AI"** — competing with a thousand tools. **AI is one Action, never the product.** The
   system works fully — every pillar, every dashboard — for a user who never enables AI.
-- **An answer machine.** A tool that hands you conclusions trains you to stop reaching them. ZettelFlow
-  gathers, proposes and challenges — the verdict is always yours.
+- **An answer machine.** Producing a plausible conclusion is not the same as helping you reach one.
+  ZettelFlow gathers, proposes and challenges — it does not treat its output as your answer without
+  your verdict.
+- **A judge of your intelligence or a productivity scoreboard.** We describe records and expose gaps;
+  we do not rank people by their notes, clicks, streaks or agreement with a machine.
 - **"Another plugin to create Zettelkasten notes."** That ceiling is too low.
 - A generic manager that pleases everyone and marks no one.
 
-## Keep every feature — reposition it
+## Preserve people's work — reposition capabilities
 
-This is the promise that made the whole thing possible without a rewrite: **almost nothing is
-deleted; what changes is its _position_ in the product.**
+The original repositioning promise made this evolution possible without a rewrite. Its durable
+meaning is **preserve people's notes, systems and established workflows — not every redundant
+interface forever**. Consolidate overlapping paths, retain compatible access when an entry point
+moves, and make any migration explicit. Subtraction must not erase someone's work or strand their
+workflow. The canvas wizard remains the engine's front end, not a discarded first product.
 
 | Today | Becomes |
 |---|---|
@@ -130,26 +179,44 @@ shallow ones.
 > **If it can be centralized, centralize it. If it can be removed, remove it. Stay minimal and
 > comprehensible — that is the feature.**
 
-Subtraction is what keeps ZettelFlow *easy to use, hard to master* instead of *hard to use, easy to
-abandon*. Minimalism here is not a lack of ambition; it is the ambition.
+Subtraction makes depth available without making complexity compulsory. Minimalism here is not a
+lack of ambition; it is the ambition.
 
-## Easy to use, hard to master
+## Useful from the first idea. Deeper as your practice grows.
 
-The best tools meet you where you are. A newcomer should be productive in **five minutes** — install a
-system, create a note, watch it land already connected, cross-checked and scored — without reading a
-manual. That is the **on-ramp**: ZettelFlow does the *mechanical* work for you from the first minute —
-the scaffolding, the gathering, the cross-checking — so that what is left for you is the judgement. It
-never does the judgement work for you, at any level: a beginner is not a user who thinks less, only a
-user with more scaffolding.
+The best tools meet you where you are. Our design target is a first useful advance on **your own
+material in five minutes** — a target to test with people, not a result to claim without evidence.
+One existing note, or one real idea captured in an empty vault, should be enough to begin. Do not
+require reorganizing a vault, adopting a methodology, learning Canvas or enabling AI before giving
+value. A sparse vault deserves an honest next question, not invented connections.
+
+That is the **on-ramp**: remove the setup and gathering work, not the user's choice of purpose or
+conclusion. Systems and the existing gallery offer scaffolding when wanted, not an admission fee.
+A beginner is not someone who thinks less — only someone who needs less configuration and clearer
+support. Keyboard and mobile access belong to that first experience, not a later reward.
 
 And there should always be another level. Compose your own workflows, program conditions and events,
 author and share systems, ask your own knowledge graph questions — the ceiling rises as far as your
-practice does. That is the **summit**: mastery that changes how you think.
+practice does. That is the **summit**: depth that serves your practice, not difficulty for its own sake.
 
-> **Easy to use, hard to master.**
+> **Useful from the first idea. Deeper as your practice grows.**
 
-This is how ZettelFlow becomes the **organizational reference for Obsidian** — for the curious beginner
-and the devoted practitioner alike. One tool, from your first note to a second brain.
+## The test for every addition
+
+Before building, ask:
+
+1. **Whose purpose does this serve?** Name a useful knowledge transformation, not an engagement metric.
+2. **What stays the person's decision?** Make proposals, evidence, uncertainty and verdicts distinct.
+3. **What does the system actually know?** State the basis, scope and limits; do not infer a mind from a log.
+4. **What do we deepen or simplify?** Reuse a capability and preserve people's work rather than add a rival surface.
+5. **How will we know it helped?** Test an observable outcome and the burden of using it, with consent and no hidden telemetry.
+
+The [constitution](development/constitution.md) makes the engineering boundaries enforceable. This
+manifesto sets the direction, not a claim that every journey described here already ships. The
+[Knowledge with purpose epic](https://github.com/RafaelGB/Obsidian-ZettelFlow/issues/401) turns the next
+step into a bounded proposal: purpose-led Cultivate and first value on your own material. Its
+requirements, validation and deferred opportunities live there; current capabilities live in the
+[product documentation](index.md).
 
 ## For the few who will love it
 


### PR DESCRIPTION
## Summary
- Establish user-owned purpose, honest signals and provisional human conclusions in the manifesto.
- Align README and direct documentation references; preserve compatibility while allowing consolidation.
- Reference #401 as proposed work, not delivered functionality. This documentation-only PR does not close the epic.

## Validation
- npm run verify: 233 suites, 1478 tests passed in the documentation session.
- Local Markdown links and git diff --check passed.
- MkDocs build was not available locally (no configured Python environment).

## Scope
Documentation only; no runtime, locale or capability changes.